### PR TITLE
feat(minor-multisig-prover)!: idempotent resigning of workerset updates

### DIFF
--- a/contracts/multisig-prover/src/execute.rs
+++ b/contracts/multisig-prover/src/execute.rs
@@ -161,6 +161,10 @@ fn get_next_worker_set(
     env: &Env,
     config: &Config,
 ) -> Result<Option<WorkerSet>, ContractError> {
+    // if there's already a pending worker set update, just return it
+    if let Some(pending_worker_set) = NEXT_WORKER_SET.may_load(deps.storage)? {
+        return Ok(Some(pending_worker_set));
+    }
     let cur_worker_set = CURRENT_WORKER_SET.may_load(deps.storage)?;
     let new_worker_set = make_worker_set(deps, env, config)?;
 
@@ -287,12 +291,10 @@ fn signers_difference_count(s1: &BTreeMap<String, Signer>, s2: &BTreeMap<String,
 }
 
 // Returns true if there is a different worker set pending for confirmation, false if there is no
-// worker set pending or if the pending set is the same. We can't use direct comparison
-// because the created_at might be different, so we compare only the signers and threshold.
+// worker set pending or if the pending set is the same
 fn different_set_in_progress(storage: &dyn Storage, new_worker_set: &WorkerSet) -> bool {
     if let Ok(Some(next_worker_set)) = NEXT_WORKER_SET.may_load(storage) {
-        return next_worker_set.signers != new_worker_set.signers
-            || next_worker_set.threshold != new_worker_set.threshold;
+        return next_worker_set != *new_worker_set;
     }
 
     false
@@ -300,12 +302,21 @@ fn different_set_in_progress(storage: &dyn Storage, new_worker_set: &WorkerSet) 
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::mock_dependencies;
+    use axelar_wasm_std::Threshold;
+    use connection_router_api::ChainName;
+    use cosmwasm_std::{
+        testing::{mock_dependencies, mock_env},
+        Addr, Uint256,
+    };
 
-    use crate::{execute::should_update_worker_set, state::NEXT_WORKER_SET, test::test_data};
+    use crate::{
+        execute::should_update_worker_set,
+        state::{Config, NEXT_WORKER_SET},
+        test::test_data,
+    };
     use std::collections::BTreeMap;
 
-    use super::different_set_in_progress;
+    use super::{different_set_in_progress, get_next_worker_set};
 
     #[test]
     fn should_update_worker_set_no_change() {
@@ -361,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_same_set_pending_confirmation() {
+    fn test_same_set_different_nonce() {
         let mut deps = mock_dependencies();
         let mut new_worker_set = test_data::new_worker_set();
 
@@ -371,7 +382,7 @@ mod tests {
 
         new_worker_set.created_at += 1;
 
-        assert!(!different_set_in_progress(
+        assert!(different_set_in_progress(
             deps.as_ref().storage,
             &new_worker_set
         ));
@@ -392,5 +403,34 @@ mod tests {
             deps.as_ref().storage,
             &new_worker_set
         ));
+    }
+
+    #[test]
+    fn get_next_worker_set_should_return_pending() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let new_worker_set = test_data::new_worker_set();
+        NEXT_WORKER_SET
+            .save(deps.as_mut().storage, &new_worker_set)
+            .unwrap();
+        let ret_worker_set = get_next_worker_set(&deps.as_mut(), &env, &mock_config());
+        assert_eq!(ret_worker_set.unwrap().unwrap(), new_worker_set);
+    }
+
+    fn mock_config() -> Config {
+        Config {
+            admin: Addr::unchecked("doesn't matter"),
+            gateway: Addr::unchecked("doesn't matter"),
+            multisig: Addr::unchecked("doesn't matter"),
+            service_registry: Addr::unchecked("doesn't matter"),
+            voting_verifier: Addr::unchecked("doesn't matter"),
+            destination_chain_id: Uint256::one(),
+            signing_threshold: Threshold::try_from((2, 3)).unwrap().try_into().unwrap(),
+            service_name: "validators".to_string(),
+            chain_name: ChainName::try_from("ethereum".to_owned()).unwrap(),
+            worker_set_diff_threshold: 0,
+            encoder: crate::encoding::Encoder::Abi,
+            key_type: multisig::key::KeyType::Ecdsa,
+        }
     }
 }

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -148,14 +148,17 @@ pub fn construct_proof_and_sign(
     sign_proof(protocol, workers, response.unwrap())
 }
 
+pub fn get_multisig_session_id(response: AppResponse) -> Uint64 {
+    get_event_attribute(&response.events, "wasm-signing_started", "session_id")
+        .map(|attr| attr.value.as_str().try_into().unwrap())
+        .expect("couldn't get session_id")
+}
+
 pub fn sign_proof(protocol: &mut Protocol, workers: &Vec<Worker>, response: AppResponse) -> Uint64 {
     let msg_to_sign = get_event_attribute(&response.events, "wasm-signing_started", "msg")
         .map(|attr| attr.value.clone())
         .expect("couldn't find message to sign");
-    let session_id: Uint64 =
-        get_event_attribute(&response.events, "wasm-signing_started", "session_id")
-            .map(|attr| attr.value.as_str().try_into().unwrap())
-            .expect("couldn't get session_id");
+    let session_id = get_multisig_session_id(response);
 
     for worker in workers {
         let signature = tofn::ecdsa::sign(

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -4,6 +4,8 @@ use cw_multi_test::Executor;
 use integration_tests::contract::Contract;
 use test_utils::Worker;
 
+use crate::test_utils::get_multisig_session_id;
+
 pub mod test_utils;
 
 #[test]
@@ -115,6 +117,9 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
         vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)],
     );
 
+    let expected_new_worker_set =
+        test_utils::workers_to_worker_set(&mut protocol, &first_wave_of_new_workers);
+
     test_utils::register_workers(&mut protocol, &first_wave_of_new_workers, min_worker_bond);
 
     // Deregister old workers
@@ -158,10 +163,123 @@ fn worker_set_cannot_be_updated_again_while_pending_worker_is_not_yet_confirmed(
     // Deregister old workers
     test_utils::deregister_workers(&mut protocol, &first_wave_of_new_workers);
 
+    // call update_worker_set again. This should just trigger resigning for the initial worker set update,
+    // ignoring any further changes to the worker set
     let response = ethereum.multisig_prover.execute(
         &mut protocol.app,
-        Addr::unchecked("relayer"),
+        ethereum.multisig_prover.admin_addr.clone(),
         &multisig_prover::msg::ExecuteMsg::UpdateWorkerSet,
     );
+    assert!(response.is_ok());
+
+    test_utils::confirm_worker_set(
+        &mut protocol.app,
+        ethereum.multisig_prover.admin_addr.clone(),
+        &ethereum.multisig_prover,
+    );
+
+    let new_worker_set = test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover);
+
+    assert_eq!(new_worker_set, expected_new_worker_set);
+
+    // starting and ending a poll for the second worker rotation
+    // in reality, this shouldn't succeed, because the prover should have prevented another rotation while an existing rotation was in progress.
+    // But even if there is a poll, the prover should ignore it
+    test_utils::execute_worker_set_poll(
+        &mut protocol,
+        &Addr::unchecked("relayer"),
+        &ethereum.voting_verifier,
+        &second_wave_of_new_workers,
+    );
+
+    let response = ethereum.multisig_prover.execute(
+        &mut protocol.app,
+        ethereum.multisig_prover.admin_addr.clone(),
+        &multisig_prover::msg::ExecuteMsg::ConfirmWorkerSet,
+    );
     assert!(response.is_err());
+}
+
+#[test]
+fn worker_set_update_can_be_resigned() {
+    let chains = vec![
+        "Ethereum".to_string().try_into().unwrap(),
+        "Polygon".to_string().try_into().unwrap(),
+    ];
+    let (mut protocol, ethereum, _, initial_workers, min_worker_bond) =
+        test_utils::setup_test_case();
+
+    let simulated_worker_set = test_utils::workers_to_worker_set(&mut protocol, &initial_workers);
+
+    let worker_set = test_utils::get_worker_set(&mut protocol.app, &ethereum.multisig_prover);
+
+    assert_eq!(worker_set, simulated_worker_set);
+
+    // creating a new worker set that only consists of two new workers
+    let first_wave_of_new_workers = test_utils::create_new_workers_vec(
+        chains.clone(),
+        vec![("worker3".to_string(), 2), ("worker4".to_string(), 3)],
+    );
+
+    test_utils::register_workers(&mut protocol, &first_wave_of_new_workers, min_worker_bond);
+
+    // Deregister old workers
+    test_utils::deregister_workers(&mut protocol, &initial_workers);
+
+    let response = protocol
+        .app
+        .execute_contract(
+            ethereum.multisig_prover.admin_addr.clone(),
+            ethereum.multisig_prover.contract_addr.clone(),
+            &multisig_prover::msg::ExecuteMsg::UpdateWorkerSet,
+            &[],
+        )
+        .unwrap();
+
+    let first_session_id = get_multisig_session_id(response.clone());
+
+    // signing didn't occur, trigger signing again
+    let response = protocol
+        .app
+        .execute_contract(
+            ethereum.multisig_prover.admin_addr.clone(),
+            ethereum.multisig_prover.contract_addr.clone(),
+            &multisig_prover::msg::ExecuteMsg::UpdateWorkerSet,
+            &[],
+        )
+        .unwrap();
+
+    let second_session_id = get_multisig_session_id(response.clone());
+    assert_ne!(first_session_id, second_session_id);
+
+    test_utils::sign_proof(&mut protocol, &initial_workers, response);
+
+    // signing did occur, trigger signing again (in case proof was lost)
+    let response = protocol
+        .app
+        .execute_contract(
+            ethereum.multisig_prover.admin_addr.clone(),
+            ethereum.multisig_prover.contract_addr.clone(),
+            &multisig_prover::msg::ExecuteMsg::UpdateWorkerSet,
+            &[],
+        )
+        .unwrap();
+
+    let third_session_id = get_multisig_session_id(response.clone());
+    assert_ne!(first_session_id, second_session_id);
+    assert_ne!(second_session_id, third_session_id);
+
+    test_utils::sign_proof(&mut protocol, &initial_workers, response);
+
+    let proof = test_utils::get_proof(
+        &mut protocol.app,
+        &ethereum.multisig_prover,
+        &second_session_id,
+    );
+
+    // proof must be completed
+    assert!(matches!(
+        proof.status,
+        multisig_prover::msg::ProofStatus::Completed { .. }
+    ));
 }


### PR DESCRIPTION
    * allow update workerset to be called multiple times for the same
      workerset update
    * reuse the same created_at nonce when resigning