### PR TITLE
feat: add Config to Multisig

### DIFF
--- a/contracts/multisig-prover/src/test/multicontract.rs
+++ b/contracts/multisig-prover/src/test/multicontract.rs
@@ -42,7 +42,9 @@ fn contract_multisig() -> Box<dyn Contract<Empty>> {
 
 fn instantiate_mock_multisig(app: &mut App) -> Addr {
     let code_id = app.store_code(contract_multisig());
-    let msg = multisig::msg::InstantiateMsg {};
+    let msg = multisig::msg::InstantiateMsg {
+        governance_address: "governance".parse().unwrap(),
+    };
 
     app.instantiate_contract(
         code_id,

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use crate::{
     events::Event,
     msg::{ExecuteMsg, InstantiateMsg, Multisig, QueryMsg},
-    state::{get_key, KEYS, SIGNING_SESSIONS, SIGNING_SESSION_COUNTER},
+    state::{get_key, Config, CONFIG, KEYS, SIGNING_SESSIONS, SIGNING_SESSION_COUNTER},
     types::{Key, KeyID, MsgToSign, MultisigState},
     ContractError,
 };
@@ -21,9 +21,12 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    _msg: InstantiateMsg,
+    msg: InstantiateMsg,
 ) -> Result<Response, axelar_wasm_std::ContractError> {
     SIGNING_SESSION_COUNTER.save(deps.storage, &Uint64::zero())?;
+
+    let governance = deps.api.addr_validate(&msg.governance_address)?;
+    CONFIG.save(deps.storage, &Config { governance })?;
 
     Ok(Response::default())
 }
@@ -322,7 +325,9 @@ mod tests {
         let info = mock_info(INSTANTIATOR, &[]);
         let env = mock_env();
 
-        let msg = InstantiateMsg {};
+        let msg = InstantiateMsg {
+            governance_address: "governance".parse().unwrap(),
+        };
 
         instantiate(deps, env, info, msg)
     }

--- a/contracts/multisig/src/msg.rs
+++ b/contracts/multisig/src/msg.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 
 #[cw_serde]
-pub struct InstantiateMsg {}
+pub struct InstantiateMsg {
+    // governance votes on adding addresses to allowed caller list.
+    pub governance_address: String,
+}
 
 #[cw_serde]
 pub enum ExecuteMsg {

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, HexBinary, Order, StdResult, Storage, Uint64};
 use cw_storage_plus::{Item, Map};
 
@@ -9,6 +10,13 @@ use crate::{
     types::{Key, KeyID},
     ContractError,
 };
+
+#[cw_serde]
+pub struct Config {
+    pub governance: Addr,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
 
 pub const SIGNING_SESSION_COUNTER: Item<Uint64> = Item::new("signing_session_counter");
 pub const SIGNING_SESSIONS: Map<u64, SigningSession> = Map::new("signing_sessions");


### PR DESCRIPTION
## Description
adds a config struct to the multisig of axelar-amplifier so we have access to governance address.
## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test
`cargo test`
## Expected Behaviour
`cargo test` passes
## Other Notes
