### PR TITLE
feat: add initial healthcheck endpoint (ampd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axelar-wasm-std",
+ "axum 0.7.5",
  "base64 0.21.4",
  "bcs",
  "clap",
@@ -237,7 +238,7 @@ dependencies = [
  "ed25519 1.5.3",
  "futures",
  "hex",
- "http",
+ "http 0.2.9",
  "matchit 0.5.0",
  "pin-project-lite",
  "pkcs8 0.9.0",
@@ -701,15 +702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "base64 0.21.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "itoa",
  "matchit 0.7.2",
  "memchr",
@@ -722,12 +723,46 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.2",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.0",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -739,12 +774,33 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2801,7 +2857,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.9",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -3447,7 +3503,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 2.0.0",
  "slab",
  "tokio",
@@ -3511,7 +3567,7 @@ dependencies = [
  "base64 0.21.4",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.9",
  "httpdate",
  "mime",
  "sha1",
@@ -3523,7 +3579,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -3595,13 +3651,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -3650,8 +3740,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -3664,6 +3754,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-proxy"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,8 +3781,8 @@ dependencies = [
  "bytes",
  "futures",
  "headers",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.27",
  "hyper-rustls 0.22.1",
  "rustls-native-certs",
  "tokio",
@@ -3690,7 +3799,7 @@ checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "ct-logs",
  "futures-util",
- "hyper",
+ "hyper 0.14.27",
  "log",
  "rustls 0.19.1",
  "rustls-native-certs",
@@ -3707,8 +3816,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.27",
  "rustls 0.21.7",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3720,10 +3829,26 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2 0.5.4",
+ "tokio",
 ]
 
 [[package]]
@@ -4873,7 +4998,7 @@ version = "0.7.0"
 source = "git+https://github.com/mystenlabs/sui?tag=mainnet-v1.14.2#299cbeafbb6aa5601e08f00ac24bd647c61a63e2"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "dashmap",
  "futures",
  "once_cell",
@@ -4898,7 +5023,7 @@ dependencies = [
  "bytes",
  "eyre",
  "futures",
- "http",
+ "http 0.2.9",
  "multiaddr",
  "serde",
  "snap",
@@ -6415,9 +6540,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-rustls 0.24.1",
  "ipnet",
  "js-sys",
@@ -6431,7 +6556,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -7304,9 +7429,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snap"
@@ -7748,6 +7873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384595c11a4e2969895cad5a8c4029115f5ab956a9e5ef4de79d11a426e5f20c"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7958,8 +8089,8 @@ dependencies = [
  "flex-error",
  "futures",
  "getrandom",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.27",
  "hyper-proxy",
  "hyper-rustls 0.22.1",
  "peg",
@@ -8300,15 +8431,15 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -8332,13 +8463,13 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.4",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -8413,8 +8544,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -8561,7 +8692,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.0",
  "hyper-util",
  "itoa",
  "matchit 0.7.2",
@@ -757,7 +757,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.0",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower",
  "tower-layer",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "9f24ce812868d86d19daa79bf3bf9175bc44ea323391147a5e3abde2a283871b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3845,7 +3845,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.0",
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio",
@@ -7874,9 +7874,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384595c11a4e2969895cad5a8c4029115f5ab956a9e5ef4de79d11a426e5f20c"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = { workspace = true }
 [dependencies]
 async-trait = "0.1.59"
 axelar-wasm-std = { workspace = true }
+axum = "0.7.5"
 base64 = "0.21.2"
 bcs = "0.1.5"
 clap = { version = "4.2.7", features = ["derive", "cargo"] }

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -52,6 +52,7 @@ type=[handler type. Could be EvmMsgWorkerSetVerifier | SuiWorkerSetVerifier]
 
 Below is an example config for connecting to a local axelard node and local tofnd process, and verifying transactions from Avalanche testnet and Sui testnet.
 ```
+health_check_bind_addr = "0.0.0.0:3000"
 tm_jsonrpc="http://localhost:26657"
 tm_grpc="tcp://localhost:9090"
 event_buffer_cap=10000

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -11,6 +11,7 @@ Below is the config file format, with explanations for each entry:
 tm_jsonrpc=[JSON-RPC URL of Axelar node]
 tm_grpc=[gRPC URL of Axelar node]
 event_buffer_cap=[max blockchain events to queue. Will error if set too low]
+health_check_bind_addr =[the /status endpoint bind address i.e "0.0.0.0:3000"]
 
 [service_registry]
 cosmwasm_contract=[address of service registry]

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -53,7 +53,7 @@ type=[handler type. Could be EvmMsgWorkerSetVerifier | SuiWorkerSetVerifier]
 
 Below is an example config for connecting to a local axelard node and local tofnd process, and verifying transactions from Avalanche testnet and Sui testnet.
 ```
-health_check_bind_addr ="0.0.0.0:3000"
+health_check_bind_addr="0.0.0.0:3000"
 tm_jsonrpc="http://localhost:26657"
 tm_grpc="tcp://localhost:9090"
 event_buffer_cap=10000

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -11,7 +11,7 @@ Below is the config file format, with explanations for each entry:
 tm_jsonrpc=[JSON-RPC URL of Axelar node]
 tm_grpc=[gRPC URL of Axelar node]
 event_buffer_cap=[max blockchain events to queue. Will error if set too low]
-health_check_bind_addr =[the /status endpoint bind address i.e "0.0.0.0:3000"]
+health_check_bind_addr=[the /status endpoint bind address i.e "0.0.0.0:3000"]
 
 [service_registry]
 cosmwasm_contract=[address of service registry]

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -53,7 +53,7 @@ type=[handler type. Could be EvmMsgWorkerSetVerifier | SuiWorkerSetVerifier]
 
 Below is an example config for connecting to a local axelard node and local tofnd process, and verifying transactions from Avalanche testnet and Sui testnet.
 ```
-health_check_bind_addr = "0.0.0.0:3000"
+health_check_bind_addr ="0.0.0.0:3000"
 tm_jsonrpc="http://localhost:26657"
 tm_grpc="tcp://localhost:9090"
 event_buffer_cap=10000

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -1,5 +1,4 @@
-use std::net::SocketAddr;
-use std::str::FromStr;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ use crate::url::Url;
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(default)]
 pub struct Config {
-    pub health_check_bind_addr: SocketAddr,
+    pub health_check_bind_addr: SocketAddrV4,
     pub tm_jsonrpc: Url,
     pub tm_grpc: Url,
     pub event_buffer_cap: usize,
@@ -37,7 +36,7 @@ impl Default for Config {
             event_buffer_cap: 100000,
             event_stream_timeout: Duration::from_secs(15),
             service_registry: ServiceRegistryConfig::default(),
-            health_check_bind_addr: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3000);
+            health_check_bind_addr: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3000),
         }
     }
 }

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+use std::str::FromStr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -11,6 +13,7 @@ use crate::url::Url;
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(default)]
 pub struct Config {
+    pub health_check_bind_addr: SocketAddr,
     pub tm_jsonrpc: Url,
     pub tm_grpc: Url,
     pub event_buffer_cap: usize,
@@ -34,6 +37,7 @@ impl Default for Config {
             event_buffer_cap: 100000,
             event_stream_timeout: Duration::from_secs(15),
             service_registry: ServiceRegistryConfig::default(),
+            health_check_bind_addr: SocketAddr::from_str("0.0.0.0:3000").unwrap(),
         }
     }
 }

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -37,7 +37,7 @@ impl Default for Config {
             event_buffer_cap: 100000,
             event_stream_timeout: Duration::from_secs(15),
             service_registry: ServiceRegistryConfig::default(),
-            health_check_bind_addr: SocketAddr::from_str("0.0.0.0:3000").unwrap(),
+            health_check_bind_addr: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3000);
         }
     }
 }

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -29,7 +29,7 @@ impl Server {
         })
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn listening_addr(&self) -> Result<SocketAddr, HealthCheckError> {
         Ok(self
             .listener

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -44,7 +44,7 @@ impl Server {
     }
 
     #[cfg(test)]
-    pub fn listening_addr(&self) -> Result<SocketAddr, HealthCheckError> {
+    fn listening_addr(&self) -> Result<SocketAddr, HealthCheckError> {
         Ok(self
             .listener
             .local_addr()

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -7,6 +7,9 @@ use axum::{http::StatusCode, routing::get, Json, Router};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
+#[cfg(test)]
+use std::net::SocketAddr;
+
 pub struct Server {
     listener: tokio::net::TcpListener,
 }
@@ -67,14 +70,14 @@ struct Status {
 #[cfg(test)]
 mod tests {
 
-    use std::{str::FromStr, time::Duration};
-
     use super::*;
+    use std::str::FromStr;
+    use std::time::Duration;
     use tokio::test as async_test;
 
     #[async_test]
     async fn server_lifecycle() {
-        let server = Server::new(SocketAddr::from_str("127.0.0.1:0").unwrap())
+        let server = Server::new(SocketAddrV4::from_str("127.0.0.1:0").unwrap())
             .await
             .unwrap();
         let listening_addr = server.listening_addr().unwrap();

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -1,5 +1,5 @@
 use error_stack::{Result, ResultExt};
-use std::net::SocketAddr;
+use std::net::SocketAddrV4;
 use thiserror::Error;
 use tracing::info;
 
@@ -18,7 +18,7 @@ pub enum HealthCheckError {
 }
 
 impl Server {
-    pub async fn new(bind_addr: SocketAddr) -> Result<Self, HealthCheckError> {
+    pub async fn new(bind_addr: SocketAddrV4) -> Result<Self, HealthCheckError> {
         Ok(Self {
             listener: tokio::net::TcpListener::bind(bind_addr)
                 .await

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -1,0 +1,99 @@
+use error_stack::{Result, ResultExt};
+use std::net::SocketAddr;
+use thiserror::Error;
+
+use axum::{http::StatusCode, routing::get, Json, Router};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+pub struct Server {
+    listener: tokio::net::TcpListener,
+}
+
+#[derive(Error, Debug)]
+pub enum HealthCheckError {
+    #[error("Health check server error: {0}")]
+    Error(String),
+}
+
+impl Server {
+    pub async fn new(bind_addr: SocketAddr) -> Result<Self, HealthCheckError> {
+        Ok(Self {
+            listener: tokio::net::TcpListener::bind(bind_addr)
+                .await
+                .change_context(HealthCheckError::Error(format!(
+                    "Failed binding to addr: {}",
+                    bind_addr
+                )))?,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn listening_addr(&self) -> Result<SocketAddr, HealthCheckError> {
+        Ok(self
+            .listener
+            .local_addr()
+            .map_err(|e| HealthCheckError::Error(e.to_string()))?)
+    }
+
+    pub async fn run(self, cancel: CancellationToken) -> Result<(), HealthCheckError> {
+        tracing_subscriber::fmt::init();
+        let app = Router::new().route("/status", get(status));
+        axum::serve(self.listener, app)
+            .with_graceful_shutdown(async move { cancel.cancelled().await })
+            .await
+            .change_context(HealthCheckError::Error(
+                "Failed executing server".to_string(),
+            ))
+    }
+}
+
+// basic handler that responds with a static string
+async fn status() -> (StatusCode, Json<Status>) {
+    (StatusCode::OK, Json(Status { ok: true }))
+}
+
+#[derive(Serialize, Deserialize)]
+struct Status {
+    ok: bool,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{str::FromStr, time::Duration};
+
+    use super::*;
+    use tokio::test as async_test;
+
+    #[async_test]
+    async fn server_lifecycle() {
+        let server = Server::new(SocketAddr::from_str("127.0.0.1:0").unwrap())
+            .await
+            .unwrap();
+        let listening_addr = server.listening_addr().unwrap();
+
+        let cancel = CancellationToken::new();
+
+        tokio::spawn(server.run(cancel.clone()));
+
+        let url = format!("http://{}/status", listening_addr);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let response = reqwest::get(&url).await.unwrap();
+        assert_eq!(reqwest::StatusCode::OK, response.status());
+
+        let status = response.json::<Status>().await.unwrap();
+        assert!(status.ok);
+
+        cancel.cancel();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        match reqwest::get(&url).await {
+            Ok(_) => panic!("health check server should be closed by now"),
+            Err(error) => assert!(error.is_connect()),
+        };
+    }
+}

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -7,16 +7,16 @@ use axum::{http::StatusCode, routing::get, Json, Router};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
-pub struct Server {
-    listener: tokio::net::TcpListener,
-}
-
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("failed to start the health check server")]
     Start,
     #[error("health check server failed unexpectedly")]
     WhileRunning,
+}
+
+pub struct Server {
+    listener: tokio::net::TcpListener,
 }
 
 impl Server {

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -32,7 +32,7 @@ impl Server {
         let app = Router::new().route("/status", get(status));
         let bind_address = self.listener.local_addr().change_context(Error::Start)?;
 
-        info!("Starting health check server at: {}", bind_address);
+        info!(address = bind_address.to_string(), "starting health check server");
 
         Ok(axum::serve(self.listener, app)
             .with_graceful_shutdown(async move { cancel.cancelled().await })

--- a/ampd/src/health_check.rs
+++ b/ampd/src/health_check.rs
@@ -35,10 +35,10 @@ impl Server {
         );
 
         let app = Router::new().route("/status", get(status));
-        Ok(axum::serve(listener, app)
+        axum::serve(listener, app)
             .with_graceful_shutdown(async move { cancel.cancelled().await })
             .await
-            .change_context(Error::WhileRunning)?)
+            .change_context(Error::WhileRunning)
     }
 }
 

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -126,7 +126,7 @@ async fn prepare_app(cfg: Config, state: State) -> Result<App<impl Broadcaster>,
 
     let health_check_server = health_check::Server::new(health_check_bind_addr)
         .await
-        .change_context(Error::HealthCheckServerError)?;
+        .change_context(Error::HealthCheckError)?;
 
     App::new(
         tm_client,
@@ -421,7 +421,7 @@ where
             .add_task(CancellableTask::create(|token| {
                 health_check_server
                     .run(token)
-                    .change_context(Error::HealthCheckServerError)
+                    .change_context(Error::HealthCheckError)
             }))
             .add_task(CancellableTask::create(|token| {
                 event_processor
@@ -473,6 +473,6 @@ pub enum Error {
     BlockHeightMonitor,
     #[error("invalid finalizer type for chain {0}")]
     InvalidFinalizerType(ChainName),
-    #[error("Health check server error")]
-    HealthCheckServerError,
+    #[error("Health check system error")]
+    HealthCheckError,
 }

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -473,6 +473,6 @@ pub enum Error {
     BlockHeightMonitor,
     #[error("invalid finalizer type for chain {0}")]
     InvalidFinalizerType(ChainName),
-    #[error("Health check system error")]
-    HealthCheckError,
+    #[error("health check is not working")]
+    HealthCheck,
 }

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -124,9 +124,7 @@ async fn prepare_app(cfg: Config, state: State) -> Result<App<impl Broadcaster>,
         .build()
         .change_context(Error::Broadcaster)?;
 
-    let health_check_server = health_check::Server::new(health_check_bind_addr)
-        .await
-        .change_context(Error::HealthCheck)?;
+    let health_check_server = health_check::Server::new(health_check_bind_addr);
 
     App::new(
         tm_client,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -176,6 +176,7 @@ impl<T> App<T>
 where
     T: Broadcaster + Send + Sync + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         tm_client: tendermint_rpc::HttpClient,
         broadcaster: T,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -126,7 +126,7 @@ async fn prepare_app(cfg: Config, state: State) -> Result<App<impl Broadcaster>,
 
     let health_check_server = health_check::Server::new(health_check_bind_addr)
         .await
-        .change_context(Error::HealthCheckError)?;
+        .change_context(Error::HealthCheck)?;
 
     App::new(
         tm_client,
@@ -421,7 +421,7 @@ where
             .add_task(CancellableTask::create(|token| {
                 health_check_server
                     .run(token)
-                    .change_context(Error::HealthCheckError)
+                    .change_context(Error::HealthCheck)
             }))
             .add_task(CancellableTask::create(|token| {
                 event_processor

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -1,3 +1,4 @@
+health_check_bind_addr = '0.0.0.0:3000'
 tm_jsonrpc = 'http://localhost:26657/'
 tm_grpc = 'tcp://localhost:9090'
 event_buffer_cap = 100000


### PR DESCRIPTION
## Description

At [Eiger](https://github.com/eigerco) we are working on the `Axelar Solana` implementation.  During this work, we realised `ampd` doesn't have a defined way to check the `liveness` of the process from an external perspective. This is specially useful when deploying workloads in i.e Kubernetes, as the cluster can query the process in order to check if its alive or not.

This is a PR proposal for adding an `HTTP` `/status` endpoint to the `ampd` process, that can be used by external systems to determine the `liveness` of the process.

Closes https://github.com/eigerco/axelar-amplifier/issues/12

## Todos

- [x] Unit tests
- [x] Manual tests See this [comment](https://github.com/axelarnetwork/axelar-amplifier/pull/344#issuecomment-2049722752) .
- [x] Documentation
- [x] Connect epics/issues

## Steps to Test

### Manual
1. Start the `ampd` server.
2. ```bash
    $ curl localhost:3000/status
    ```
### Unit tests

```bash
$ cd ampd && cargo test
```

## Expected Behaviour

Once `ampd` starts its activity, an HTTP request to the `/status` endpoint should return a `200 OK` response in json format:

```bash
{
 ok: true
}
```

## Other Notes

This is just a dummy HTTP health check endpoint that only provides a probe of liveness of the process. It doesn't query any subsystem in order to check their internal health. In a future, such option could be revisited.