### PR TITLE
refactor: move finalizer picker into finalizer module

### DIFF
--- a/ampd/src/evm/mod.rs
+++ b/ampd/src/evm/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
 use enum_display_derive::Display;
-use ethers::types::U64;
 use serde::{Deserialize, Serialize};
 
 pub mod error;
@@ -19,26 +18,6 @@ pub enum ChainName {
 impl PartialEq<connection_router::state::ChainName> for ChainName {
     fn eq(&self, other: &connection_router::state::ChainName) -> bool {
         self.to_string().eq_ignore_ascii_case(other.as_ref())
-    }
-}
-
-impl ChainName {
-    pub fn finalizer<'a, C, H>(
-        &'a self,
-        rpc_client: &'a C,
-        confirmation_height: H,
-    ) -> Box<dyn finalizer::Finalizer + 'a>
-    where
-        C: json_rpc::EthereumClient + Send + Sync,
-        H: Into<U64>,
-    {
-        match self {
-            ChainName::Ethereum => Box::new(finalizer::EthereumFinalizer::new(rpc_client)),
-            ChainName::Other(_) => Box::new(finalizer::PoWFinalizer::new(
-                rpc_client,
-                confirmation_height,
-            )),
-        }
     }
 }
 

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -20,7 +20,7 @@ use voting_verifier::msg::ExecuteMsg;
 use crate::event_processor::EventHandler;
 use crate::evm::json_rpc::EthereumClient;
 use crate::evm::verifier::verify_message;
-use crate::evm::ChainName;
+use crate::evm::{finalizer, ChainName};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::queue::queued_broadcaster::BroadcasterClient;
@@ -96,12 +96,11 @@ where
     where
         T: IntoIterator<Item = Hash>,
     {
-        let latest_finalized_block_height = self
-            .chain
-            .finalizer(&self.rpc_client, confirmation_height)
-            .latest_finalized_block_height()
-            .await
-            .change_context(Error::Finalizer)?;
+        let latest_finalized_block_height =
+            finalizer::pick(&self.chain, &self.rpc_client, confirmation_height)
+                .latest_finalized_block_height()
+                .await
+                .change_context(Error::Finalizer)?;
 
         Ok(join_all(
             tx_hashes


### PR DESCRIPTION
## Description
It was strange that `ChainName` had a method to select a finalizer. Instead the function is moved into the `finalizer` module and renamed to create the ergonomic call name `finalizer::pick()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for obtaining the latest finalized block height in EVM-related operations.
- **Bug Fixes**
	- Improved the selection of finalization strategies for different blockchain networks.
- **Chores**
	- Removed unused code related to blockchain finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->