### PR TITLE
fix: get_outgoing_messages in the gateway returns error if msgs are missing

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -123,7 +123,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -A deprecated -D clippy::arithmetic_side_effects
+          args: --all-targets -- -D warnings -A deprecated
 
       - name: Check Diff
         # fails if any changes not committed

--- a/contracts/gateway/src/contract.rs
+++ b/contracts/gateway/src/contract.rs
@@ -1,3 +1,4 @@
+use connection_router_api::CrossChainId;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
@@ -52,6 +53,8 @@ pub enum Error {
     InvalidAddress,
     #[error("failed to query message status")]
     MessageStatus,
+    #[error("message with ID {0} not found")]
+    MessageNotFound(CrossChainId),
 }
 
 mod internal {

--- a/contracts/gateway/src/contract/query.rs
+++ b/contracts/gateway/src/contract/query.rs
@@ -1,9 +1,9 @@
+use crate::contract::Error;
+use axelar_wasm_std::error::extend_err;
 use connection_router_api::{CrossChainId, Message};
 use cosmwasm_std::Storage;
-use error_stack::{Result, ResultExt};
-use itertools::Itertools;
+use error_stack::{report, Result, ResultExt};
 
-use crate::contract::Error;
 use crate::state;
 
 pub fn get_outgoing_messages(
@@ -12,7 +12,120 @@ pub fn get_outgoing_messages(
 ) -> Result<Vec<Message>, Error> {
     cross_chain_ids
         .into_iter()
-        .filter_map(|id| state::may_load_outgoing_msg(storage, id).transpose())
-        .try_collect()
+        .map(|id| try_load_msg(storage, id))
+        .fold(Ok(vec![]), accumulate_errs)
+}
+
+fn try_load_msg(storage: &dyn Storage, id: CrossChainId) -> Result<Message, Error> {
+    state::may_load_outgoing_msg(storage, id.clone())
         .change_context(Error::InvalidStoreAccess)
+        .transpose()
+        .unwrap_or(Err(report!(Error::MessageNotFound(id))))
+}
+
+fn accumulate_errs(
+    acc: Result<Vec<Message>, Error>,
+    msg: Result<Message, Error>,
+) -> Result<Vec<Message>, Error> {
+    match (acc, msg) {
+        (Ok(mut acc), Ok(msg)) => {
+            acc.push(msg);
+            Ok(acc)
+        }
+        (Err(acc), Ok(_)) => Err(acc),
+        (acc, Err(msg_err)) => extend_err(acc, msg_err),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::state;
+    use connection_router_api::{CrossChainId, Message};
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn get_outgoing_messages_all_messages_present_returns_all() {
+        let mut deps = mock_dependencies();
+
+        let messages = generate_messages();
+
+        for message in messages.iter() {
+            state::save_outgoing_msg(deps.as_mut().storage, message.cc_id.clone(), message)
+                .unwrap();
+        }
+
+        let ids = messages.iter().map(|msg| msg.cc_id.clone()).collect();
+
+        let res = super::get_outgoing_messages(&deps.storage, ids).unwrap();
+        assert_eq!(res, messages);
+    }
+
+    #[test]
+    fn get_outgoing_messages_nothing_stored_returns_not_found_error() {
+        let deps = mock_dependencies();
+
+        let messages = generate_messages();
+        let ids = messages.iter().map(|msg| msg.cc_id.clone()).collect();
+
+        let res = super::get_outgoing_messages(&deps.storage, ids);
+
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().current_frames().len(), messages.len());
+    }
+
+    #[test]
+    fn get_outgoing_messages_only_partially_found_returns_not_found_error() {
+        let mut deps = mock_dependencies();
+
+        let messages = generate_messages();
+
+        state::save_outgoing_msg(
+            deps.as_mut().storage,
+            messages[1].cc_id.clone(),
+            &messages[1],
+        )
+        .unwrap();
+
+        let ids = messages.iter().map(|msg| msg.cc_id.clone()).collect();
+
+        let res = super::get_outgoing_messages(&deps.storage, ids);
+
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().current_frames().len(), messages.len() - 1);
+    }
+
+    fn generate_messages() -> Vec<Message> {
+        vec![
+            Message {
+                cc_id: CrossChainId {
+                    chain: "chain1".parse().unwrap(),
+                    id: "id1".parse().unwrap(),
+                },
+                destination_address: "addr1".parse().unwrap(),
+                destination_chain: "chain2".parse().unwrap(),
+                source_address: "addr2".parse().unwrap(),
+                payload_hash: [0; 32],
+            },
+            Message {
+                cc_id: CrossChainId {
+                    chain: "chain2".parse().unwrap(),
+                    id: "id2".parse().unwrap(),
+                },
+                destination_address: "addr3".parse().unwrap(),
+                destination_chain: "chain3".parse().unwrap(),
+                source_address: "addr4".parse().unwrap(),
+                payload_hash: [1; 32],
+            },
+            Message {
+                cc_id: CrossChainId {
+                    chain: "chain3".parse().unwrap(),
+                    id: "id3".parse().unwrap(),
+                },
+                destination_address: "addr5".parse().unwrap(),
+                destination_chain: "chain4".parse().unwrap(),
+                source_address: "addr6".parse().unwrap(),
+                payload_hash: [2; 32],
+            },
+        ]
+    }
 }

--- a/contracts/gateway/tests/contract.rs
+++ b/contracts/gateway/tests/contract.rs
@@ -142,14 +142,15 @@ fn successful_route_outgoing() {
         };
 
         // check no messages are outgoing
-        iter::repeat(query(deps.as_ref(), mock_env(), query_msg.clone()).unwrap())
-            .take(2)
-            .for_each(|response| {
-                assert_eq!(
-                    response,
-                    to_json_binary::<Vec<CrossChainId>>(&vec![]).unwrap()
-                )
-            });
+        let query_response = query(deps.as_ref(), mock_env(), query_msg.clone());
+        if msgs.len() == 0 {
+            assert_eq!(
+                query_response.unwrap(),
+                to_json_binary::<Vec<CrossChainId>>(&vec![]).unwrap()
+            )
+        } else {
+            assert!(query_response.is_err());
+        }
 
         // check routing of outgoing messages is idempotent
         let response = iter::repeat(

--- a/contracts/gateway/tests/contract.rs
+++ b/contracts/gateway/tests/contract.rs
@@ -143,7 +143,7 @@ fn successful_route_outgoing() {
 
         // check no messages are outgoing
         let query_response = query(deps.as_ref(), mock_env(), query_msg.clone());
-        if msgs.len() == 0 {
+        if msgs.is_empty(){
             assert_eq!(
                 query_response.unwrap(),
                 to_json_binary::<Vec<CrossChainId>>(&vec![]).unwrap()

--- a/contracts/gateway/tests/contract.rs
+++ b/contracts/gateway/tests/contract.rs
@@ -143,7 +143,7 @@ fn successful_route_outgoing() {
 
         // check no messages are outgoing
         let query_response = query(deps.as_ref(), mock_env(), query_msg.clone());
-        if msgs.is_empty(){
+        if msgs.is_empty() {
             assert_eq!(
                 query_response.unwrap(),
                 to_json_binary::<Vec<CrossChainId>>(&vec![]).unwrap()


### PR DESCRIPTION
Expected behaviour for the query is to return an error if any of the message IDs cannot be found, but instead it just dropped those IDs from the response

AXE-3579