### PR TITLE
feat(multisig-prover): encode commands via bcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3022,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axelar-wasm-std",
+ "bcs",
  "connection-router",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/multisig-prover/Cargo.toml
+++ b/contracts/multisig-prover/Cargo.toml
@@ -29,6 +29,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dependencies]
 axelar-wasm-std = { workspace = true }
+bcs = { version = "0.1.5"}
 connection-router = { workspace = true, features = ["library"] }
 cosmwasm-schema = "1.1.3"
 cosmwasm-std = "1.1.3"

--- a/contracts/multisig-prover/src/encoding/abi.rs
+++ b/contracts/multisig-prover/src/encoding/abi.rs
@@ -20,7 +20,7 @@ use ethabi::ethereum_types;
 
 pub const GATEWAY_EXECUTE_FUNCTION_NAME: &str = "execute";
 
-pub fn encode(data: &Data) -> HexBinary {
+pub fn encode(data: &Data) -> Result<HexBinary, ContractError> {
     let destination_chain_id = Token::Uint(ethabi::ethereum_types::U256::from_big_endian(
         &data.destination_chain_id.to_be_bytes(),
     ));
@@ -37,17 +37,17 @@ pub fn encode(data: &Data) -> HexBinary {
         })
         .multiunzip();
 
-    ethabi::encode(&[
+    Ok(ethabi::encode(&[
         destination_chain_id,
         Token::Array(commands_ids),
         Token::Array(commands_types),
         Token::Array(commands_params),
     ])
-    .into()
+    .into())
 }
 
-pub fn msg_to_sign(command_batch: &CommandBatch) -> HexBinary {
-    let msg = Keccak256::digest(encode(&command_batch.data).as_slice());
+pub fn msg_to_sign(command_batch: &CommandBatch) -> Result<HexBinary, ContractError> {
+    let msg = Keccak256::digest(encode(&command_batch.data)?.as_slice());
 
     // Prefix for standard EVM signed data https://eips.ethereum.org/EIPS/eip-191
     let unsigned = [
@@ -56,7 +56,7 @@ pub fn msg_to_sign(command_batch: &CommandBatch) -> HexBinary {
     ]
     .concat();
 
-    Keccak256::digest(unsigned).as_slice().into()
+    Ok(Keccak256::digest(unsigned).as_slice().into())
 }
 
 pub fn encode_execute_data(
@@ -65,7 +65,7 @@ pub fn encode_execute_data(
     signers: Vec<(Signer, Option<Signature>)>,
 ) -> Result<HexBinary, ContractError> {
     let param = ethabi::encode(&[
-        Token::Bytes(encode(&command_batch.data).into()),
+        Token::Bytes(encode(&command_batch.data)?.into()),
         Token::Bytes(encode_proof(quorum, signers)?.into()),
     ]);
 
@@ -589,7 +589,8 @@ mod test {
         let data = decode_data(&encoded_data);
         let res = data.encode(Encoder::Abi);
 
-        assert_eq!(res, encoded_data);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), encoded_data);
     }
 
     #[test]
@@ -615,7 +616,8 @@ mod test {
         let res = batch.msg_to_sign();
         let expected_msg = test_data::msg_to_sign();
 
-        assert_eq!(res, expected_msg);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), expected_msg);
     }
 
     #[test]

--- a/contracts/multisig-prover/src/encoding/bcs.rs
+++ b/contracts/multisig-prover/src/encoding/bcs.rs
@@ -1,0 +1,165 @@
+use bcs::to_bytes;
+use cosmwasm_std::HexBinary;
+use itertools::Itertools;
+
+use crate::error::ContractError;
+
+use super::Data;
+
+pub fn command_params(
+    source_chain: String,
+    source_address: String,
+    destination_address: String,
+    payload_hash: HexBinary,
+) -> Result<HexBinary, ContractError> {
+    let ret = to_bytes(&(
+        source_chain,
+        source_address,
+        <[u8; 30]>::try_from(&HexBinary::from_hex(&destination_address)?.to_vec()[..30])
+            .expect("couldn't convert destination_address to 30 byte array"), // TODO: is this right? Why are addresses 30 bytes?
+        payload_hash.to_vec(),
+    ))?;
+
+    Ok(ret.into())
+}
+
+pub fn encode(data: &Data) -> Result<HexBinary, ContractError> {
+    // destination chain id is u64
+    let destination_chain_id = &u64::from_le_bytes(
+        data.destination_chain_id.to_le_bytes()[..8]
+            .try_into()
+            .expect("Couldn't convert u256 to u64"),
+    );
+
+    let (commands_ids, command_types, command_params): (Vec<[u8; 32]>, Vec<String>, Vec<Vec<u8>>) =
+        data.commands
+            .iter()
+            .map(|command| {
+                (
+                    <[u8; 32]>::try_from(&command.id.to_vec()[..32])
+                        .expect("couldn't convert command id to 32 byte array"), // command-ids are fixed length sequences
+                    command.ty.to_string(),
+                    command.params.to_vec(),
+                )
+            })
+            .multiunzip();
+
+    Ok(to_bytes(&(
+        destination_chain_id,
+        commands_ids,
+        command_types,
+        command_params,
+    ))?
+    .into())
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::vec;
+
+    use bcs::from_bytes;
+    use cosmwasm_std::HexBinary;
+
+    use crate::{
+        encoding::{
+            bcs::{command_params, encode},
+            Data,
+        },
+        types::Command,
+    };
+
+    #[test]
+    fn test_command_params() {
+        let res = command_params(
+            "Ethereum".into(),
+            "00".into(),
+            "01".repeat(30).into(),
+            HexBinary::from_hex("02").unwrap(),
+        );
+        assert!(res.is_ok());
+
+        let res = res.unwrap();
+        let params = from_bytes(&res.to_vec());
+        assert!(params.is_ok());
+        let (source_chain, source_address, destination_address, payload_hash): (
+            String,
+            String,
+            [u8; 30],
+            Vec<u8>,
+        ) = params.unwrap();
+        assert_eq!(source_chain, "Ethereum".to_string());
+
+        assert_eq!(source_address, "00".to_string());
+
+        assert_eq!(
+            destination_address.to_vec(),
+            HexBinary::from_hex(&"01".repeat(30)).unwrap().to_vec()
+        );
+
+        assert_eq!(payload_hash, vec![2]);
+    }
+
+    #[test]
+    fn test_encode() {
+        let source_chain = "Ethereum";
+        let source_address = "AA";
+        let destination_address = "BB".repeat(30);
+        let payload_hash = HexBinary::from_hex("CC").unwrap();
+        let destination_chain_id = 1u64;
+        let command_id = HexBinary::from_hex(&"FF".repeat(32)).unwrap();
+        let data = Data {
+            destination_chain_id: destination_chain_id.into(),
+            commands: vec![Command {
+                id: command_id.clone(),
+                ty: crate::types::CommandType::ApproveContractCall,
+                params: command_params(
+                    source_chain.into(),
+                    source_address.into(),
+                    destination_address.clone().into(),
+                    payload_hash.clone().into(),
+                )
+                .unwrap(),
+            }],
+        };
+        let res = encode(&data);
+        assert!(res.is_ok());
+        let encoded = res.unwrap();
+        let decoded: Result<(u64, Vec<[u8; 32]>, Vec<String>, Vec<Vec<u8>>), _> =
+            from_bytes(&encoded.to_vec());
+        assert!(decoded.is_ok());
+        let (chain_id, command_ids, command_types, params) = decoded.unwrap();
+
+        assert_eq!(chain_id, destination_chain_id);
+
+        assert_eq!(command_ids.len(), 1);
+        assert_eq!(command_ids[0].to_vec(), command_id.to_vec());
+
+        assert_eq!(command_types.len(), 1);
+        assert_eq!(
+            command_types[0],
+            crate::types::CommandType::ApproveContractCall.to_string()
+        );
+
+        assert_eq!(params.len(), 1);
+        let command = from_bytes(&params[0]);
+        assert!(command.is_ok());
+        let (
+            source_chain_decoded,
+            source_address_decoded,
+            destination_address_decoded,
+            payload_hash_decoded,
+        ): (String, String, [u8; 30], Vec<u8>) = command.unwrap();
+
+        assert_eq!(source_chain_decoded, source_chain);
+
+        assert_eq!(source_address_decoded, source_address);
+
+        assert_eq!(
+            destination_address_decoded.to_vec(),
+            HexBinary::from_hex(&destination_address).unwrap().to_vec()
+        );
+
+        assert_eq!(payload_hash_decoded, payload_hash.to_vec());
+    }
+}

--- a/contracts/multisig-prover/src/encoding/mod.rs
+++ b/contracts/multisig-prover/src/encoding/mod.rs
@@ -1,4 +1,5 @@
 mod abi;
+mod bcs;
 
 use axelar_wasm_std::operators::Operators;
 use cosmwasm_schema::cw_serde;
@@ -31,7 +32,12 @@ fn make_command(msg: Message, encoding: Encoder) -> Result<Command, ContractErro
                 msg.destination_address,
                 msg.payload_hash,
             )?,
-            Encoder::Bcs => todo!(),
+            Encoder::Bcs => bcs::command_params(
+                msg.source_chain,
+                msg.source_address,
+                msg.destination_address,
+                msg.payload_hash,
+            )?,
         },
         id: command_id(msg.id),
     })
@@ -104,7 +110,7 @@ impl CommandBatchBuilder {
 }
 
 impl CommandBatch {
-    pub fn msg_to_sign(&self) -> HexBinary {
+    pub fn msg_to_sign(&self) -> Result<HexBinary, ContractError> {
         match self.encoder {
             Encoder::Abi => abi::msg_to_sign(self),
             Encoder::Bcs => todo!(),
@@ -130,10 +136,10 @@ pub struct Data {
 }
 
 impl Data {
-    pub fn encode(&self, encoder: Encoder) -> HexBinary {
+    pub fn encode(&self, encoder: Encoder) -> Result<HexBinary, ContractError> {
         match encoder {
             Encoder::Abi => abi::encode(self),
-            Encoder::Bcs => todo!(),
+            Encoder::Bcs => bcs::encode(self),
         }
     }
 }

--- a/contracts/multisig-prover/src/error.rs
+++ b/contracts/multisig-prover/src/error.rs
@@ -34,6 +34,9 @@ pub enum ContractError {
     #[error(transparent)]
     NonEmptyError(#[from] nonempty::Error),
 
+    #[error(transparent)]
+    BcsError(#[from] bcs::Error),
+
     #[error("worker set has not changed sufficiently since last update")]
     WorkerSetUnchanged,
 

--- a/contracts/multisig-prover/src/execute.rs
+++ b/contracts/multisig-prover/src/execute.rs
@@ -49,7 +49,7 @@ pub fn construct_proof(deps: DepsMut, message_ids: Vec<String>) -> Result<Respon
 
     let start_sig_msg = multisig::msg::ExecuteMsg::StartSigningSession {
         key_id,
-        msg: command_batch.msg_to_sign(),
+        msg: command_batch.msg_to_sign()?,
     };
 
     let wasm_msg = wasm_execute(config.multisig, &start_sig_msg, vec![])?;
@@ -203,7 +203,7 @@ pub fn update_worker_set(deps: DepsMut, env: Env) -> Result<Response, ContractEr
 
             let start_sig_msg = multisig::msg::ExecuteMsg::StartSigningSession {
                 key_id: cur_worker_set.id(), // TODO remove the key_id
-                msg: batch.msg_to_sign(),
+                msg: batch.msg_to_sign()?,
             };
 
             Ok(Response::new().add_submessage(SubMsg::reply_on_success(


### PR DESCRIPTION
First of the sui encoding PRs. Encode the commands in bcs format.
