### PR TITLE
chore: work in progress - removing grace from multisig config

### DIFF
--- a/contracts/multisig-prover/src/test/multicontract.rs
+++ b/contracts/multisig-prover/src/test/multicontract.rs
@@ -48,7 +48,6 @@ fn instantiate_mock_multisig(app: &mut App) -> Addr {
         governance_address: "governance".parse().unwrap(),
         rewards_address: "rewards".to_string(),
         block_expiry: SIGNATURE_BLOCK_EXPIRY,
-        grace_period: 2,
     };
 
     app.instantiate_contract(

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -29,7 +29,6 @@ pub fn instantiate(
         governance: deps.api.addr_validate(&msg.governance_address)?,
         rewards_contract: deps.api.addr_validate(&msg.rewards_address)?,
         block_expiry: msg.block_expiry,
-        grace_period: msg.grace_period,
     };
     CONFIG.save(deps.storage, &config)?;
 
@@ -143,7 +142,6 @@ mod tests {
             governance_address: "governance".parse().unwrap(),
             rewards_address: REWARDS_CONTRACT.to_string(),
             block_expiry: SIGNATURE_BLOCK_EXPIRY,
-            grace_period: 2,
         };
 
         instantiate(deps, env, info, msg)

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -586,7 +586,7 @@ mod tests {
             assert!(!res
                 .events
                 .iter()
-                .any(|e| e.ty == "signing_completed".to_string())); // event is not re-emitted before expiry
+                .any(|e| e.ty == "signing_completed".to_string())); // event is not re-emitted
         }
     }
 

--- a/contracts/multisig/src/contract/execute.rs
+++ b/contracts/multisig/src/contract/execute.rs
@@ -31,11 +31,12 @@ pub fn start_signing_session(
         },
     )?;
 
-    let signing_session = SigningSession::new(session_id, worker_set_id.clone(), msg.clone());
+    let expires_at = env.block.height + config.block_expiry;
+
+    let signing_session =
+        SigningSession::new(session_id, worker_set_id.clone(), msg.clone(), expires_at);
 
     SIGNING_SESSIONS.save(deps.storage, session_id.into(), &signing_session)?;
-
-    let expires_at = env.block.height + config.block_expiry;
 
     let event = Event::SigningStarted {
         session_id,
@@ -79,7 +80,6 @@ pub fn submit_signature(
         &info.sender,
         &signature,
         pub_key,
-        config.grace_period,
         env.block.height,
     )?;
     let signature = save_signature(deps.storage, session_id, signature, &info.sender)?;

--- a/contracts/multisig/src/msg.rs
+++ b/contracts/multisig/src/msg.rs
@@ -14,7 +14,6 @@ pub struct InstantiateMsg {
     pub governance_address: String,
     pub rewards_address: String,
     pub block_expiry: u64,
-    pub grace_period: u64, // in blocks after session has been completed
 }
 
 #[cw_serde]

--- a/contracts/multisig/src/signing.rs
+++ b/contracts/multisig/src/signing.rs
@@ -53,7 +53,7 @@ pub fn validate_session_signature(
     pub_key: &PublicKey,
     block_height: u64,
 ) -> Result<(), ContractError> {
-    if (session.expires_at < block_height) {
+    if session.expires_at < block_height {
         return Err(ContractError::SigningSessionClosed {
             session_id: session.id,
         });

--- a/contracts/multisig/src/signing.rs
+++ b/contracts/multisig/src/signing.rs
@@ -16,15 +16,17 @@ pub struct SigningSession {
     pub worker_set_id: String,
     pub msg: MsgToSign,
     pub state: MultisigState,
+    pub expires_at: u64,
 }
 
 impl SigningSession {
-    pub fn new(session_id: Uint64, worker_set_id: String, msg: MsgToSign) -> Self {
+    pub fn new(session_id: Uint64, worker_set_id: String, msg: MsgToSign, expires_at: u64) -> Self {
         Self {
             id: session_id,
             worker_set_id,
             msg,
             state: MultisigState::Pending,
+            expires_at,
         }
     }
 
@@ -49,11 +51,9 @@ pub fn validate_session_signature(
     signer: &Addr,
     signature: &Signature,
     pub_key: &PublicKey,
-    grace_period: u64,
     block_height: u64,
 ) -> Result<(), ContractError> {
-    if matches!(session.state, MultisigState::Completed { completed_at } if completed_at + grace_period < block_height)
-    {
+    if (session.expires_at < block_height) {
         return Err(ContractError::SigningSessionClosed {
             session_id: session.id,
         });
@@ -112,7 +112,9 @@ mod tests {
         let worker_set = build_worker_set(KeyType::Ecdsa, &signers);
 
         let message: MsgToSign = ecdsa_test_data::message().try_into().unwrap();
-        let session = SigningSession::new(Uint64::one(), worker_set_id, message.clone());
+        let expires_at = 12345;
+        let session =
+            SigningSession::new(Uint64::one(), worker_set_id, message.clone(), expires_at);
 
         let signatures: HashMap<String, Signature> = signers
             .iter()
@@ -143,7 +145,9 @@ mod tests {
         let worker_set = build_worker_set(key_type, &signers);
 
         let message: MsgToSign = ed25519_test_data::message().try_into().unwrap();
-        let session = SigningSession::new(Uint64::one(), worker_set_id, message.clone());
+        let expires_at = 12345;
+        let session =
+            SigningSession::new(Uint64::one(), worker_set_id, message.clone(), expires_at);
 
         let signatures: HashMap<String, Signature> = signers
             .iter()
@@ -194,31 +198,25 @@ mod tests {
             let signature = config.signatures.values().next().unwrap();
             let pub_key = &worker_set.signers.get(&signer.to_string()).unwrap().pub_key;
 
-            assert!(
-                validate_session_signature(&session, &signer, signature, pub_key, 0, 0).is_ok()
-            );
+            assert!(validate_session_signature(&session, &signer, signature, pub_key, 0).is_ok());
         }
     }
 
     #[test]
-    fn success_validation_grace_period() {
+    fn success_validation_expiry_not_reached() {
         for config in [ecdsa_setup(), ed25519_setup()] {
             let mut session = config.session;
             let worker_set = config.worker_set;
             let signer = Addr::unchecked(config.signatures.keys().next().unwrap());
             let signature = config.signatures.values().next().unwrap();
-            let completed_at = 12345;
-            let grace_period = 10;
-            let block_height = completed_at + grace_period; // inclusive
+            let block_height = 12340; // inclusive
             let pub_key = &worker_set.signers.get(&signer.to_string()).unwrap().pub_key;
 
-            session.state = MultisigState::Completed { completed_at };
             assert!(validate_session_signature(
                 &session,
                 &signer,
                 signature,
                 pub_key,
-                grace_period,
                 block_height
             )
             .is_ok());
@@ -232,20 +230,11 @@ mod tests {
             let worker_set = config.worker_set;
             let signer = Addr::unchecked(config.signatures.keys().next().unwrap());
             let signature = config.signatures.values().next().unwrap();
-            let completed_at = 12345;
-            let grace_period = 10;
-            let block_height = completed_at + grace_period + 1;
+            let block_height = 12346;
             let pub_key = &worker_set.signers.get(&signer.to_string()).unwrap().pub_key;
 
-            session.state = MultisigState::Completed { completed_at };
-            let result = validate_session_signature(
-                &session,
-                &signer,
-                signature,
-                pub_key,
-                grace_period,
-                block_height,
-            );
+            let result =
+                validate_session_signature(&session, &signer, signature, pub_key, block_height);
 
             assert_eq!(
                 result.unwrap_err(),
@@ -273,7 +262,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-            let result = validate_session_signature(&session, &signer, &invalid_sig, pub_key, 0, 0);
+            let result = validate_session_signature(&session, &signer, &invalid_sig, pub_key, 0);
 
             assert_eq!(
                 result.unwrap_err(),

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -16,7 +16,6 @@ pub struct Config {
     pub governance: Addr,
     pub rewards_contract: Addr,
     pub block_expiry: u64, // number of blocks after which a signing session expires
-    pub grace_period: u64, // TODO: add update mechanism to change this after instantiation
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -338,7 +338,6 @@ pub fn setup_protocol(service_name: nonempty::String) -> Protocol {
             rewards_address: rewards_address.to_string(),
             governance_address: governance_address.to_string(),
             block_expiry: SIGNATURE_BLOCK_EXPIRY,
-            grace_period: 2,
         },
     );
     let service_registry_address = instantiate_service_registry(


### PR DESCRIPTION
## Description

## Todos

One of the testcases in multisig (contract.rs) is failing that is related to grace period.

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the `grace_period` parameter from multisig contract logic, focusing on `block_expiry` for expiration management.
	- Updated signing session initialization to include an `expires_at` field for better handling of signature expiration.
- **Tests**
	- Adjusted integration and contract tests to reflect the removal of the `grace_period` parameter and the introduction of `expires_at`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->