### PR TITLE
fix(nexus-gateway): remove untagged and split RouteMessages into two separate messages

### DIFF
--- a/contracts/nexus-gateway/src/contract.rs
+++ b/contracts/nexus-gateway/src/contract.rs
@@ -1,7 +1,9 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
+use error_stack::ResultExt;
 
+use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg};
 use crate::nexus;
 use crate::state::{Config, GatewayStore, Store};
@@ -35,7 +37,12 @@ pub fn execute(
     let contract = Contract::new(GatewayStore::new(deps.storage));
 
     let res = match msg {
-        ExecuteMsg::RouteMessages(msgs) => contract.route_messages(info.sender, msgs)?,
+        ExecuteMsg::RouteMessages(msgs) => contract
+            .route_to_nexus(info.sender, msgs)
+            .change_context(ContractError::RouteToNexus)?,
+        ExecuteMsg::RouteMessagesFromNexus(msgs) => contract
+            .route_to_router(info.sender, msgs)
+            .change_context(ContractError::RouteToRouter)?,
     };
 
     Ok(res)

--- a/contracts/nexus-gateway/src/msg.rs
+++ b/contracts/nexus-gateway/src/msg.rs
@@ -1,6 +1,4 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::nexus;
 
@@ -10,34 +8,10 @@ pub struct InstantiateMsg {
     pub router: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(untagged)]
-pub enum Message {
-    RouterMessage(connection_router::Message),
-    NexusMessage(nexus::Message),
-}
-
-impl From<Message> for connection_router::Message {
-    fn from(msg: Message) -> Self {
-        match msg {
-            Message::RouterMessage(msg) => msg,
-            Message::NexusMessage(msg) => msg.into(),
-        }
-    }
-}
-
-impl From<Message> for nexus::Message {
-    fn from(msg: Message) -> Self {
-        match msg {
-            Message::RouterMessage(msg) => msg.into(),
-            Message::NexusMessage(msg) => msg,
-        }
-    }
-}
-
 #[cw_serde]
 pub enum ExecuteMsg {
-    RouteMessages(Vec<Message>),
+    RouteMessages(Vec<connection_router::Message>),
+    RouteMessagesFromNexus(Vec<nexus::Message>),
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
