### PR TITLE
feat: add generalized contract error with derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,8 +42,6 @@ dependencies = [
 name = "aggregate-verifier"
 version = "0.1.0"
 dependencies = [
- "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -52,8 +50,6 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 0.15.1",
- "error-stack",
- "report",
  "schemars",
  "serde",
  "serde_json",
@@ -418,13 +414,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "batching"
 version = "0.1.0"
 dependencies = [
- "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
- "error-stack",
- "report",
  "thiserror",
 ]
 
@@ -768,18 +760,15 @@ name = "connection-router"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw2 0.15.1",
- "error-stack",
  "flagset",
  "hex",
  "rand",
- "report",
  "schemars",
  "serde",
  "serde_json",
@@ -2272,8 +2261,6 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "aggregate-verifier",
- "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2282,8 +2269,6 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 0.15.1",
- "error-stack",
- "report",
  "schemars",
  "serde",
  "serde_json",
@@ -3020,7 +3005,6 @@ name = "multisig"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "cosmwasm-crypto",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3028,10 +3012,8 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw2 0.15.1",
- "error-stack",
  "getrandom",
  "rand",
- "report",
  "schemars",
  "serde",
  "serde_json",
@@ -3044,7 +3026,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3054,14 +3035,12 @@ dependencies = [
  "cw-utils 1.0.1",
  "cw2 0.15.1",
  "either",
- "error-stack",
  "ethabi",
  "gateway",
  "hex",
  "itertools 0.11.0",
  "k256 0.13.1",
  "multisig",
- "report",
  "schemars",
  "serde",
  "serde_json",
@@ -4478,15 +4457,12 @@ name = "service-registry"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
- "error-stack",
- "report",
  "schemars",
  "serde",
  "thiserror",
@@ -5534,7 +5510,6 @@ name = "voting-verifier"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
- "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5544,8 +5519,6 @@ dependencies = [
  "cw0",
  "cw2 0.15.1",
  "either",
- "error-stack",
- "report",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,8 @@ dependencies = [
 name = "aggregate-verifier"
 version = "0.1.0"
 dependencies = [
+ "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -50,6 +52,8 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 0.15.1",
+ "error-stack",
+ "report",
  "schemars",
  "serde",
  "serde_json",
@@ -296,13 +300,27 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
+ "error-stack",
  "flagset",
  "num-traits",
  "rand",
+ "report",
  "schemars",
  "serde",
  "serde_json",
  "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "axelar-wasm-std-derive"
+version = "0.1.0"
+dependencies = [
+ "axelar-wasm-std",
+ "error-stack",
+ "quote",
+ "report",
+ "syn 2.0.29",
  "thiserror",
 ]
 
@@ -400,9 +418,13 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "batching"
 version = "0.1.0"
 dependencies = [
+ "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
+ "error-stack",
+ "report",
  "thiserror",
 ]
 
@@ -746,15 +768,18 @@ name = "connection-router"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw2 0.15.1",
+ "error-stack",
  "flagset",
  "hex",
  "rand",
+ "report",
  "schemars",
  "serde",
  "serde_json",
@@ -2247,6 +2272,8 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "aggregate-verifier",
+ "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2255,6 +2282,8 @@ dependencies = [
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
  "cw2 0.15.1",
+ "error-stack",
+ "report",
  "schemars",
  "serde",
  "serde_json",
@@ -2991,6 +3020,7 @@ name = "multisig"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "cosmwasm-crypto",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2998,8 +3028,10 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
  "cw2 0.15.1",
+ "error-stack",
  "getrandom",
  "rand",
+ "report",
  "schemars",
  "serde",
  "serde_json",
@@ -3012,6 +3044,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3021,12 +3054,14 @@ dependencies = [
  "cw-utils 1.0.1",
  "cw2 0.15.1",
  "either",
+ "error-stack",
  "ethabi",
  "gateway",
  "hex",
  "itertools 0.11.0",
  "k256 0.13.1",
  "multisig",
+ "report",
  "schemars",
  "serde",
  "serde_json",
@@ -4443,12 +4478,15 @@ name = "service-registry"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
+ "error-stack",
+ "report",
  "schemars",
  "serde",
  "thiserror",
@@ -5496,6 +5534,7 @@ name = "voting-verifier"
 version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
+ "axelar-wasm-std-derive",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5505,6 +5544,8 @@ dependencies = [
  "cw0",
  "cw2 0.15.1",
  "either",
+ "error-stack",
+ "report",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ error-stack = { version = "0.4.0", features = ["eyre"] }
 events = { version = "^0.1.0", path = "packages/events" }
 events-derive = { version = "^0.1.0", path = "packages/events-derive" }
 axelar-wasm-std = { version = "^0.1.0", path = "packages/axelar-wasm-std" }
+axelar-wasm-std-derive = { version = "^0.1.0", path = "packages/axelar-wasm-std-derive" }
 itertools = "0.11.0"
 voting-verifier = { version = "^0.1.0", path = "contracts/voting-verifier" }
 multisig = { version = "^0.1.0", path = "contracts/multisig" }

--- a/packages/axelar-wasm-std-derive/Cargo.toml
+++ b/packages/axelar-wasm-std-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "axelar-wasm-std-derive"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+axelar-wasm-std = { workspace = true }
+error-stack = { workspace = true }
+quote = "1.0.33"
+report = { workspace = true }
+syn = "2.0.29"
+thiserror = { workspace = true }

--- a/packages/axelar-wasm-std-derive/src/lib.rs
+++ b/packages/axelar-wasm-std-derive/src/lib.rs
@@ -1,0 +1,25 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+
+#[proc_macro_derive(IntoContractError)]
+pub fn into_contract_error_derive(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    let name = &ast.ident;
+
+    let gen = quote! {
+        use axelar_wasm_std::ContractError as _ContractError;
+
+        impl From<#name> for _ContractError {
+            fn from(error: #name) -> Self {
+                use report::LoggableError;
+                use error_stack::report;
+
+                LoggableError::from(&report!(error)).into()
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/packages/axelar-wasm-std-derive/tests/derive.rs
+++ b/packages/axelar-wasm-std-derive/tests/derive.rs
@@ -1,0 +1,14 @@
+use axelar_wasm_std::ContractError;
+use axelar_wasm_std_derive::IntoContractError;
+use thiserror::Error;
+
+#[derive(Error, Debug, IntoContractError)]
+enum TestError {
+    #[error("error")]
+    Something,
+}
+
+#[test]
+fn can_convert_error() {
+    _ = ContractError::from(TestError::Something);
+}

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -32,8 +32,10 @@ cosmwasm-schema = "1.1.3"
 cosmwasm-std = "1.2.1"
 cosmwasm-storage = "1.1.3"
 cw-storage-plus = "1.1.0"
+error-stack = { workspace = true }
 flagset = { version = "0.4.3", features = ["serde"] }
 num-traits = { version = "0.2.14", default-features = false }
+report = { workspace = true }
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 serde_json = "1.0.89"

--- a/packages/axelar-wasm-std/src/error.rs
+++ b/packages/axelar-wasm-std/src/error.rs
@@ -1,0 +1,11 @@
+use cosmwasm_std::StdError;
+use report::LoggableError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+    #[error(transparent)]
+    Structured(#[from] LoggableError),
+}

--- a/packages/axelar-wasm-std/src/lib.rs
+++ b/packages/axelar-wasm-std/src/lib.rs
@@ -1,10 +1,12 @@
 pub use crate::{
+    error::ContractError,
     fn_ext::FnExt,
     snapshot::{Participant, Snapshot},
     threshold::Threshold,
 };
 
 pub mod counter;
+mod error;
 pub mod flagset;
 mod fn_ext;
 pub mod nonempty;


### PR DESCRIPTION
In preparation to introduce error-stack into the contracts, we need a top level error that cosmwasm is able to return and which accepts both cosmwasm StdErrors and error stack reports. In order to make implementation for contract specific errors easier, a derive macro is provided that implements the From/Into trait.

The changes to LoggableError are simple restructuring the file