### PR TITLE
refactor: eliminate MessageId struct

### DIFF
--- a/contracts/connection-router/src/state.rs
+++ b/contracts/connection-router/src/state.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)]
 
 use core::panic;
+use std::any::type_name;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
@@ -128,81 +129,10 @@ impl TryFrom<String> for Address {
 }
 
 #[cw_serde]
-#[serde(try_from = "String")]
-#[derive(Eq, Hash)]
-pub struct MessageId(String);
-
-impl MessageId {
-    pub fn into_bytes(self) -> Vec<u8> {
-        self.0.into_bytes()
-    }
-}
-
-impl FromStr for MessageId {
-    type Err = ContractError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // todo: should split in exactly 2 parts when migrated to state::NewMessage
-        let split: Vec<_> = s.split(ID_SEPARATOR).filter(|s| !s.is_empty()).collect();
-        if split.len() < 2 {
-            return Err(ContractError::InvalidMessageId);
-        }
-        Ok(MessageId(s.to_lowercase()))
-    }
-}
-
-impl TryFrom<String> for MessageId {
-    type Error = ContractError;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        value.as_str().parse()
-    }
-}
-
-impl From<MessageId> for String {
-    fn from(d: MessageId) -> Self {
-        d.0
-    }
-}
-
-impl Deref for MessageId {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Display for MessageId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl<'a> PrimaryKey<'a> for MessageId {
-    type Prefix = ();
-    type SubPrefix = ();
-    type Suffix = Self;
-    type SuperSuffix = Self;
-
-    fn key(&self) -> Vec<Key> {
-        vec![Key::Ref(self.0.as_bytes())]
-    }
-}
-
-impl KeyDeserialize for MessageId {
-    type Output = Self;
-
-    fn from_vec(value: Vec<u8>) -> StdResult<Self> {
-        let value = String::from_utf8(value).map_err(StdError::invalid_utf8)?;
-        Ok(Self(value))
-    }
-}
-
-#[cw_serde]
 #[derive(Eq, Hash)]
 pub struct CrossChainId {
     pub chain: ChainName,
-    pub id: MessageId,
+    pub id: nonempty::String,
 }
 
 /// todo: remove this when state::NewMessage is used
@@ -212,7 +142,13 @@ impl FromStr for CrossChainId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts = s.split_once(ID_SEPARATOR);
         let (chain, id) = parts
-            .map(|(chain, id)| (chain.parse::<ChainName>(), id.parse::<MessageId>()))
+            .map(|(chain, id)| {
+                (
+                    chain.parse::<ChainName>(),
+                    id.parse::<nonempty::String>()
+                        .map_err(|_| ContractError::InvalidMessageId),
+                )
+            })
             .ok_or(ContractError::InvalidMessageId)?;
         Ok(CrossChainId {
             chain: chain?,
@@ -223,15 +159,15 @@ impl FromStr for CrossChainId {
 
 impl Display for CrossChainId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}{}", &self.chain, ID_SEPARATOR, &self.id)
+        write!(f, "{}{}{}", self.chain, ID_SEPARATOR, self.id.to_string())
     }
 }
 
 impl PrimaryKey<'_> for CrossChainId {
     type Prefix = ChainName;
     type SubPrefix = ();
-    type Suffix = MessageId;
-    type SuperSuffix = (ChainName, MessageId);
+    type Suffix = String;
+    type SuperSuffix = (ChainName, String);
 
     fn key(&self) -> Vec<Key> {
         let mut keys = self.chain.key();
@@ -244,8 +180,13 @@ impl KeyDeserialize for CrossChainId {
     type Output = Self;
 
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-        let (chain, id) = <(ChainName, MessageId)>::from_vec(value)?;
-        Ok(CrossChainId { chain, id })
+        let (chain, id) = <(ChainName, String)>::from_vec(value)?;
+        Ok(CrossChainId {
+            chain,
+            id: id
+                .try_into()
+                .map_err(|err| StdError::parse_err(type_name::<nonempty::String>(), err))?,
+        })
     }
 }
 
@@ -326,10 +267,7 @@ impl KeyDeserialize for &ChainName {
 
     #[inline(always)]
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-        String::from_utf8(value)
-            .map_err(StdError::invalid_utf8)?
-            .then(ChainName::try_from)
-            .map_err(StdError::invalid_utf8)
+        ChainName::from_vec(value)
     }
 }
 
@@ -367,13 +305,6 @@ mod tests {
     use sha3::{Digest, Sha3_256};
 
     use crate::ContractError;
-
-    #[test]
-    fn create_correct_global_message_id() {
-        let msg = dummy_message();
-
-        assert_eq!(msg.cc_id.to_string(), "chain:hash:index".to_string());
-    }
 
     #[test]
     // Any modifications to the Message struct fields or their types
@@ -454,34 +385,6 @@ mod tests {
         assert!(chain_name.eq(&"ethEReum".to_string()));
 
         assert!(!chain_name.eq(&"Ethereum-1".to_string()));
-    }
-
-    #[test]
-    fn message_id_must_have_at_least_one_separator() {
-        assert!(MessageId::from_str("source_chain:hash:id").is_ok());
-        assert!(serde_json::from_str::<MessageId>("\"source_chain:hash:id\"").is_ok());
-
-        assert!(MessageId::from_str("invalid_hash").is_err());
-        assert!(serde_json::from_str::<MessageId>("\"invalid_hash\"").is_err());
-
-        assert!(MessageId::from_str("invalid_hash:").is_err());
-    }
-
-    #[test]
-    fn message_id_is_lower_case() {
-        let msg_id = "HaSH:iD".parse::<MessageId>().unwrap();
-        assert_eq!(msg_id.to_string(), "hash:id");
-    }
-
-    #[test]
-    fn serialize_global_message_id() {
-        let id = CrossChainId {
-            chain: "ethereum".parse().unwrap(),
-            id: "hash:id".parse().unwrap(),
-        };
-
-        let serialized = serde_json::to_string(&id).unwrap();
-        assert_eq!(id, serde_json::from_str(&serialized).unwrap());
     }
 
     fn dummy_message() -> Message {

--- a/contracts/connection-router/src/state.rs
+++ b/contracts/connection-router/src/state.rs
@@ -159,7 +159,7 @@ impl FromStr for CrossChainId {
 
 impl Display for CrossChainId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}{}", self.chain, ID_SEPARATOR, self.id.to_string())
+        write!(f, "{}{}{}", self.chain, ID_SEPARATOR, *self.id)
     }
 }
 

--- a/contracts/multisig-prover/src/test/mocks/voting_verifier.rs
+++ b/contracts/multisig-prover/src/test/mocks/voting_verifier.rs
@@ -1,5 +1,4 @@
 use axelar_wasm_std::operators::Operators;
-use connection_router::state::MessageId;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_binary, Addr, Binary, Deps, DepsMut, Env, HexBinary, MessageInfo, Response, StdError,
@@ -57,7 +56,7 @@ pub fn confirm_worker_set(
         Addr::unchecked("relayer"),
         voting_verifier_address.clone(),
         &ExecuteMsg::ConfirmWorkerSet {
-            message_id: MessageId::try_from("ethereum:00".to_string()).unwrap(),
+            message_id: "ethereum:00".parse().unwrap(),
             new_operators: Operators {
                 weights_by_addresses: new_operators,
                 threshold,

--- a/contracts/nexus-gateway/src/error.rs
+++ b/contracts/nexus-gateway/src/error.rs
@@ -1,4 +1,3 @@
-use connection_router::state::MessageId;
 use cosmwasm_std::HexBinary;
 use thiserror::Error;
 
@@ -10,7 +9,7 @@ pub enum ContractError {
     Unauthorized,
 
     #[error("invalid message id {0}")]
-    InvalidMessageId(MessageId),
+    InvalidMessageId(String),
 
     #[error("invalid payload hash {0}")]
     InvalidMessagePayloadHash(HexBinary),

--- a/contracts/voting-verifier/src/error.rs
+++ b/contracts/voting-verifier/src/error.rs
@@ -1,7 +1,7 @@
 use axelar_wasm_std::{nonempty, voting};
 use axelar_wasm_std_derive::IntoContractError;
 use connection_router;
-use connection_router::state::{ChainName, MessageId};
+use connection_router::state::ChainName;
 use cosmwasm_std::StdError;
 use service_registry;
 use thiserror::Error;
@@ -30,7 +30,7 @@ pub enum ContractError {
     MessageMismatch(String),
 
     #[error("invalid message id {0}")]
-    InvalidMessageID(MessageId),
+    InvalidMessageID(String),
 
     #[error("poll not found")]
     PollNotFound,

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{Addr, Attribute, Event, HexBinary};
 use axelar_wasm_std::nonempty;
 use axelar_wasm_std::operators::Operators;
 use axelar_wasm_std::voting::PollID;
-use connection_router::state::{Address, ChainName, Message, MessageId, ID_SEPARATOR};
+use connection_router::state::{Address, ChainName, Message, ID_SEPARATOR};
 
 use crate::error::ContractError;
 use crate::state::Config;
@@ -113,7 +113,7 @@ pub struct WorkerSetConfirmation {
 }
 
 impl WorkerSetConfirmation {
-    pub fn new(message_id: MessageId, operators: Operators) -> Result<Self, ContractError> {
+    pub fn new(message_id: nonempty::String, operators: Operators) -> Result<Self, ContractError> {
         let (tx_id, event_index) = parse_message_id(&message_id)?;
         Ok(Self {
             tx_id,
@@ -150,19 +150,21 @@ impl TryFrom<Message> for TxEventConfirmation {
     }
 }
 
-fn parse_message_id(message_id: &MessageId) -> Result<(nonempty::String, u64), ContractError> {
+fn parse_message_id(
+    message_id: &nonempty::String,
+) -> Result<(nonempty::String, u64), ContractError> {
     // expected format: <tx_id>:<index>
     let components = message_id.split(ID_SEPARATOR).collect::<Vec<_>>();
 
     if components.len() != 2 {
-        return Err(ContractError::InvalidMessageID(message_id.clone()));
+        return Err(ContractError::InvalidMessageID(message_id.to_string()));
     }
 
     Ok((
         components[0].try_into()?,
         components[1]
             .parse::<u64>()
-            .map_err(|_| ContractError::InvalidMessageID(message_id.clone()))?,
+            .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?,
     ))
 }
 

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -5,10 +5,10 @@ use cosmwasm_std::{
 
 use axelar_wasm_std::voting::{PollID, PollResult};
 use axelar_wasm_std::{
-    snapshot,
+    nonempty, snapshot,
     voting::{Poll, WeightedPoll},
 };
-use connection_router::state::{ChainName, Message, MessageId};
+use connection_router::state::{ChainName, Message};
 use service_registry::msg::QueryMsg;
 use service_registry::state::Worker;
 
@@ -33,7 +33,7 @@ enum VerificationStatus {
 pub fn confirm_worker_set(
     deps: DepsMut,
     env: Env,
-    message_id: MessageId,
+    message_id: nonempty::String,
     new_operators: Operators,
 ) -> Result<Response, ContractError> {
     if CONFIRMED_WORKER_SETS

--- a/contracts/voting-verifier/src/msg.rs
+++ b/contracts/voting-verifier/src/msg.rs
@@ -6,7 +6,7 @@ use axelar_wasm_std::{
     voting::{PollID, PollResult},
     Threshold,
 };
-use connection_router::state::{ChainName, CrossChainId, Message, MessageId};
+use connection_router::state::{ChainName, CrossChainId, Message};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -43,7 +43,7 @@ pub enum ExecuteMsg {
 
     // Starts a poll to confirm a worker set update on the external evm gateway
     ConfirmWorkerSet {
-        message_id: MessageId,
+        message_id: nonempty::String,
         new_operators: Operators,
     },
 }

--- a/contracts/voting-verifier/tests/tests.rs
+++ b/contracts/voting-verifier/tests/tests.rs
@@ -3,7 +3,7 @@ use cw_multi_test::{App, ContractWrapper, Executor};
 
 use axelar_wasm_std::operators::Operators;
 use axelar_wasm_std::{nonempty, Threshold};
-use connection_router::state::{ChainName, CrossChainId, Message, MessageId, ID_SEPARATOR};
+use connection_router::state::{ChainName, CrossChainId, Message, ID_SEPARATOR};
 use service_registry::state::Worker;
 use voting_verifier::{contract, error::ContractError, msg};
 
@@ -44,8 +44,10 @@ fn initialize_contract(app: &mut App, service_registry_address: nonempty::String
     address
 }
 
-fn message_id(id: &str, index: u64) -> String {
+fn message_id(id: &str, index: u64) -> nonempty::String {
     format!("{}{}{}", id, ID_SEPARATOR, index)
+        .try_into()
+        .unwrap()
 }
 
 fn messages(len: u64) -> Vec<Message> {
@@ -252,7 +254,7 @@ fn should_start_worker_set_confirmation() {
         threshold: 1u64.into(),
     };
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -291,7 +293,7 @@ fn should_confirm_worker_set() {
         threshold: 1u64.into(),
     };
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -345,7 +347,7 @@ fn should_not_confirm_worker_set() {
         threshold: 1u64.into(),
     };
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -399,7 +401,7 @@ fn should_confirm_worker_set_after_failed() {
         threshold: 1u64.into(),
     };
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -431,7 +433,7 @@ fn should_confirm_worker_set_after_failed() {
 
     // try again, and this time vote true
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -485,7 +487,7 @@ fn should_not_confirm_twice() {
         threshold: 1u64.into(),
     };
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);
@@ -508,7 +510,7 @@ fn should_not_confirm_twice() {
 
     // try again, should fail
     let msg = msg::ExecuteMsg::ConfirmWorkerSet {
-        message_id: MessageId::try_from(message_id("id", 0)).unwrap(),
+        message_id: message_id("id", 0),
         new_operators: operators.clone(),
     };
     let res = app.execute_contract(Addr::unchecked(SENDER), contract_address.clone(), &msg, &[]);

--- a/packages/axelar-wasm-std/src/nonempty/string.rs
+++ b/packages/axelar-wasm-std/src/nonempty/string.rs
@@ -50,6 +50,12 @@ impl Deref for String {
     }
 }
 
+impl From<String> for crate::nonempty::Vec<u8> {
+    fn from(value: String) -> Self {
+        value.0.into_bytes().try_into().expect("cannot be empty")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::nonempty;


### PR DESCRIPTION
Any way I tried to cut it, it's impossible to move to using the apis defined in #146 without massive changes. So instead, the strategy will be to modify the data structs in connection router step by step until they look exactly like #146 and then have a single massive PR that only changes the dependency path in all affected files