### PR TITLE
feat(voting-verifier): integrate voting with rewards contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12837,6 +12837,7 @@ dependencies = [
  "either",
  "error-stack",
  "report",
+ "rewards",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/voting-verifier/Cargo.toml
+++ b/contracts/voting-verifier/Cargo.toml
@@ -38,6 +38,7 @@ cw-storage-plus = { workspace = true }
 either = "1.8.1"
 error-stack = { workspace = true }
 report = { workspace = true }
+rewards = { workspace = true, features = ["library"] }
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 serde_json = "1.0.89"

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -24,7 +24,6 @@ pub fn instantiate(
         confirmation_height: msg.confirmation_height,
         source_chain: msg.source_chain,
         rewards_contract: deps.api.addr_validate(&msg.rewards_address)?,
-        grace_period: msg.grace_period,
     };
     CONFIG.save(deps.storage, &config)?;
 

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -23,6 +23,8 @@ pub fn instantiate(
         block_expiry: msg.block_expiry,
         confirmation_height: msg.confirmation_height,
         source_chain: msg.source_chain,
+        rewards_contract: deps.api.addr_validate(&msg.rewards_address)?,
+        grace_period: msg.grace_period,
     };
     CONFIG.save(deps.storage, &config)?;
 

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -274,7 +274,8 @@ pub fn end_poll(deps: DepsMut, env: Env, poll_id: PollID) -> Result<Response, Co
                 msg: to_binary(&rewards::msg::ExecuteMsg::RecordParticipation {
                     event_id: poll_id.into(),
                     worker_address: address.to_string(),
-                })?,
+                })
+                .expect("failed to serialize message for rewards contract"),
                 funds: vec![],
             })
         })

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -259,7 +259,7 @@ pub fn end_poll(deps: DepsMut, env: Env, poll_id: PollID) -> Result<Response, Co
 
     let poll_result = match &mut poll {
         state::Poll::Messages(poll) | state::Poll::ConfirmWorkerSet(poll) => {
-            poll.tally(env.block.height)?
+            poll.complete(env.block.height)?
         }
     };
     POLLS.save(deps.storage, poll_id, &poll)?;

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -167,12 +167,14 @@ pub fn vote(
     poll_id: PollID,
     votes: Vec<bool>,
 ) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+
     let mut poll = POLLS
         .may_load(deps.storage, poll_id)?
         .ok_or(ContractError::PollNotFound)?;
     match &mut poll {
         state::Poll::Messages(poll) | state::Poll::ConfirmWorkerSet(poll) => {
-            poll.cast_vote(env.block.height, &info.sender, votes)?
+            poll.cast_vote(env.block.height, config.grace_period, &info.sender, votes)?
         }
     };
 

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -276,8 +276,7 @@ pub fn end_poll(deps: DepsMut, env: Env, poll_id: PollID) -> Result<Response, Co
             })
             .expect("failed to serialize message for rewards contract"),
             funds: vec![],
-        })
-        .collect::<Vec<_>>();
+        });
 
     Ok(Response::new()
         .add_messages(rewards_msgs)

--- a/contracts/voting-verifier/src/execute.rs
+++ b/contracts/voting-verifier/src/execute.rs
@@ -268,18 +268,16 @@ pub fn end_poll(deps: DepsMut, env: Env, poll_id: PollID) -> Result<Response, Co
     let rewards_msgs = poll_result
         .consensus_participants
         .iter()
-        .map(|address| -> Result<WasmMsg, ContractError> {
-            Ok(WasmMsg::Execute {
-                contract_addr: config.rewards_contract.to_string(),
-                msg: to_binary(&rewards::msg::ExecuteMsg::RecordParticipation {
-                    event_id: poll_id.into(),
-                    worker_address: address.to_string(),
-                })
-                .expect("failed to serialize message for rewards contract"),
-                funds: vec![],
+        .map(|address| WasmMsg::Execute {
+            contract_addr: config.rewards_contract.to_string(),
+            msg: to_binary(&rewards::msg::ExecuteMsg::RecordParticipation {
+                event_id: poll_id.into(),
+                worker_address: address.to_string(),
             })
+            .expect("failed to serialize message for rewards contract"),
+            funds: vec![],
         })
-        .collect::<Result<Vec<WasmMsg>, ContractError>>()?;
+        .collect::<Vec<_>>();
 
     Ok(Response::new()
         .add_messages(rewards_msgs)

--- a/contracts/voting-verifier/src/msg.rs
+++ b/contracts/voting-verifier/src/msg.rs
@@ -19,10 +19,7 @@ pub struct InstantiateMsg {
     pub block_expiry: u64,
     pub confirmation_height: u64,
     pub source_chain: ChainName,
-
-    // rewards
     pub rewards_address: String,
-    pub grace_period: u64, // in blocks after session has been completed
 }
 
 #[cw_serde]

--- a/contracts/voting-verifier/src/msg.rs
+++ b/contracts/voting-verifier/src/msg.rs
@@ -19,6 +19,10 @@ pub struct InstantiateMsg {
     pub block_expiry: u64,
     pub confirmation_height: u64,
     pub source_chain: ChainName,
+
+    // rewards
+    pub rewards_address: String,
+    pub grace_period: u64, // in blocks after session has been completed
 }
 
 #[cw_serde]

--- a/contracts/voting-verifier/src/state.rs
+++ b/contracts/voting-verifier/src/state.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub block_expiry: u64, // number of blocks after which a poll expires
     pub confirmation_height: u64,
     pub source_chain: ChainName,
+    pub rewards_contract: Addr,
+    pub grace_period: u64, // TODO: add update mechanism to change this after instantiation
 }
 
 #[cw_serde]

--- a/contracts/voting-verifier/src/state.rs
+++ b/contracts/voting-verifier/src/state.rs
@@ -20,7 +20,6 @@ pub struct Config {
     pub confirmation_height: u64,
     pub source_chain: ChainName,
     pub rewards_contract: Addr,
-    pub grace_period: u64, // TODO: add update mechanism to change this after instantiation
 }
 
 #[cw_serde]

--- a/contracts/voting-verifier/tests/mock.rs
+++ b/contracts/voting-verifier/tests/mock.rs
@@ -81,3 +81,44 @@ pub fn make_mock_service_registry(app: &mut App) -> Addr {
         .unwrap();
     contract_address
 }
+
+#[cw_serde]
+pub struct MockRewardsInstantiateMsg;
+
+pub fn mock_rewards_execute(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: rewards::msg::ExecuteMsg,
+) -> Result<Response, ContractError> {
+    Ok(Response::new())
+}
+
+pub fn mock_rewards_query(
+    _deps: Deps,
+    _env: Env,
+    _msg: rewards::msg::QueryMsg,
+) -> StdResult<Binary> {
+    Ok(to_binary("")?)
+}
+
+pub fn make_mock_rewards(app: &mut App) -> Addr {
+    let code = ContractWrapper::new(
+        mock_rewards_execute,
+        |_, _, _, _: MockRewardsInstantiateMsg| Ok::<Response, ContractError>(Response::new()),
+        mock_rewards_query,
+    );
+    let code_id = app.store_code(Box::new(code));
+
+    let contract_address = app
+        .instantiate_contract(
+            code_id,
+            Addr::unchecked("sender"),
+            &MockRewardsInstantiateMsg,
+            &[],
+            "Contract",
+            None,
+        )
+        .unwrap();
+    contract_address
+}

--- a/contracts/voting-verifier/tests/tests.rs
+++ b/contracts/voting-verifier/tests/tests.rs
@@ -29,7 +29,6 @@ fn initialize_contract(app: &mut App, service_registry_address: nonempty::String
         source_gateway_address: "gateway_address".parse().unwrap(),
         source_chain: source_chain(),
         rewards_address,
-        grace_period: 2,
     };
 
     let code = ContractWrapper::new(contract::execute, contract::instantiate, contract::query);

--- a/contracts/voting-verifier/tests/tests.rs
+++ b/contracts/voting-verifier/tests/tests.rs
@@ -4,6 +4,7 @@ use cw_multi_test::{App, ContractWrapper, Executor};
 use axelar_wasm_std::operators::Operators;
 use axelar_wasm_std::{nonempty, Threshold};
 use connection_router::state::{ChainName, CrossChainId, Message, ID_SEPARATOR};
+use mock::make_mock_rewards;
 use service_registry::state::Worker;
 use voting_verifier::{contract, error::ContractError, msg};
 
@@ -12,12 +13,13 @@ use crate::mock::make_mock_service_registry;
 pub mod mock;
 
 const SENDER: &str = "sender";
-const REWARDS_CONTRACT: &str = "rewards";
 fn source_chain() -> ChainName {
     "source_chain".parse().unwrap()
 }
 
 fn initialize_contract(app: &mut App, service_registry_address: nonempty::String) -> Addr {
+    let rewards_address = make_mock_rewards(app).into();
+
     let msg = msg::InstantiateMsg {
         service_registry_address,
         service_name: "service_name".parse().unwrap(),
@@ -26,7 +28,7 @@ fn initialize_contract(app: &mut App, service_registry_address: nonempty::String
         confirmation_height: 100,
         source_gateway_address: "gateway_address".parse().unwrap(),
         source_chain: source_chain(),
-        rewards_address: REWARDS_CONTRACT.to_string(),
+        rewards_address,
         grace_period: 2,
     };
 

--- a/contracts/voting-verifier/tests/tests.rs
+++ b/contracts/voting-verifier/tests/tests.rs
@@ -12,6 +12,7 @@ use crate::mock::make_mock_service_registry;
 pub mod mock;
 
 const SENDER: &str = "sender";
+const REWARDS_CONTRACT: &str = "rewards";
 fn source_chain() -> ChainName {
     "source_chain".parse().unwrap()
 }
@@ -25,6 +26,8 @@ fn initialize_contract(app: &mut App, service_registry_address: nonempty::String
         confirmation_height: 100,
         source_gateway_address: "gateway_address".parse().unwrap(),
         source_chain: source_chain(),
+        rewards_address: REWARDS_CONTRACT.to_string(),
+        grace_period: 2,
     };
 
     let code = ContractWrapper::new(contract::execute, contract::instantiate, contract::query);

--- a/packages/axelar-wasm-std/src/voting.rs
+++ b/packages/axelar-wasm-std/src/voting.rs
@@ -390,6 +390,18 @@ mod tests {
     }
 
     #[test]
+    fn vote_during_grace_period() {
+        let mut poll = new_poll(5, 2, vec!["addr1", "addr2"]);
+        let votes = vec![true, true];
+        poll.status = PollStatus::Finished { completed_at: 1 };
+
+        assert!(poll
+            .cast_vote(2, 1, &Addr::unchecked("addr1"), votes)
+            .is_ok());
+        assert_eq!(poll.status, PollStatus::Finished { completed_at: 1 });
+    }
+
+    #[test]
     fn tally_before_poll_end() {
         let mut poll = new_poll(1, 2, vec!["addr1", "addr2"]);
         assert_eq!(poll.tally(0), Err(Error::PollNotEnded));

--- a/packages/axelar-wasm-std/src/voting.rs
+++ b/packages/axelar-wasm-std/src/voting.rs
@@ -415,15 +415,17 @@ mod tests {
         let votes = vec![false, false];
 
         assert!(poll
-            .cast_vote(0, &Addr::unchecked("addr1"), votes.clone())
+            .cast_vote(0, 1, &Addr::unchecked("addr1"), votes.clone())
             .is_ok());
         assert!(poll
-            .cast_vote(0, &Addr::unchecked("addr2"), votes.clone())
+            .cast_vote(0, 1, &Addr::unchecked("addr2"), votes.clone())
             .is_ok());
-        assert!(poll.cast_vote(0, &Addr::unchecked("addr3"), votes).is_ok());
+        assert!(poll
+            .cast_vote(0, 1, &Addr::unchecked("addr3"), votes)
+            .is_ok());
 
         let result = poll.tally(0).unwrap();
-        assert_eq!(poll.status, PollStatus::Finished);
+        assert_eq!(poll.status, PollStatus::Finished { completed_at: 0 });
 
         assert_eq!(
             result,
@@ -440,12 +442,14 @@ mod tests {
         let votes = vec![true, true];
 
         assert!(poll
-            .cast_vote(0, &Addr::unchecked("addr1"), votes.clone())
+            .cast_vote(0, 1, &Addr::unchecked("addr1"), votes.clone())
             .is_ok());
-        assert!(poll.cast_vote(0, &Addr::unchecked("addr2"), votes).is_ok());
+        assert!(poll
+            .cast_vote(0, 1, &Addr::unchecked("addr2"), votes)
+            .is_ok());
 
         let result = poll.tally(0).unwrap();
-        assert_eq!(poll.status, PollStatus::Finished);
+        assert_eq!(poll.status, PollStatus::Finished { completed_at: 0 });
 
         assert_eq!(
             result,


### PR DESCRIPTION
## Description
Calls reward contract to record participation when casting a vote. Rewards gets distributed after poll completion to all participants that voted for the consensus result

https://axelarnetwork.atlassian.net/browse/AXE-2411

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
