### PR TITLE
chore: run coverage action when pushing to main or release

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,11 @@
 name: Coverage
 
-on: pull_request
+on: 
+  pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'releases/**'
 
 jobs:
   coverage:


### PR DESCRIPTION
## Description
Updates coverage action to run when pushing into main or a release branch, so codecov receives a code coverage report from the main branch that can be used to compare a PR branch's code coverage.
## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
