### PR TITLE
fix(minor-connection-router)!: emit correct event when unfreezing chain and add freeze/unfreeze direction to events

### DIFF
--- a/contracts/connection-router/src/events.rs
+++ b/contracts/connection-router/src/events.rs
@@ -1,5 +1,6 @@
-use connection_router_api::{ChainName, Message};
+use connection_router_api::{ChainName, GatewayDirection, Message};
 use cosmwasm_std::{Addr, Attribute, Event};
+use serde_json::to_string;
 
 pub struct RouterInstantiated {
     pub admin: Addr,
@@ -31,10 +32,12 @@ pub struct GatewayUnfrozen {
 
 pub struct ChainFrozen {
     pub name: ChainName,
+    pub direction: GatewayDirection,
 }
 
 pub struct ChainUnfrozen {
     pub name: ChainName,
+    pub direction: GatewayDirection,
 }
 
 pub struct MessageRouted {
@@ -89,13 +92,23 @@ impl From<GatewayUnfrozen> for Event {
 
 impl From<ChainFrozen> for Event {
     fn from(other: ChainFrozen) -> Self {
-        Event::new("chain_frozen").add_attribute("name", other.name)
+        Event::new("chain_frozen")
+            .add_attribute("name", other.name)
+            .add_attribute(
+                "direction",
+                to_string(&other.direction).expect("failed to serialize direction"),
+            )
     }
 }
 
 impl From<ChainUnfrozen> for Event {
     fn from(other: ChainUnfrozen) -> Self {
-        Event::new("chain_unfrozen").add_attribute("name", other.name)
+        Event::new("chain_unfrozen")
+            .add_attribute("name", other.name)
+            .add_attribute(
+                "direction",
+                to_string(&other.direction).expect("failed to serialize direction"),
+            )
     }
 }
 

--- a/contracts/connection-router/src/events.rs
+++ b/contracts/connection-router/src/events.rs
@@ -1,6 +1,6 @@
+use axelar_wasm_std::event;
 use connection_router_api::{ChainName, GatewayDirection, Message};
 use cosmwasm_std::{Addr, Attribute, Event};
-use serde_json::to_string;
 
 pub struct RouterInstantiated {
     pub admin: Addr,
@@ -96,7 +96,7 @@ impl From<ChainFrozen> for Event {
             .add_attribute("name", other.name)
             .add_attribute(
                 "direction",
-                to_string(&other.direction).expect("failed to serialize direction"),
+                event::attribute_value(&other.direction).expect("failed to serialize direction"),
             )
     }
 }
@@ -107,7 +107,7 @@ impl From<ChainUnfrozen> for Event {
             .add_attribute("name", other.name)
             .add_attribute(
                 "direction",
-                to_string(&other.direction).expect("failed to serialize direction"),
+                event::attribute_value(&other.direction).expect("failed to serialize direction"),
             )
     }
 }

--- a/doc/src/contracts/connection_router.md
+++ b/doc/src/contracts/connection_router.md
@@ -77,10 +77,12 @@ pub struct GatewayUnfrozen {
 
 pub struct ChainFrozen {
     pub name: ChainName,
+    pub direction: GatewayDirection,
 }
 
 pub struct ChainUnfrozen {
     pub name: ChainName,
+    pub direction: GatewayDirection,
 }
 
 pub struct MessageRouted {


### PR DESCRIPTION
`unfreeze_chain()` was emitting `ChainFreeze` event instead of `ChainUnfreeze`. Fixed that and also added the gateway direction to these events attributes

https://axelarnetwork.atlassian.net/browse/AXE-3418

## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [x] Documentation
- [x] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
