### PR TITLE
feat: add expiry field of u64 to SigningStarted event

### DIFF
--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -243,6 +243,7 @@ mod test {
             pub_keys,
             msg: MsgToSign::unchecked(rand_message()),
             chain_name: rand_chain_name(),
+            expires_at: 100u64,
         };
 
         let mut event: cosmwasm_std::Event = poll_started.into();

--- a/contracts/multisig-prover/src/test/multicontract.rs
+++ b/contracts/multisig-prover/src/test/multicontract.rs
@@ -6,6 +6,8 @@ use super::{mocks, test_data};
 pub const INSTANTIATOR: &str = "instantiator";
 pub const RELAYER: &str = "relayer";
 
+pub const SIGNATURE_BLOCK_EXPIRY: u64 = 100;
+
 pub struct TestCaseConfig {
     pub app: App,
     pub admin: Addr,
@@ -45,6 +47,7 @@ fn instantiate_mock_multisig(app: &mut App) -> Addr {
     let msg = multisig::msg::InstantiateMsg {
         governance_address: "governance".parse().unwrap(),
         rewards_address: "rewards".to_string(),
+        block_expiry: SIGNATURE_BLOCK_EXPIRY,
         grace_period: 2,
     };
 

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -28,6 +28,7 @@ pub fn instantiate(
     let config = Config {
         governance: deps.api.addr_validate(&msg.governance_address)?,
         rewards_contract: deps.api.addr_validate(&msg.rewards_address)?,
+        block_expiry: msg.block_expiry,
         grace_period: msg.grace_period,
     };
     CONFIG.save(deps.storage, &config)?;
@@ -58,6 +59,7 @@ pub fn execute(
                 .transpose()?; // TODO: handle callback
             execute::start_signing_session(
                 deps,
+                env,
                 worker_set_id,
                 msg.try_into()
                     .map_err(axelar_wasm_std::ContractError::from)?,
@@ -131,6 +133,8 @@ mod tests {
     const PROVER: &str = "prover";
     const REWARDS_CONTRACT: &str = "rewards";
 
+    const SIGNATURE_BLOCK_EXPIRY: u64 = 100;
+
     fn do_instantiate(deps: DepsMut) -> Result<Response, axelar_wasm_std::ContractError> {
         let info = mock_info(INSTANTIATOR, &[]);
         let env = mock_env();
@@ -138,6 +142,7 @@ mod tests {
         let msg = InstantiateMsg {
             governance_address: "governance".parse().unwrap(),
             rewards_address: REWARDS_CONTRACT.to_string(),
+            block_expiry: SIGNATURE_BLOCK_EXPIRY,
             grace_period: 2,
         };
 

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -17,6 +17,7 @@ pub enum Event {
         pub_keys: HashMap<String, PublicKey>,
         msg: MsgToSign,
         chain_name: ChainName,
+        expires_at: u64,
     },
     // Emitted when a participants submits a signature
     SignatureSubmitted {
@@ -50,6 +51,7 @@ impl From<Event> for cosmwasm_std::Event {
                 pub_keys,
                 msg,
                 chain_name: chain,
+                expires_at,
             } => cosmwasm_std::Event::new("signing_started")
                 .add_attribute("session_id", session_id)
                 .add_attribute("worker_set_id", worker_set_id)
@@ -59,7 +61,8 @@ impl From<Event> for cosmwasm_std::Event {
                         .expect("violated invariant: pub_keys are not serializable"),
                 )
                 .add_attribute("msg", HexBinary::from(msg).to_hex())
-                .add_attribute("chain", chain),
+                .add_attribute("chain", chain)
+                .add_attribute("expiry", expires_at.to_string()),
             Event::SignatureSubmitted {
                 session_id,
                 participant,

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -62,7 +62,7 @@ impl From<Event> for cosmwasm_std::Event {
                 )
                 .add_attribute("msg", HexBinary::from(msg).to_hex())
                 .add_attribute("chain", chain)
-                .add_attribute("expiry", expires_at.to_string()),
+                .add_attribute("expires_at", expires_at.to_string()),
             Event::SignatureSubmitted {
                 session_id,
                 participant,

--- a/contracts/multisig/src/msg.rs
+++ b/contracts/multisig/src/msg.rs
@@ -13,6 +13,7 @@ pub struct InstantiateMsg {
     // the governance address is allowed to modify the authorized caller list for this contract
     pub governance_address: String,
     pub rewards_address: String,
+    pub block_expiry: u64,
     pub grace_period: u64, // in blocks after session has been completed
 }
 

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -15,7 +15,7 @@ use crate::{
 pub struct Config {
     pub governance: Addr,
     pub rewards_contract: Addr,
-    pub block_expiry: u64, // number of blocks after which a completed signing session expires
+    pub block_expiry: u64, // number of blocks after which a signing session expires
     pub grace_period: u64, // TODO: add update mechanism to change this after instantiation
 }
 

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -15,6 +15,7 @@ use crate::{
 pub struct Config {
     pub governance: Addr,
     pub rewards_contract: Addr,
+    pub block_expiry: u64, // number of blocks after which a completed signing session expires
     pub grace_period: u64, // TODO: add update mechanism to change this after instantiation
 }
 

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -20,6 +20,8 @@ use tofn::ecdsa::KeyPair;
 
 pub const AXL_DENOMINATION: &str = "uaxl";
 
+pub const SIGNATURE_BLOCK_EXPIRY: u64 = 100;
+
 fn get_event_attribute<'a>(
     events: &'a [Event],
     event_type: &str,
@@ -335,6 +337,7 @@ pub fn setup_protocol(service_name: nonempty::String) -> Protocol {
         multisig::msg::InstantiateMsg {
             rewards_address: rewards_address.to_string(),
             governance_address: governance_address.to_string(),
+            block_expiry: SIGNATURE_BLOCK_EXPIRY,
             grace_period: 2,
         },
     );


### PR DESCRIPTION
## Description

The first phase of skipping signing session if it is expired.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an expiration feature for multisig transactions, enhancing security by setting a validity period.

- **Enhancements**
	- Improved multisig contract configuration to allow setting a block expiry parameter.

- **Bug Fixes**
	- Ensured consistent expiry time across all relevant multisig operations and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->