### PR TITLE
feat(ampd): add support for command line arguments

### DIFF
--- a/ampd/Dockerfile
+++ b/ampd/Dockerfile
@@ -6,6 +6,5 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim AS final
 COPY --from=build /app/target/release/ampd /usr/local/bin/ampd
-COPY --from=build /app/ampd/config.toml /usr/local/bin/config.toml
 WORKDIR /usr/local/bin
 ENTRYPOINT ["ampd"]

--- a/ampd/Dockerfile
+++ b/ampd/Dockerfile
@@ -6,5 +6,6 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim AS final
 COPY --from=build /app/target/release/ampd /usr/local/bin/ampd
+COPY --from=build /app/ampd/config.toml /usr/local/bin/config.toml
 WORKDIR /usr/local/bin
-CMD ["ampd"]
+ENTRYPOINT ["ampd"]


### PR DESCRIPTION
## Description
[AXE-2450]

1. Place your `config.toml` file in the `ampd` folder.

2. Build the docker container:
`docker build -t ampd -f ampd/Dockerfile .`

3. Run the docker container with arguments (example usage)
docker run -v $(pwd)/ampd:/usr/local/bin/config -it ampd -c config/config.toml`



[AXE-2450]: https://axelarnetwork.atlassian.net/browse/AXE-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ