### PR TITLE
consume messages by id. allow rerouting

### DIFF
--- a/contracts/connection-router/src/error.rs
+++ b/contracts/connection-router/src/error.rs
@@ -43,4 +43,7 @@ pub enum ContractError {
 
     #[error("Address is invalid")]
     InvalidAddress {},
+
+    #[error("Destination domain of message does not match domain of caller")]
+    WrongDomain {},
 }

--- a/contracts/connection-router/src/msg.rs
+++ b/contracts/connection-router/src/msg.rs
@@ -63,10 +63,10 @@ pub enum ExecuteMsg {
         source_address: String,
         payload_hash: HexBinary,
     },
-    // Returns count messages and deletes them from the gateway's queue.
+    // For each id, returns the associated message and deletes the message from storage
     // Called by an outgoing gateway
     ConsumeMessages {
-        count: Option<u32>,
+        ids: Vec<String>,
     },
 }
 

--- a/contracts/connection-router/src/state.rs
+++ b/contracts/connection-router/src/state.rs
@@ -4,7 +4,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, DepsMut, Order, StdResult};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
-use crate::types::{Domain, DomainName};
+use crate::types::{Domain, DomainName, Message};
 
 #[cw_serde]
 pub struct Config {
@@ -75,10 +75,5 @@ impl<'a> IndexList<Domain> for DomainIndexes<'a> {
     }
 }
 
-// a set of all message uuids
-pub const MESSAGES: Map<String, ()> = Map::new("messages");
-
-const MESSAGE_QUEUE_SUFFIX: &str = "-messages";
-pub fn get_message_queue_id(destination_domain: &DomainName) -> String {
-    format!("{}{}", destination_domain.to_string(), MESSAGE_QUEUE_SUFFIX)
-}
+// maps a message uuid to a message
+pub const MESSAGES: Map<String, Message> = Map::new("messages");


### PR DESCRIPTION
Replace gateway queues with map of messages. Outgoing gateways can now consume individual messages by specifying the ids of the desired messages. 

Allows rerouting the same message more than once. Replay prevention needs to be done by the destination gateway regardless, and so allowing rerouting in the router makes handling failures easier by allowing retransmission from source if necessary.