### PR TITLE
fix(ampd): skip events from unknown contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ version = "0.1.0"
 dependencies = [
  "axelar-wasm-std",
  "base64 0.21.4",
+ "cosmrs",
  "error-stack",
  "serde_json",
  "tendermint 0.33.0",

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -148,7 +148,7 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> Result<()> {
-        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+        if !event.is_from_contract(self.voting_verifier.as_ref()) {
             return Ok(());
         }
 

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -41,8 +41,6 @@ pub struct Message {
 #[derive(Deserialize, Debug)]
 #[try_from("wasm-messages_poll_started")]
 struct PollStartedEvent {
-    #[serde(rename = "_contract_address")]
-    contract_address: TMAddress,
     poll_id: PollId,
     source_chain: connection_router::state::ChainName,
     source_gateway_address: EVMAddress,
@@ -150,8 +148,11 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> Result<()> {
+        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+            return Ok(());
+        }
+
         let PollStartedEvent {
-            contract_address,
             poll_id,
             source_chain,
             source_gateway_address,
@@ -165,10 +166,6 @@ where
             }
             event => event.change_context(DeserializeEvent)?,
         };
-
-        if self.voting_verifier != contract_address {
-            return Ok(());
-        }
 
         if self.chain != source_chain {
             return Ok(());

--- a/ampd/src/handlers/evm_verify_worker_set.rs
+++ b/ampd/src/handlers/evm_verify_worker_set.rs
@@ -144,7 +144,7 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> Result<()> {
-        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+        if !event.is_from_contract(self.voting_verifier.as_ref()) {
             return Ok(());
         }
 

--- a/ampd/src/handlers/evm_verify_worker_set.rs
+++ b/ampd/src/handlers/evm_verify_worker_set.rs
@@ -41,8 +41,6 @@ pub struct WorkerSetConfirmation {
 #[derive(Deserialize, Debug)]
 #[try_from("wasm-worker_set_poll_started")]
 struct PollStartedEvent {
-    #[serde(rename = "_contract_address")]
-    contract_address: TMAddress,
     worker_set: WorkerSetConfirmation,
     poll_id: PollId,
     source_chain: connection_router::state::ChainName,
@@ -146,8 +144,11 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> Result<()> {
+        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+            return Ok(());
+        }
+
         let PollStartedEvent {
-            contract_address,
             poll_id,
             source_chain,
             source_gateway_address,
@@ -161,10 +162,6 @@ where
             }
             event => event.change_context(Error::DeserializeEvent)?,
         };
-
-        if self.voting_verifier != contract_address {
-            return Ok(());
-        }
 
         if self.chain != source_chain {
             return Ok(());

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -28,8 +28,6 @@ use crate::types::TMAddress;
 #[derive(Debug, Deserialize)]
 #[try_from("wasm-signing_started")]
 struct SigningStartedEvent {
-    #[serde(rename = "_contract_address")]
-    contract_address: TMAddress,
     session_id: u64,
     #[serde(deserialize_with = "deserialize_public_keys")]
     pub_keys: HashMap<TMAddress, PublicKey>,
@@ -132,8 +130,11 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> error_stack::Result<(), Error> {
+        if !events::event_is_from_contract(event, self.multisig.as_ref()) {
+            return Ok(());
+        }
+
         let SigningStartedEvent {
-            contract_address,
             session_id,
             pub_keys,
             msg,
@@ -144,10 +145,6 @@ where
             }
             result => result.change_context(DeserializeEvent)?,
         };
-
-        if self.multisig != contract_address {
-            return Ok(());
-        }
 
         info!(
             session_id = session_id,
@@ -278,6 +275,44 @@ mod test {
         .unwrap()
     }
 
+    // this returns an event that is named SigningStarted,
+    // but the fields are different than what the handler expects
+    fn wrong_signing_started_event() -> events::Event {
+        let pub_keys = (0..10)
+            .map(|_| (rand_account().to_string(), rand_public_key()))
+            .collect::<HashMap<String, PublicKey>>();
+
+        let poll_started = SigningStarted {
+            session_id: Uint64::one(),
+            worker_set_id: "worker_set_id".to_string(),
+            pub_keys,
+            msg: MsgToSign::unchecked(rand_message()),
+            chain_name: rand_chain_name(),
+            expires_at: 100u64,
+        };
+
+        let mut event: cosmwasm_std::Event = poll_started.into();
+        event.ty = format!("wasm-{}", event.ty);
+        event = event.add_attribute("_contract_address", MULTISIG_ADDRESS);
+        let idx = event
+            .attributes
+            .iter()
+            .position(|element| element.key == "expires_at")
+            .unwrap();
+        event.attributes.remove(idx);
+
+        events::Event::try_from(abci::Event::new(
+            event.ty,
+            event
+                .attributes
+                .into_iter()
+                .map(|cosmwasm_std::Attribute { key, value }| {
+                    (STANDARD.encode(key), STANDARD.encode(value))
+                }),
+        ))
+        .unwrap()
+    }
+
     fn get_handler(
         worker: TMAddress,
         multisig: TMAddress,
@@ -353,7 +388,44 @@ mod test {
     }
 
     #[tokio::test]
-    async fn should_not_handle_event_if_multisig_address_does_not_match() {
+    async fn should_not_handle_wrong_event_if_multisig_address_does_not_match() {
+        let mut client = MockEcdsaClient::new();
+        client
+            .expect_sign()
+            .returning(move |_, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+
+        let handler = get_handler(
+            rand_account(),
+            rand_account(),
+            SharableEcdsaClient::new(client),
+            100u64,
+        );
+
+        assert!(handler.handle(&wrong_signing_started_event()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn should_error_on_wrong_event_if_multisig_address_does_match() {
+        let mut client = MockEcdsaClient::new();
+        client
+            .expect_sign()
+            .returning(move |_, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+
+        let handler = get_handler(
+            rand_account(),
+            TMAddress::from(MULTISIG_ADDRESS.parse::<AccountId>().unwrap()),
+            SharableEcdsaClient::new(client),
+            100u64,
+        );
+
+        assert!(handler
+            .handle(&wrong_signing_started_event())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn should_not_handle_correct_event_if_multisig_address_does_not_match() {
         let mut client = MockEcdsaClient::new();
         client
             .expect_sign()

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -130,7 +130,7 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> error_stack::Result<(), Error> {
-        if !events::event_is_from_contract(event, self.multisig.as_ref()) {
+        if !event.is_from_contract(self.multisig.as_ref()) {
             return Ok(());
         }
 

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -382,11 +382,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn should_not_handle_wrong_event_if_multisig_address_does_not_match() {
-        let mut client = MockEcdsaClient::new();
-        client
-            .expect_sign()
-            .returning(move |_, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+    async fn should_not_handle_event_with_missing_fields_if_multisig_address_does_not_match() {
+        let client = MockEcdsaClient::new();
 
         let handler = get_handler(
             rand_account(),
@@ -404,11 +401,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn should_error_on_wrong_event_if_multisig_address_does_match() {
-        let mut client = MockEcdsaClient::new();
-        client
-            .expect_sign()
-            .returning(move |_, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+    async fn should_error_on_event_with_missing_fields_if_multisig_address_does_match() {
+        let client = MockEcdsaClient::new();
 
         let handler = get_handler(
             rand_account(),
@@ -424,11 +418,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn should_not_handle_correct_event_if_multisig_address_does_not_match() {
-        let mut client = MockEcdsaClient::new();
-        client
-            .expect_sign()
-            .returning(move |_, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+    async fn should_not_handle_event_if_multisig_address_does_not_match() {
+        let client = MockEcdsaClient::new();
 
         let handler = get_handler(
             rand_account(),

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -100,7 +100,7 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &Event) -> Result<()> {
-        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+        if !event.is_from_contract(self.voting_verifier.as_ref()) {
             return Ok(());
         }
 

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -103,6 +103,7 @@ where
         if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
             return Ok(());
         }
+
         let PollStartedEvent {
             poll_id,
             source_gateway_address,

--- a/ampd/src/handlers/sui_verify_worker_set.rs
+++ b/ampd/src/handlers/sui_verify_worker_set.rs
@@ -108,7 +108,7 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &Event) -> error_stack::Result<(), Error> {
-        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+        if !event.is_from_contract(self.voting_verifier.as_ref()) {
             return Ok(());
         }
 

--- a/ampd/src/handlers/sui_verify_worker_set.rs
+++ b/ampd/src/handlers/sui_verify_worker_set.rs
@@ -40,8 +40,6 @@ pub struct WorkerSetConfirmation {
 #[derive(Deserialize, Debug)]
 #[try_from("wasm-worker_set_poll_started")]
 struct PollStartedEvent {
-    #[serde(rename = "_contract_address")]
-    contract_address: TMAddress,
     poll_id: PollId,
     source_gateway_address: SuiAddress,
     worker_set: WorkerSetConfirmation,
@@ -110,8 +108,11 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &Event) -> error_stack::Result<(), Error> {
+        if !events::event_is_from_contract(event, self.voting_verifier.as_ref()) {
+            return Ok(());
+        }
+
         let PollStartedEvent {
-            contract_address,
             poll_id,
             source_gateway_address,
             worker_set,
@@ -124,10 +125,6 @@ where
             }
             event => event.change_context(Error::DeserializeEvent)?,
         };
-
-        if self.voting_verifier != contract_address {
-            return Ok(());
-        }
 
         if !participants.contains(&self.worker) {
             return Ok(());

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 axelar-wasm-std = { workspace = true }
 base64 = "0.21.2"
+cosmrs = { version = "0.14.0", features = ["cosmwasm"] }
 error-stack = { workspace = true }
 serde_json = "1.0.105"
 # Need to switch to our own fork of tendermint and tendermint-rpc due to event attribute value being nullable.

--- a/packages/events/src/event.rs
+++ b/packages/events/src/event.rs
@@ -9,6 +9,8 @@ use tendermint::{abci, block};
 use crate::errors::DecodingError;
 use crate::Error;
 
+use cosmrs::AccountId;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
     BlockBegin(block::Height),
@@ -70,4 +72,98 @@ fn decode_event_attribute(attribute: &EventAttribute) -> Result<(String, String)
 
 fn base64_to_utf8(base64_str: &str) -> std::result::Result<String, DecodingError> {
     Ok(STANDARD.decode(base64_str)?.then(String::from_utf8)?)
+}
+
+pub fn get_contract_address(event: &Event) -> Option<AccountId> {
+    let contract_address = match event {
+        Event::Abci {
+            event_type: _,
+            attributes,
+        } => {
+            if let Some(address) = attributes.get("_contract_address") {
+                return serde_json::from_value::<AccountId>(address.clone()).ok();
+            }
+            None
+        }
+        _ => None,
+    };
+    contract_address
+}
+
+pub fn event_is_from_contract(event: &Event, contract_address: &AccountId) -> bool {
+    match get_contract_address(event) {
+        Some(address) => &address == contract_address,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use cosmrs::AccountId;
+
+    use crate::{event_is_from_contract, get_contract_address, Event};
+
+    fn make_event_with_contract_address(contract_address: &AccountId) -> Event {
+        let mut attributes = serde_json::Map::new();
+        attributes.insert(
+            "_contract_address".to_string(),
+            contract_address.to_string().into(),
+        );
+        Event::Abci {
+            event_type: "some_event".to_string(),
+            attributes,
+        }
+    }
+
+    #[test]
+    fn should_get_contract_address_if_exists() {
+        let expected_contract_address =
+            AccountId::from_str("axelarvaloper1zh9wrak6ke4n6fclj5e8yk397czv430ygs5jz7").unwrap();
+
+        let event = make_event_with_contract_address(&expected_contract_address);
+
+        let contract_address = get_contract_address(&event);
+        assert!(contract_address.is_some());
+        assert_eq!(contract_address.unwrap(), expected_contract_address);
+    }
+
+    #[test]
+    fn should_not_get_contract_address_if_not_exists() {
+        let event = Event::Abci {
+            event_type: "some_event".to_string(),
+            attributes: serde_json::Map::new(),
+        };
+        let contract_address = get_contract_address(&event);
+        assert!(contract_address.is_none());
+    }
+
+    #[test]
+    fn event_is_from_contract_should_return_true_iff_contract_address_matches() {
+        let contract_address =
+            AccountId::from_str("axelarvaloper1zh9wrak6ke4n6fclj5e8yk397czv430ygs5jz7").unwrap();
+        let event = make_event_with_contract_address(&contract_address);
+        assert!(event_is_from_contract(&event, &contract_address));
+
+        let diff_contract_address =
+            AccountId::from_str("axelarvaloper1tee73c83k2vqky9gt59jd3ztwxhqjm27l588q6").unwrap();
+        assert!(!event_is_from_contract(&event, &diff_contract_address));
+    }
+
+    #[test]
+    fn event_is_from_contract_should_return_false_if_contract_address_does_not_exist() {
+        let contract_address =
+            AccountId::from_str("axelarvaloper1zh9wrak6ke4n6fclj5e8yk397czv430ygs5jz7").unwrap();
+
+        let event_without_contract_address = Event::Abci {
+            event_type: "some_event".to_string(),
+            attributes: serde_json::Map::new(),
+        };
+
+        assert!(!event_is_from_contract(
+            &event_without_contract_address,
+            &contract_address
+        ));
+    }
 }


### PR DESCRIPTION
The handlers currently return an error when encountering an event with the same event_type as what they are looking for, but with different fields. This can happen due to contract upgrades, but also if any random contract emits an event with the same event_type as the event the handler cares about. This can cause either crashing the process, or unnecessary retries (and waiting).

This PR makes a change so that the handlers first check the "_contract_address" field of the event, and simply skip the event (returning `Ok(())` ) if the address doesn't match the contract address for which the handler is configured to handle events.

https://axelarnetwork.atlassian.net/browse/AXE-3080