### PR TITLE
feat(service-registry): jail worker

### DIFF
--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -241,7 +241,7 @@ pub mod execute {
             |sw| -> Result<Worker, ContractError> {
                 match sw {
                     Some(worker) => Ok(Worker {
-                        bonding_state: worker.bonding_state.add_bond(bond)?,
+                        bonding_state: worker.add_bond(bond)?,
                         ..worker
                     }),
                     None => Ok(Worker {
@@ -312,13 +312,9 @@ pub mod execute {
             .may_load(deps.storage, (&service_name, &info.sender))?
             .ok_or(ContractError::WorkerNotFound)?;
 
-        if worker.is_jailed() {
-            return Err(ContractError::WorkerJailed);
-        }
-
         let can_unbond = true; // TODO: actually query the service to determine this value
 
-        let bonding_state = worker.bonding_state.unbond(can_unbond, env.block.time)?;
+        let bonding_state = worker.unbond(can_unbond, env.block.time)?;
 
         WORKERS.save(
             deps.storage,
@@ -346,13 +342,8 @@ pub mod execute {
             .may_load(deps.storage, (&service_name, &info.sender))?
             .ok_or(ContractError::WorkerNotFound)?;
 
-        if worker.is_jailed() {
-            return Err(ContractError::WorkerJailed);
-        }
-
-        let (bonding_state, released_bond) = worker
-            .bonding_state
-            .claim_stake(env.block.time, service.unbonding_period_days as u64)?;
+        let (bonding_state, released_bond) =
+            worker.claim_stake(env.block.time, service.unbonding_period_days as u64)?;
 
         WORKERS.save(
             deps.storage,

--- a/contracts/service-registry/src/error.rs
+++ b/contracts/service-registry/src/error.rs
@@ -32,4 +32,6 @@ pub enum ContractError {
     InvalidBondingState(BondingState),
     #[error("not enough workers")]
     NotEnoughWorkers,
+    #[error("worker is jailed")]
+    WorkerJailed,
 }

--- a/contracts/service-registry/src/msg.rs
+++ b/contracts/service-registry/src/msg.rs
@@ -30,6 +30,11 @@ pub enum ExecuteMsg {
         workers: Vec<String>,
         service_name: String,
     },
+    // Jail workers. Can only be called by governance account. Jailed workers are not allowed to unbond or claim stake.
+    JailWorkers {
+        workers: Vec<String>,
+        service_name: String,
+    },
 
     // Register support for the specified chains. Called by the worker.
     RegisterChainSupport {

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -40,6 +40,12 @@ pub struct Worker {
     pub service_name: String,
 }
 
+impl Worker {
+    pub fn is_jailed(&self) -> bool {
+        matches!(self.authorization_state, AuthorizationState::Jailed)
+    }
+}
+
 #[cw_serde]
 pub struct WeightedWorker {
     pub worker_info: Worker,
@@ -129,6 +135,7 @@ impl BondingState {
 pub enum AuthorizationState {
     NotAuthorized,
     Authorized,
+    Jailed,
 }
 
 type ChainNames = HashSet<ChainName>;


### PR DESCRIPTION
## Description
Governance can jail workers. A jailed worker cannot unbond or claim stake.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
