### PR TITLE
refactor(multisig): adjust diverging behavior in signature verification

### DIFF
--- a/contracts/multisig/src/ed25519.rs
+++ b/contracts/multisig/src/ed25519.rs
@@ -3,9 +3,35 @@ use crate::ContractError;
 pub const ED25519_SIGNATURE_LEN: usize = 64;
 
 pub fn ed25519_verify(msg_hash: &[u8], sig: &[u8], pub_key: &[u8]) -> Result<bool, ContractError> {
-    cosmwasm_crypto::ed25519_verify(msg_hash, &sig[0..ED25519_SIGNATURE_LEN], pub_key).map_err(
-        |e| ContractError::SignatureVerificationFailed {
+    cosmwasm_crypto::ed25519_verify(msg_hash, sig, pub_key).map_err(|e| {
+        ContractError::SignatureVerificationFailed {
             reason: e.to_string(),
-        },
-    )
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::HexBinary;
+
+    use crate::test::common::ed25519_test_data;
+
+    use super::*;
+
+    #[test]
+    fn should_fail_sig_verification_instead_of_truncating() {
+        let sig_with_extra_byte = ed25519_test_data::signature().to_hex() + "00";
+
+        let signature = HexBinary::from_hex(&sig_with_extra_byte).unwrap().to_vec();
+        let message = ed25519_test_data::message().to_vec();
+        let public_key = ed25519_test_data::pub_key().to_vec();
+
+        let result = ed25519_verify(&message, &signature, &public_key);
+        assert_eq!(
+            result.unwrap_err(),
+            ContractError::SignatureVerificationFailed {
+                reason: "Invalid signature format".into(),
+            }
+        );
+    }
 }

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -180,7 +180,7 @@ impl Signature {
         }
 
         let res = match self.key_type() {
-            KeyType::Ecdsa => ecdsa_verify(msg.as_ref(), self, pub_key.as_ref()),
+            KeyType::Ecdsa => ecdsa_verify(msg.as_ref(), self.as_ref(), pub_key.as_ref()),
             KeyType::Ed25519 => ed25519_verify(msg.as_ref(), self.as_ref(), pub_key.as_ref()),
         }?;
 

--- a/contracts/multisig/src/secp256k1.rs
+++ b/contracts/multisig/src/secp256k1.rs
@@ -1,17 +1,37 @@
 use cosmwasm_crypto::secp256k1_verify;
 
-// TODO: Logic specific to secp256k1 will most likely be handled by core in the future.
-use crate::key::Signature;
 use crate::ContractError;
 
-pub fn ecdsa_verify(
-    msg_hash: &[u8],
-    sig: &Signature,
-    pub_key: &[u8],
-) -> Result<bool, ContractError> {
-    secp256k1_verify(msg_hash, sig.as_ref(), pub_key).map_err(|err| {
+pub fn ecdsa_verify(msg_hash: &[u8], sig: &[u8], pub_key: &[u8]) -> Result<bool, ContractError> {
+    secp256k1_verify(msg_hash, sig, pub_key).map_err(|err| {
         ContractError::SignatureVerificationFailed {
             reason: err.to_string(),
         }
     })
+}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::HexBinary;
+
+    use crate::test::common::ecdsa_test_data;
+
+    use super::*;
+
+    #[test]
+    fn should_fail_sig_verification_instead_of_truncating() {
+        let sig_with_extra_byte = ecdsa_test_data::signature().to_hex() + "00";
+
+        let signature = HexBinary::from_hex(&sig_with_extra_byte).unwrap().to_vec();
+        let message = ecdsa_test_data::message().to_vec();
+        let public_key = ecdsa_test_data::pub_key().to_vec();
+
+        let result = ecdsa_verify(&message, &signature, &public_key);
+        assert_eq!(
+            result.unwrap_err(),
+            ContractError::SignatureVerificationFailed {
+                reason: "Invalid signature format".into(),
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Description

- make sure parameters for ecdsa and ed25519 verifying functions are the same
- ensure they throw an error instead of truncating to required byte length

https://axelarnetwork.atlassian.net/browse/AXE-3275

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
