### PR TITLE
feat(axelar-wasm-std): make Operators.weights_by_addresses public

### DIFF
--- a/packages/axelar-wasm-std/src/operators.rs
+++ b/packages/axelar-wasm-std/src/operators.rs
@@ -7,7 +7,7 @@ use crate::hash::Hash;
 
 #[cw_serde]
 pub struct Operators {
-    weights_by_addresses: Vec<(HexBinary, Uint256)>,
+    pub weights_by_addresses: Vec<(HexBinary, Uint256)>,
     pub threshold: Uint256,
 }
 


### PR DESCRIPTION
Update to match the definition in the EVM handler: https://github.com/axelarnetwork/axelar-amplifier/blob/e04a85fc635448559cdd265da582d1f49a6b8f52/ampd/src/handlers/evm_verify_worker_set.rs#L28