### PR TITLE
chore: revert conventional commits action running on push

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,11 +1,6 @@
 name: Ensure Conventional Commit message
 
-on: 
-  pull_request:
-  push:
-    branches:
-      - 'main'
-      - 'releases/**'
+on: pull_request
 
 jobs:
   ensure-CC:


### PR DESCRIPTION
## Description
https://github.com/axelarnetwork/axelar-amplifier/actions/runs/6175533191/job/16762609790
conventional commits action can only run on pull requests.
## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
