### PR TITLE
fix(multisig): normalize compressed and uncompressed public keys for proper duplicate check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek 4.1.1",
  "ed25519 2.2.2",
@@ -4809,6 +4809,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.1.0",
+ "ed25519-dalek",
  "enum-display-derive",
  "error-stack",
  "getrandom",

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -46,6 +46,7 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
+ed25519-dalek = { version = "2.1.1", default-features = false }
 enum-display-derive = "0.1.1"
 error-stack = { workspace = true }
 getrandom = { version = "0.2", default-features = false, features = ["custom"] }

--- a/contracts/multisig/src/ed25519.rs
+++ b/contracts/multisig/src/ed25519.rs
@@ -1,6 +1,6 @@
 use crate::ContractError;
 
-const ED25519_SIGNATURE_LEN: usize = 64;
+pub const ED25519_SIGNATURE_LEN: usize = 64;
 
 pub fn ed25519_verify(msg_hash: &[u8], sig: &[u8], pub_key: &[u8]) -> Result<bool, ContractError> {
     cosmwasm_crypto::ed25519_verify(msg_hash, &sig[0..ED25519_SIGNATURE_LEN], pub_key).map_err(

--- a/contracts/multisig/src/error.rs
+++ b/contracts/multisig/src/error.rs
@@ -28,9 +28,6 @@ pub enum ContractError {
     #[error("invalid public key")]
     InvalidPublicKey,
 
-    #[error("ECDSA public key must be in compressed format (33 bytes)")]
-    InvalidEcdsaPublicKeyFormat,
-
     #[error("public key is already registered")]
     DuplicatePublicKey,
 

--- a/contracts/multisig/src/error.rs
+++ b/contracts/multisig/src/error.rs
@@ -28,6 +28,9 @@ pub enum ContractError {
     #[error("invalid public key")]
     InvalidPublicKey,
 
+    #[error("ECDSA public key must be in compressed format (33 bytes)")]
+    InvalidEcdsaPublicKeyFormat,
+
     #[error("public key is already registered")]
     DuplicatePublicKey,
 

--- a/contracts/multisig/src/error.rs
+++ b/contracts/multisig/src/error.rs
@@ -25,8 +25,8 @@ pub enum ContractError {
     #[error("signed sender address could not be verified using submitted public key")]
     InvalidPublicKeyRegistrationSignature,
 
-    #[error("invalid public key format: {reason:?}")]
-    InvalidPublicKeyFormat { reason: String },
+    #[error("invalid public key")]
+    InvalidPublicKey,
 
     #[error("public key is already registered")]
     DuplicatePublicKey,

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -1,4 +1,8 @@
-use crate::{ed25519::ed25519_verify, secp256k1::ecdsa_verify, ContractError};
+use crate::{
+    ed25519::{ed25519_verify, ED25519_SIGNATURE_LEN},
+    secp256k1::ecdsa_verify,
+    ContractError,
+};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{HexBinary, StdError, StdResult};
 use cw_storage_plus::{KeyDeserialize, PrimaryKey};
@@ -249,8 +253,6 @@ impl TryFrom<(KeyType, HexBinary)> for PublicKey {
     }
 }
 
-const ED25519_SIGNATURE_LEN: usize = 64;
-
 impl TryFrom<(KeyType, HexBinary)> for Signature {
     type Error = ContractError;
 
@@ -357,8 +359,8 @@ mod ecdsa_tests {
         .unwrap();
 
         assert_eq!(
-            PublicKey::try_from((KeyType::Ecdsa, uncompressed.clone())),
-            PublicKey::try_from((KeyType::Ecdsa, compressed.clone()))
+            PublicKey::try_from((KeyType::Ecdsa, uncompressed.clone())).unwrap(),
+            PublicKey::try_from((KeyType::Ecdsa, compressed.clone())).unwrap()
         )
     }
 

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -220,7 +220,7 @@ impl KeyDeserialize for KeyType {
 
 fn check_ecdsa_format(pub_key: HexBinary) -> Result<HexBinary, ContractError> {
     if pub_key.len() != ECDSA_COMPRESSED_PUBKEY_LEN {
-        return Err(ContractError::InvalidEcdsaPublicKeyFormat);
+        return Err(ContractError::InvalidPublicKey);
     }
     Ok(pub_key)
 }
@@ -360,7 +360,7 @@ mod ecdsa_tests {
 
         assert_eq!(
             PublicKey::try_from((KeyType::Ecdsa, uncompressed_pub_key.clone())).unwrap_err(),
-            ContractError::InvalidEcdsaPublicKeyFormat
+            ContractError::InvalidPublicKey
         );
     }
 

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -125,8 +125,7 @@ mod tests {
     #[test]
     fn should_fail_if_duplicate_public_key() {
         let mut deps = mock_dependencies();
-        let uncompressed_pub_key = HexBinary::from_hex("049bb8e80670371f45508b5f8f59946a7c4dea4b3a23a036cf24c1f40993f4a1daad1716de8bd664ecb4596648d722a4685293de208c1d2da9361b9cba74c3d1ec").unwrap();
-        let compressed_pub_key = HexBinary::from_hex(
+        let pub_key = HexBinary::from_hex(
             "029bb8e80670371f45508b5f8f59946a7c4dea4b3a23a036cf24c1f40993f4a1da",
         )
         .unwrap();
@@ -135,9 +134,7 @@ mod tests {
         save_pub_key(
             deps.as_mut().storage,
             Addr::unchecked("1"),
-            (KeyType::Ecdsa, uncompressed_pub_key.clone())
-                .try_into()
-                .unwrap(),
+            (KeyType::Ecdsa, pub_key.clone()).try_into().unwrap(),
         )
         .unwrap();
 
@@ -146,24 +143,13 @@ mod tests {
             save_pub_key(
                 deps.as_mut().storage,
                 Addr::unchecked("2"),
-                (KeyType::Ecdsa, uncompressed_pub_key).try_into().unwrap(),
+                (KeyType::Ecdsa, pub_key).try_into().unwrap(),
             )
             .unwrap_err(),
             ContractError::DuplicatePublicKey
         );
 
-        // 3. Fails to store the compressed version of the same key
-        assert_eq!(
-            save_pub_key(
-                deps.as_mut().storage,
-                Addr::unchecked("3"),
-                (KeyType::Ecdsa, compressed_pub_key).try_into().unwrap(),
-            )
-            .unwrap_err(),
-            ContractError::DuplicatePublicKey
-        );
-
-        // 4. Storing a different key succeeds
+        // 3. Storing a different key succeeds
         save_pub_key(
             deps.as_mut().storage,
             Addr::unchecked("4"),

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -125,24 +125,53 @@ mod tests {
     #[test]
     fn should_fail_if_duplicate_public_key() {
         let mut deps = mock_dependencies();
-        let pub_key = ecdsa_test_data::pub_key();
-
-        save_pub_key(
-            deps.as_mut().storage,
-            Addr::unchecked("1"),
-            (KeyType::Ecdsa, pub_key.clone()).try_into().unwrap(),
+        let uncompressed_pub_key = HexBinary::from_hex("049bb8e80670371f45508b5f8f59946a7c4dea4b3a23a036cf24c1f40993f4a1daad1716de8bd664ecb4596648d722a4685293de208c1d2da9361b9cba74c3d1ec").unwrap();
+        let compressed_pub_key = HexBinary::from_hex(
+            "029bb8e80670371f45508b5f8f59946a7c4dea4b3a23a036cf24c1f40993f4a1da",
         )
         .unwrap();
 
+        // 1. Store first key
+        save_pub_key(
+            deps.as_mut().storage,
+            Addr::unchecked("1"),
+            (KeyType::Ecdsa, uncompressed_pub_key.clone())
+                .try_into()
+                .unwrap(),
+        )
+        .unwrap();
+
+        // 2. Fails to store the same key
         assert_eq!(
             save_pub_key(
                 deps.as_mut().storage,
                 Addr::unchecked("2"),
-                (KeyType::Ecdsa, pub_key).try_into().unwrap(),
+                (KeyType::Ecdsa, uncompressed_pub_key).try_into().unwrap(),
             )
             .unwrap_err(),
             ContractError::DuplicatePublicKey
         );
+
+        // 3. Fails to store the compressed version of the same key
+        assert_eq!(
+            save_pub_key(
+                deps.as_mut().storage,
+                Addr::unchecked("3"),
+                (KeyType::Ecdsa, compressed_pub_key).try_into().unwrap(),
+            )
+            .unwrap_err(),
+            ContractError::DuplicatePublicKey
+        );
+
+        // 4. Storing a different key succeeds
+        save_pub_key(
+            deps.as_mut().storage,
+            Addr::unchecked("4"),
+            (KeyType::Ecdsa, ecdsa_test_data::pub_key())
+                .try_into()
+                .unwrap(),
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Description

https://axelarnetwork.atlassian.net/browse/AXE-3263

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
