### PR TITLE
update cosmwasm-check to use 1.3.3

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --debug --version 1.5.0 cosmwasm-check
+          args: --debug --version 1.3.3 cosmwasm-check
     
       - name: Check wasm contracts
         run: cosmwasm-check ./target/wasm32-unknown-unknown/release/*.wasm


### PR DESCRIPTION
## Description
Matches the version of `cosmwasm-check` with `cosmwasm-std`, 1.3.3
