### PR TITLE
fix(multisig-prover): don't prevent signing due to multiple workerset rotations

### DIFF
--- a/contracts/multisig-prover/src/execute.rs
+++ b/contracts/multisig-prover/src/execute.rs
@@ -39,8 +39,14 @@ pub fn construct_proof(
             let mut builder = CommandBatchBuilder::new(config.destination_chain_id, config.encoder);
 
             if let Some(new_worker_set) = new_worker_set {
-                if save_next_worker_set(deps.storage, &new_worker_set).is_ok() {
-                    builder.add_new_worker_set(new_worker_set)?;
+                match save_next_worker_set(deps.storage, &new_worker_set) {
+                    Ok(()) => {
+                        builder.add_new_worker_set(new_worker_set)?;
+                    }
+                    Err(ContractError::WorkerSetConfirmationInProgress) => {}
+                    Err(other_error) => {
+                        return Err(other_error);
+                    }
                 }
             }
 
@@ -180,7 +186,8 @@ fn save_next_worker_set(
         return Err(ContractError::WorkerSetConfirmationInProgress);
     }
 
-    Ok(NEXT_WORKER_SET.save(storage, new_worker_set)?)
+    NEXT_WORKER_SET.save(storage, new_worker_set)?;
+    Ok(())
 }
 
 pub fn update_worker_set(deps: DepsMut, env: Env) -> Result<Response, ContractError> {

--- a/contracts/multisig-prover/src/execute.rs
+++ b/contracts/multisig-prover/src/execute.rs
@@ -39,8 +39,9 @@ pub fn construct_proof(
             let mut builder = CommandBatchBuilder::new(config.destination_chain_id, config.encoder);
 
             if let Some(new_worker_set) = new_worker_set {
-                save_next_worker_set(deps.storage, &new_worker_set)?;
-                builder.add_new_worker_set(new_worker_set)?;
+                if save_next_worker_set(deps.storage, &new_worker_set).is_ok() {
+                    builder.add_new_worker_set(new_worker_set)?;
+                }
             }
 
             for msg in messages {

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -632,14 +632,14 @@ pub fn execute_worker_set_poll(
     relayer_addr: &Addr,
     verifier_address: &Addr,
     new_workers: &Vec<Worker>,
-    expected_new_worker_set: &WorkerSet,
+    new_worker_set: &WorkerSet,
 ) {
     // Create worker set poll
     let (poll_id, expiry) = create_worker_set_poll(
         &mut protocol.app,
         relayer_addr.clone(),
         verifier_address.clone(),
-        expected_new_worker_set.clone(),
+        new_worker_set.clone(),
     );
 
     // Vote for the worker set

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -593,7 +593,6 @@ pub fn update_registry_and_construct_proof(
     chain_multisig_prover_address: &Addr,
     min_worker_bond: Uint128,
 ) -> Uint64 {
-
     // Register new workers
     register_workers(
         &mut protocol.app,
@@ -616,15 +615,13 @@ pub fn update_registry_and_construct_proof(
     );
 
     // Construct proof and sign
-    let session_id = construct_proof_and_sign(
+    construct_proof_and_sign(
         &mut protocol.app,
         &chain_multisig_prover_address,
         &protocol.multisig_address,
         &Vec::<Message>::new(),
         &current_workers,
-    );
-
-    session_id
+    )
 }
 
 pub fn process_poll(
@@ -643,24 +640,14 @@ pub fn process_poll(
     );
 
     // Vote for the worker set
-    vote_true_for_worker_set(
-        &mut protocol.app,
-        verifier_address,
-        new_workers,
-        poll_id,
-    );
+    vote_true_for_worker_set(&mut protocol.app, verifier_address, new_workers, poll_id);
 
     // Advance to expiration height
     advance_at_least_to_height(&mut protocol.app, expiry);
 
     // End the poll
-    end_poll(
-        &mut protocol.app,
-        verifier_address,
-        poll_id,
-    );
+    end_poll(&mut protocol.app, verifier_address, poll_id);
 }
-
 
 #[derive(Clone)]
 pub struct Chain {

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -616,7 +616,7 @@ pub fn setup_chain(protocol: &mut Protocol, chain_name: ChainName) -> Chain {
             signing_threshold: Threshold::try_from((2, 3)).unwrap().try_into().unwrap(),
             service_name: protocol.service_name.to_string(),
             chain_name: chain_name.to_string(),
-            worker_set_diff_threshold: 1,
+            worker_set_diff_threshold: 0,
             encoder: multisig_prover::encoding::Encoder::Abi,
             key_type: multisig::key::KeyType::Ecdsa,
         },

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -571,19 +571,18 @@ pub fn workers_to_worker_set(protocol: &mut Protocol, workers: &Vec<Worker>) -> 
     )
 }
 
-pub fn create_new_workers_vec(chains: Vec<ChainName>, worker_details: Vec<(String, u32)>) -> Vec<Worker> {
-    let mut new_workers = Vec::new();
-
-    for (name, seed) in worker_details {
-        let new_worker = Worker {
-            addr: Addr::unchecked(&name),
+pub fn create_new_workers_vec(
+    chains: Vec<ChainName>,
+    worker_details: Vec<(String, u32)>,
+) -> Vec<Worker> {
+    worker_details
+        .into_iter()
+        .map(|(name, seed)| Worker {
+            addr: Addr::unchecked(name),
             supported_chains: chains.clone(),
             key_pair: generate_key(seed),
-        };
-        new_workers.push(new_worker);
-    }
-
-    new_workers
+        })
+        .collect()
 }
 
 pub fn update_registry_and_construct_proof(

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -631,8 +631,10 @@ pub fn execute_worker_set_poll(
     relayer_addr: &Addr,
     verifier_address: &Addr,
     new_workers: &Vec<Worker>,
-    new_worker_set: &WorkerSet,
 ) {
+    // Create worker set
+    let new_worker_set = workers_to_worker_set(protocol, new_workers);
+
     // Create worker set poll
     let (poll_id, expiry) = create_worker_set_poll(
         &mut protocol.app,

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -588,8 +588,8 @@ pub fn create_new_workers_vec(
 pub fn update_registry_and_construct_proof(
     protocol: &mut Protocol,
     new_workers: &Vec<Worker>,
-    previous_workers: &Vec<Worker>,
-    initial_workers: &Vec<Worker>,
+    workers_to_remove: &Vec<Worker>,
+    current_workers: &Vec<Worker>,
     chain_multisig_prover_address: &Addr,
     min_worker_bond: Uint128,
 ) -> Uint64 {
@@ -611,7 +611,7 @@ pub fn update_registry_and_construct_proof(
         &mut protocol.app,
         protocol.service_registry_address.clone(),
         protocol.governance_address.clone(),
-        previous_workers,
+        workers_to_remove,
         protocol.service_name.clone(),
     );
 
@@ -621,7 +621,7 @@ pub fn update_registry_and_construct_proof(
         &chain_multisig_prover_address,
         &protocol.multisig_address,
         &Vec::<Message>::new(),
-        &initial_workers,
+        &current_workers,
     );
 
     session_id

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -571,6 +571,98 @@ pub fn workers_to_worker_set(protocol: &mut Protocol, workers: &Vec<Worker>) -> 
     )
 }
 
+pub fn create_new_workers_vec(chains: Vec<ChainName>, worker_details: Vec<(String, u32)>) -> Vec<Worker> {
+    let mut new_workers = Vec::new();
+
+    for (name, seed) in worker_details {
+        let new_worker = Worker {
+            addr: Addr::unchecked(&name),
+            supported_chains: chains.clone(),
+            key_pair: generate_key(seed),
+        };
+        new_workers.push(new_worker);
+    }
+
+    new_workers
+}
+
+pub fn update_registry_and_construct_proof(
+    protocol: &mut Protocol,
+    new_workers: &Vec<Worker>,
+    previous_workers: &Vec<Worker>,
+    initial_workers: &Vec<Worker>,
+    chain_multisig_prover_address: &Addr,
+    min_worker_bond: Uint128,
+) -> Uint64 {
+
+    // Register new workers
+    register_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.multisig_address.clone(),
+        protocol.governance_address.clone(),
+        protocol.genesis_address.clone(),
+        new_workers,
+        protocol.service_name.clone(),
+        min_worker_bond,
+    );
+
+    // Deregister old workers
+    deregister_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.governance_address.clone(),
+        previous_workers,
+        protocol.service_name.clone(),
+    );
+
+    // Construct proof and sign
+    let session_id = construct_proof_and_sign(
+        &mut protocol.app,
+        &chain_multisig_prover_address,
+        &protocol.multisig_address,
+        &Vec::<Message>::new(),
+        &initial_workers,
+    );
+
+    session_id
+}
+
+pub fn process_poll(
+    protocol: &mut Protocol,
+    relayer_addr: &Addr,
+    verifier_address: &Addr,
+    new_workers: &Vec<Worker>,
+    expected_new_worker_set: &WorkerSet,
+) {
+    // Create worker set poll
+    let (poll_id, expiry) = create_worker_set_poll(
+        &mut protocol.app,
+        relayer_addr.clone(),
+        verifier_address.clone(),
+        expected_new_worker_set.clone(),
+    );
+
+    // Vote for the worker set
+    vote_true_for_worker_set(
+        &mut protocol.app,
+        verifier_address,
+        new_workers,
+        poll_id,
+    );
+
+    // Advance to expiration height
+    advance_at_least_to_height(&mut protocol.app, expiry);
+
+    // End the poll
+    end_poll(
+        &mut protocol.app,
+        verifier_address,
+        poll_id,
+    );
+}
+
+
 #[derive(Clone)]
 pub struct Chain {
     pub gateway_address: Addr,

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -624,7 +624,7 @@ pub fn update_registry_and_construct_proof(
     )
 }
 
-pub fn process_poll(
+pub fn execute_worker_set_poll(
     protocol: &mut Protocol,
     relayer_addr: &Addr,
     verifier_address: &Addr,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -290,8 +290,8 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
 
     let second_wave_session_id = test_utils::update_registry_and_construct_proof(
         &mut protocol,
-        &second_wave_of_new_workers,
-        &first_wave_of_new_workers, // as previous_workers compared to the second wave of new workers
+        &second_wave_of_new_workers, // as new_workers
+        &first_wave_of_new_workers, // as workers_to_remove
         &initial_workers,
         &ethereum.multisig_prover_address,
         min_worker_bond,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -243,13 +243,12 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
 
     assert_eq!(worker_set, simulated_worker_set);
 
-    // creating third and fourth workers
+    // creating a new worker set that only consists of two new workers
     let first_wave_of_new_workers = test_utils::create_new_workers_vec(
         chains.clone(),
         vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)],
     );
 
-    // consists of workers three and four
     let first_wave_worker_set =
         test_utils::workers_to_worker_set(&mut protocol, &first_wave_of_new_workers);
 

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -243,49 +243,23 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
 
     assert_eq!(worker_set, simulated_worker_set);
 
-    // add third and fourth worker
-    let mut new_workers = Vec::new();
-    let new_worker = Worker {
-        addr: Addr::unchecked("worker3"),
-        supported_chains: chains.clone(),
-        key_pair: test_utils::generate_key(2),
-    };
-    new_workers.push(new_worker);
-    let new_worker = Worker {
-        addr: Addr::unchecked("worker4"),
-        supported_chains: chains.clone(),
-        key_pair: test_utils::generate_key(3),
-    };
-    new_workers.push(new_worker);
+    // creating third and fourth workers
+    let worker_details = vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)];
+    let first_wave_of_new_workers =
+        test_utils::create_new_workers_vec(chains.clone(), worker_details);
 
-    let expected_new_worker_set = test_utils::workers_to_worker_set(&mut protocol, &new_workers);
+    // consists of workers three and four
+    let first_wave_worker_set =
+        test_utils::workers_to_worker_set(&mut protocol, &first_wave_of_new_workers);
 
-    test_utils::register_workers(
-        &mut protocol.app,
-        protocol.service_registry_address.clone(),
-        protocol.multisig_address.clone(),
-        protocol.governance_address.clone(),
-        protocol.genesis_address.clone(),
-        &new_workers,
-        protocol.service_name.clone(),
-        min_worker_bond,
-    );
-
-    // remove old workers
-    test_utils::deregister_workers(
-        &mut protocol.app,
-        protocol.service_registry_address.clone(),
-        protocol.governance_address.clone(),
+    // register the new workers (3 and 4), deregister old workers, then create proof and get id
+    let session_id = test_utils::update_registry_and_construct_proof(
+        &mut protocol,
+        &first_wave_of_new_workers,
+        &initial_workers, // as previous_workers compared to the first wave of new workers
         &initial_workers,
-        protocol.service_name.clone(),
-    );
-
-    let session_id = test_utils::construct_proof_and_sign(
-        &mut protocol.app,
         &ethereum.multisig_prover_address,
-        &protocol.multisig_address,
-        &Vec::<Message>::new(),
-        &initial_workers,
+        min_worker_bond,
     );
 
     let proof = test_utils::get_proof(
@@ -293,108 +267,59 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
         &ethereum.multisig_prover_address,
         &session_id,
     );
+
+    // proof must be completed
     assert!(matches!(
         proof.status,
         multisig_prover::msg::ProofStatus::Completed { .. }
     ));
-
     assert_eq!(proof.message_ids.len(), 0);
 
-    // confirm the initial rotation
-    let (poll_id, expiry) = test_utils::create_worker_set_poll(
-        &mut protocol.app,
-        Addr::unchecked("relayer"),
-        ethereum.voting_verifier_address.clone(),
-        expected_new_worker_set.clone(),
-    );
-
-    // do voting
-    test_utils::vote_true_for_worker_set(
-        &mut protocol.app,
+    // confirm the initial rotation by starting and ending a poll
+    test_utils::process_poll(
+        &mut protocol,
+        &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,
-        &new_workers,
-        poll_id,
+        &first_wave_of_new_workers,
+        &first_wave_worker_set,
     );
 
-    test_utils::advance_at_least_to_height(&mut protocol.app, expiry);
+    // try to rotate again. this should be ignored, because the first rotation is not yet confirmed
+    let second_worker_details = vec![("worker5".to_string(), 5)];
+    let second_wave_of_new_workers =
+        test_utils::create_new_workers_vec(chains.clone(), second_worker_details);
 
-    test_utils::end_poll(
-        &mut protocol.app,
-        &ethereum.voting_verifier_address,
-        poll_id,
-    );
-
-    // try to rotate again. this should be ignored, because the first rotation was not yet confirmed
-    let new_new_workers = vec![Worker {
-        addr: Addr::unchecked("worker5"),
-        supported_chains: chains.clone(),
-        key_pair: test_utils::generate_key(5),
-    }];
-
-    test_utils::register_workers(
-        &mut protocol.app,
-        protocol.service_registry_address.clone(),
-        protocol.multisig_address.clone(),
-        protocol.governance_address.clone(),
-        protocol.genesis_address.clone(),
-        &new_new_workers,
-        protocol.service_name.clone(),
+    let second_wave_session_id = test_utils::update_registry_and_construct_proof(
+        &mut protocol,
+        &second_wave_of_new_workers,
+        &first_wave_of_new_workers, // as previous_workers compared to the second wave of new workers
+        &initial_workers,
+        &ethereum.multisig_prover_address,
         min_worker_bond,
     );
 
-    test_utils::deregister_workers(
-        &mut protocol.app,
-        protocol.service_registry_address.clone(),
-        protocol.governance_address.clone(),
-        &new_workers,
-        protocol.service_name.clone(),
-    );
-
-    let _ = test_utils::construct_proof_and_sign(
-        &mut protocol.app,
-        &ethereum.multisig_prover_address,
-        &protocol.multisig_address,
-        &Vec::<Message>::new(),
-        &initial_workers,
-    );
-
-    // confirm the first rotation
+    // confirm the first rotation's set of workers
     test_utils::confirm_worker_set(
         &mut protocol.app,
         Addr::unchecked("relayer"),
         ethereum.multisig_prover_address.clone(),
     );
 
-    let new_worker_set =
+    // get the latest worker set, it should be equal to the first wave worker set
+    let latest_worker_set =
         test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover_address);
-
-    assert_eq!(new_worker_set, expected_new_worker_set);
+    assert_eq!(latest_worker_set, first_wave_worker_set);
 
     // attempt to confirm the second rotation
-    let expected_new_new_worker_set =
-        test_utils::workers_to_worker_set(&mut protocol, &new_new_workers);
+    let second_wave_worker_set =
+        test_utils::workers_to_worker_set(&mut protocol, &second_wave_of_new_workers);
 
-    let (poll_id, expiry) = test_utils::create_worker_set_poll(
-        &mut protocol.app,
-        Addr::unchecked("relayer"),
-        ethereum.voting_verifier_address.clone(),
-        expected_new_new_worker_set.clone(),
-    );
-
-    // do voting
-    test_utils::vote_true_for_worker_set(
-        &mut protocol.app,
+    test_utils::process_poll(
+        &mut protocol,
+        &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,
-        &new_new_workers,
-        poll_id,
-    );
-
-    test_utils::advance_at_least_to_height(&mut protocol.app, expiry);
-
-    test_utils::end_poll(
-        &mut protocol.app,
-        &ethereum.voting_verifier_address,
-        poll_id,
+        &second_wave_of_new_workers,
+        &second_wave_worker_set,
     );
 
     let response = protocol.app.execute_contract(

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -275,8 +275,8 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     ));
     assert_eq!(proof.message_ids.len(), 0);
 
-    // confirm the initial rotation by starting and ending a poll
-    test_utils::process_poll(
+    // starting and ending a poll as first rotation
+    test_utils::execute_worker_set_poll(
         &mut protocol,
         &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,
@@ -285,9 +285,8 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     );
 
     // try to rotate again. this should be ignored, because the first rotation is not yet confirmed
-    let second_worker_details = vec![("worker5".to_string(), 5)];
     let second_wave_of_new_workers =
-        test_utils::create_new_workers_vec(chains.clone(), second_worker_details);
+        test_utils::create_new_workers_vec(chains.clone(), vec![("worker5".to_string(), 5)]);
 
     let second_wave_session_id = test_utils::update_registry_and_construct_proof(
         &mut protocol,
@@ -314,7 +313,7 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     let second_wave_worker_set =
         test_utils::workers_to_worker_set(&mut protocol, &second_wave_of_new_workers);
 
-    test_utils::process_poll(
+    test_utils::execute_worker_set_poll(
         &mut protocol,
         &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -252,7 +252,7 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     let first_wave_worker_set =
         test_utils::workers_to_worker_set(&mut protocol, &first_wave_of_new_workers);
 
-    // register the new workers (3 and 4), deregister old workers, then create proof and get id
+    // register the new workers (3 and 4), deregister all old workers, then create proof and get id
     let session_id = test_utils::update_registry_and_construct_proof(
         &mut protocol,
         &first_wave_of_new_workers,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -244,9 +244,10 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     assert_eq!(worker_set, simulated_worker_set);
 
     // creating third and fourth workers
-    let worker_details = vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)];
-    let first_wave_of_new_workers =
-        test_utils::create_new_workers_vec(chains.clone(), worker_details);
+    let first_wave_of_new_workers = test_utils::create_new_workers_vec(
+        chains.clone(),
+        vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)],
+    );
 
     // consists of workers three and four
     let first_wave_worker_set =
@@ -256,7 +257,7 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     let session_id = test_utils::update_registry_and_construct_proof(
         &mut protocol,
         &first_wave_of_new_workers,
-        &initial_workers, // as previous_workers compared to the first wave of new workers
+        &initial_workers,
         &initial_workers,
         &ethereum.multisig_prover_address,
         min_worker_bond,
@@ -275,7 +276,7 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     ));
     assert_eq!(proof.message_ids.len(), 0);
 
-    // starting and ending a poll as first rotation
+    // starting and ending a poll for the first worker set rotation
     test_utils::execute_worker_set_poll(
         &mut protocol,
         &Addr::unchecked("relayer"),
@@ -290,8 +291,8 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
 
     let second_wave_session_id = test_utils::update_registry_and_construct_proof(
         &mut protocol,
-        &second_wave_of_new_workers, // as new_workers
-        &first_wave_of_new_workers, // as workers_to_remove
+        &second_wave_of_new_workers,
+        &first_wave_of_new_workers,
         &initial_workers,
         &ethereum.multisig_prover_address,
         min_worker_bond,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -1,5 +1,6 @@
 use connection_router::Message;
 use cosmwasm_std::Addr;
+use cw_multi_test::Executor;
 use test_utils::Worker;
 
 mod test_utils;
@@ -224,4 +225,184 @@ fn worker_set_can_be_initialized_and_then_automatically_updated_during_proof_con
         test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover_address);
 
     assert_eq!(new_worker_set, expected_new_worker_set);
+}
+
+#[test]
+fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed() {
+    let chains = vec![
+        "Ethereum".to_string().try_into().unwrap(),
+        "Polygon".to_string().try_into().unwrap(),
+    ];
+    let (mut protocol, ethereum, _, initial_workers, min_worker_bond) =
+        test_utils::setup_test_case();
+
+    let simulated_worker_set = test_utils::workers_to_worker_set(&mut protocol, &initial_workers);
+
+    let worker_set =
+        test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover_address);
+
+    assert_eq!(worker_set, simulated_worker_set);
+
+    // add third and fourth worker
+    let mut new_workers = Vec::new();
+    let new_worker = Worker {
+        addr: Addr::unchecked("worker3"),
+        supported_chains: chains.clone(),
+        key_pair: test_utils::generate_key(2),
+    };
+    new_workers.push(new_worker);
+    let new_worker = Worker {
+        addr: Addr::unchecked("worker4"),
+        supported_chains: chains.clone(),
+        key_pair: test_utils::generate_key(3),
+    };
+    new_workers.push(new_worker);
+
+    let expected_new_worker_set = test_utils::workers_to_worker_set(&mut protocol, &new_workers);
+
+    test_utils::register_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.multisig_address.clone(),
+        protocol.governance_address.clone(),
+        protocol.genesis_address.clone(),
+        &new_workers,
+        protocol.service_name.clone(),
+        min_worker_bond,
+    );
+
+    // remove old workers
+    test_utils::deregister_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.governance_address.clone(),
+        &initial_workers,
+        protocol.service_name.clone(),
+    );
+
+    let session_id = test_utils::construct_proof_and_sign(
+        &mut protocol.app,
+        &ethereum.multisig_prover_address,
+        &protocol.multisig_address,
+        &Vec::<Message>::new(),
+        &initial_workers,
+    );
+
+    let proof = test_utils::get_proof(
+        &mut protocol.app,
+        &ethereum.multisig_prover_address,
+        &session_id,
+    );
+    assert!(matches!(
+        proof.status,
+        multisig_prover::msg::ProofStatus::Completed { .. }
+    ));
+
+    assert_eq!(proof.message_ids.len(), 0);
+
+    // confirm the initial rotation
+    let (poll_id, expiry) = test_utils::create_worker_set_poll(
+        &mut protocol.app,
+        Addr::unchecked("relayer"),
+        ethereum.voting_verifier_address.clone(),
+        expected_new_worker_set.clone(),
+    );
+
+    // do voting
+    test_utils::vote_true_for_worker_set(
+        &mut protocol.app,
+        &ethereum.voting_verifier_address,
+        &new_workers,
+        poll_id,
+    );
+
+    test_utils::advance_at_least_to_height(&mut protocol.app, expiry);
+
+    test_utils::end_poll(
+        &mut protocol.app,
+        &ethereum.voting_verifier_address,
+        poll_id,
+    );
+
+    // try to rotate again. this should be ignored, because the first rotation was not yet confirmed
+    let new_new_workers = vec![Worker {
+        addr: Addr::unchecked("worker5"),
+        supported_chains: chains.clone(),
+        key_pair: test_utils::generate_key(5),
+    }];
+
+    test_utils::register_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.multisig_address.clone(),
+        protocol.governance_address.clone(),
+        protocol.genesis_address.clone(),
+        &new_new_workers,
+        protocol.service_name.clone(),
+        min_worker_bond,
+    );
+
+    test_utils::deregister_workers(
+        &mut protocol.app,
+        protocol.service_registry_address.clone(),
+        protocol.governance_address.clone(),
+        &new_workers,
+        protocol.service_name.clone(),
+    );
+
+    let _ = test_utils::construct_proof_and_sign(
+        &mut protocol.app,
+        &ethereum.multisig_prover_address,
+        &protocol.multisig_address,
+        &Vec::<Message>::new(),
+        &initial_workers,
+    );
+
+    // confirm the first rotation
+    test_utils::confirm_worker_set(
+        &mut protocol.app,
+        Addr::unchecked("relayer"),
+        ethereum.multisig_prover_address.clone(),
+    );
+
+    let new_worker_set =
+        test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover_address);
+
+    assert_eq!(new_worker_set, expected_new_worker_set);
+
+    // attempt to confirm the second rotation
+    let expected_new_new_worker_set =
+        test_utils::workers_to_worker_set(&mut protocol, &new_new_workers);
+
+    let (poll_id, expiry) = test_utils::create_worker_set_poll(
+        &mut protocol.app,
+        Addr::unchecked("relayer"),
+        ethereum.voting_verifier_address.clone(),
+        expected_new_new_worker_set.clone(),
+    );
+
+    // do voting
+    test_utils::vote_true_for_worker_set(
+        &mut protocol.app,
+        &ethereum.voting_verifier_address,
+        &new_new_workers,
+        poll_id,
+    );
+
+    test_utils::advance_at_least_to_height(&mut protocol.app, expiry);
+
+    test_utils::end_poll(
+        &mut protocol.app,
+        &ethereum.voting_verifier_address,
+        poll_id,
+    );
+
+    let response = protocol.app.execute_contract(
+        Addr::unchecked("relayer"),
+        ethereum.multisig_prover_address.clone(),
+        &multisig_prover::msg::ExecuteMsg::ConfirmWorkerSet,
+        &[],
+    );
+
+    assert!(response.is_err());
 }

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -281,7 +281,6 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
         &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,
         &first_wave_of_new_workers,
-        &first_wave_worker_set,
     );
 
     // try to rotate again. this should be ignored, because the first rotation is not yet confirmed
@@ -310,15 +309,11 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     assert_eq!(latest_worker_set, first_wave_worker_set);
 
     // attempt to confirm the second rotation
-    let second_wave_worker_set =
-        test_utils::workers_to_worker_set(&mut protocol, &second_wave_of_new_workers);
-
     test_utils::execute_worker_set_poll(
         &mut protocol,
         &Addr::unchecked("relayer"),
         &ethereum.voting_verifier_address,
         &second_wave_of_new_workers,
-        &second_wave_worker_set,
     );
 
     let response = protocol.app.execute_contract(


### PR DESCRIPTION
The prover would not let batches be signed if the worker set changed twice without confirming the first. This PR removes that restriction, and just ignores the second rotation until the first is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced multisig operations with conditional worker set updates.
  
- **Bug Fixes**
  - Fixed an issue to prevent updating the worker set while a worker is pending confirmation.

- **Tests**
  - Added tests to validate the new worker set update restrictions.
  - Updated chain setup process in integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->