### PR TITLE
ci: use blacksmith runners for gh actions

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -2,7 +2,6 @@
 
 on:
   pull_request:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,7 +12,7 @@ name: Basic
 jobs:
   test:
     name: Test Suite
-    runs-on: blacksmith-16vcpu-ubuntu-2204
+    runs-on: blacksmith-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install protoc
         uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache build artifacts
         uses: useblacksmith/rust-cache@v3

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,7 +12,7 @@ name: Basic
 jobs:
   test:
     name: Test Suite
-    runs-on: blacksmith-16vcpu-ubuntu-2204
+    runs-on: blacksmith-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
 
   cosmwasm-compilation:
     name: Cosmwasm Compilation
-    runs-on: blacksmith-16vcpu-ubuntu-2204
+    runs-on: blacksmith-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -12,7 +12,7 @@ name: Basic
 jobs:
   test:
     name: Test Suite
-    runs-on: blacksmith-32vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -2,6 +2,7 @@
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -12,7 +13,7 @@ name: Basic
 jobs:
   test:
     name: Test Suite
-    runs-on: ubuntu-8-core-32-gb
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 
@@ -27,7 +28,7 @@ jobs:
         uses: arduino/setup-protoc@v2
 
       - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: useblacksmith/rust-cache@v3
         with:
           shared-key: "cache"
 
@@ -42,7 +43,7 @@ jobs:
 
   cosmwasm-compilation:
     name: Cosmwasm Compilation
-    runs-on: ubuntu-8-core-32-gb
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +56,7 @@ jobs:
           override: true
 
       - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: useblacksmith/rust-cache@v3
         with:
           shared-key: "cache"
 
@@ -78,7 +79,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: ubuntu-8-core-32-gb
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 
@@ -96,7 +97,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: useblacksmith/rust-cache@v3
         with:
           shared-key: "cache"
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install protoc
         uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install libclang-dev
         run: sudo apt-get install libclang-dev

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-8-core-32-gb
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -29,7 +29,7 @@ jobs:
         run: sudo apt-get install libclang-dev
 
       - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: useblacksmith/rust-cache@v3
         with:
           shared-key: "cache"
 


### PR DESCRIPTION
## Description

Use faster blacksmith runners for gh actions. More info here https://github.com/BlacksmithOSSTests/axelar-amplifier/pull/4

See the following for comparison
GH runners, `~8.5 mins`: https://github.com/axelarnetwork/axelar-amplifier/actions/runs/7903746303/job/21572373695
Blacksmith runners `~3.5 mins` but still cheaper than github 8-core cpu: https://github.com/axelarnetwork/axelar-amplifier/actions/runs/7906836074/job/21583013684?pr=271

See blacksmith pricing [here](https://docs.blacksmith.sh/runners/pricing). First `3000` mins/month are free.

- the 8vCPU run is ~38% [faster](https://github.com/BlacksmithOSSTests/axelar-amplifier/actions/runs/7892299883/job/21538883237?pr=1), and ~70% cheaper
- the 16vCPU runs are ~50% [faster](https://github.com/axelarnetwork/axelar-amplifier/actions/runs/7907999879?pr=271) and ~50% cheaper
- the 32vCPU runs are ~62% [faster](https://github.com/axelarnetwork/axelar-amplifier/actions/runs/7906836074/job/21583013684?pr=271) and ~25% cheaper

[AXE-3170]

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes


[AXE-3170]: https://axelarnetwork.atlassian.net/browse/AXE-3170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ