### PR TITLE
refactor: implement AsRef in uint.rs

### DIFF
--- a/packages/axelar-wasm-std/src/nonempty/uint.rs
+++ b/packages/axelar-wasm-std/src/nonempty/uint.rs
@@ -141,6 +141,19 @@ mod tests {
     }
 
     #[test]
+    fn convert_from_cosmwasm_uint128_to_uint128() {
+        // zero
+        let val = cosmwasm_std::Uint128::zero();
+        assert_eq!(
+            Uint128::try_from(val).unwrap_err(),
+            Error::InvalidValue(val.into())
+        );
+
+        // non-zero
+        assert!(Uint128::try_from(cosmwasm_std::Uint128::one()).is_ok());
+    }
+
+    #[test]
     fn convert_from_cosmwasm_uint256_to_uint256() {
         // zero
         assert_eq!(

--- a/packages/axelar-wasm-std/src/nonempty/uint.rs
+++ b/packages/axelar-wasm-std/src/nonempty/uint.rs
@@ -82,6 +82,12 @@ impl TryFrom<cosmwasm_std::Uint128> for Uint256 {
     }
 }
 
+impl AsRef<cosmwasm_std::Uint256> for Uint256 {
+    fn as_ref(&self) -> &cosmwasm_std::Uint256 {
+        &self.0
+    }
+}
+
 #[cw_serde]
 #[derive(Copy, PartialOrd, Eq)]
 pub struct Uint128(cosmwasm_std::Uint128);
@@ -157,5 +163,12 @@ mod tests {
 
         // non-zero
         assert!(Uint256::try_from(cosmwasm_std::Uint128::one()).is_ok());
+    }
+
+    #[test]
+    fn convert_from_uint256_to_reference_cosmwasm_uint256() {
+        let val = Uint256(cosmwasm_std::Uint256::one());
+        let converted: &cosmwasm_std::Uint256 = val.as_ref();
+        assert_eq!(&val.0, converted);
     }
 }

--- a/packages/axelar-wasm-std/src/nonempty/uint.rs
+++ b/packages/axelar-wasm-std/src/nonempty/uint.rs
@@ -29,12 +29,6 @@ impl TryFrom<u64> for Uint64 {
     }
 }
 
-impl<'a> From<&'a Uint64> for &'a cosmwasm_std::Uint64 {
-    fn from(value: &'a Uint64) -> Self {
-        &value.0
-    }
-}
-
 impl From<Uint64> for cosmwasm_std::Uint64 {
     fn from(value: Uint64) -> Self {
         value.0
@@ -73,12 +67,6 @@ impl TryFrom<cosmwasm_std::Uint256> for Uint256 {
 impl From<Uint256> for cosmwasm_std::Uint256 {
     fn from(value: Uint256) -> Self {
         value.0
-    }
-}
-
-impl<'a> From<&'a Uint256> for &'a cosmwasm_std::Uint256 {
-    fn from(value: &'a Uint256) -> Self {
-        &value.0
     }
 }
 
@@ -169,12 +157,5 @@ mod tests {
 
         // non-zero
         assert!(Uint256::try_from(cosmwasm_std::Uint128::one()).is_ok());
-    }
-
-    #[test]
-    fn convert_from_uint64_to_reference_cosmwasm_uint64() {
-        let val = Uint64(cosmwasm_std::Uint64::one());
-        let converted: &cosmwasm_std::Uint64 = (&val).into();
-        assert_eq!(&val.0, converted);
     }
 }

--- a/packages/axelar-wasm-std/src/snapshot.rs
+++ b/packages/axelar-wasm-std/src/snapshot.rs
@@ -25,7 +25,7 @@ impl Snapshot {
         let participants: HashMap<String, Participant> = participants
             .into_iter()
             .map(|participant| {
-                let weight: &Uint256 = (&participant.weight).into();
+                let weight: Uint256 = participant.weight.into();
                 total_weight += weight;
 
                 (participant.address.to_string(), participant)
@@ -42,10 +42,10 @@ impl Snapshot {
         }
     }
 
-    pub fn get_participant_weight(&self, participant: &Addr) -> Option<&Uint256> {
+    pub fn get_participant_weight(&self, participant: &Addr) -> Option<Uint256> {
         self.participants
             .get(participant.as_str())
-            .map(|p| (&p.weight).into())
+            .map(|p| p.weight.into())
     }
 
     pub fn get_participants(&self) -> Vec<Addr> {

--- a/packages/axelar-wasm-std/src/snapshot.rs
+++ b/packages/axelar-wasm-std/src/snapshot.rs
@@ -25,7 +25,7 @@ impl Snapshot {
         let participants: HashMap<String, Participant> = participants
             .into_iter()
             .map(|participant| {
-                let weight: Uint256 = participant.weight.into();
+                let weight: &Uint256 = participant.weight.as_ref();
                 total_weight += weight;
 
                 (participant.address.to_string(), participant)
@@ -42,10 +42,10 @@ impl Snapshot {
         }
     }
 
-    pub fn get_participant_weight(&self, participant: &Addr) -> Option<Uint256> {
+    pub fn get_participant_weight(&self, participant: &Addr) -> Option<&Uint256> {
         self.participants
             .get(participant.as_str())
-            .map(|p| p.weight.into())
+            .map(|p| p.weight.as_ref())
     }
 
     pub fn get_participants(&self) -> Vec<Addr> {


### PR DESCRIPTION
## Description
[AXE-2636]
Uses AsRef for Uint256

## Steps to Test
`cargo test` passes


[AXE-2636]: https://axelarnetwork.atlassian.net/browse/AXE-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ