### PR TITLE
fix(minor-nexus-gateway)!: make msg id consistent with evm chains

### DIFF
--- a/contracts/nexus-gateway/src/contract/execute.rs
+++ b/contracts/nexus-gateway/src/contract/execute.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{to_binary, Addr, Response, WasmMsg};
 use error_stack::report;
 
 use crate::error::ContractError;
-use crate::nexus::{self};
+use crate::nexus;
 use crate::state::Store;
 
 use super::Contract;
@@ -25,7 +25,7 @@ where
         let msgs: Vec<_> = msgs
             .into_iter()
             .map(connection_router_api::Message::try_from)
-            .collect::<Result<Vec<connection_router_api::Message>>>()?;
+            .collect::<Result<Vec<_>>>()?;
         if msgs.is_empty() {
             return Ok(Response::default());
         }

--- a/contracts/nexus-gateway/src/contract/execute.rs
+++ b/contracts/nexus-gateway/src/contract/execute.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{to_binary, Addr, Response, WasmMsg};
 use error_stack::report;
 
 use crate::error::ContractError;
-use crate::nexus;
+use crate::nexus::{self};
 use crate::state::Store;
 
 use super::Contract;
@@ -24,8 +24,8 @@ where
 
         let msgs: Vec<_> = msgs
             .into_iter()
-            .map(connection_router_api::Message::from)
-            .collect();
+            .map(connection_router_api::Message::try_from)
+            .collect::<Result<Vec<connection_router_api::Message>>>()?;
         if msgs.is_empty() {
             return Ok(Response::default());
         }
@@ -134,7 +134,7 @@ mod test {
                 .unwrap()
                 .try_into()
                 .unwrap(),
-                source_tx_id: vec![0x2f, 0xe4].try_into().unwrap(),
+                source_tx_id: vec![0x2f; 32].try_into().unwrap(),
                 source_tx_index: 100,
             },
             nexus::Message {
@@ -148,7 +148,7 @@ mod test {
                 .unwrap()
                 .try_into()
                 .unwrap(),
-                source_tx_id: vec![0x23, 0xf4].try_into().unwrap(),
+                source_tx_id: vec![0x23; 32].try_into().unwrap(),
                 source_tx_index: 1000,
             },
         ];

--- a/contracts/nexus-gateway/src/error.rs
+++ b/contracts/nexus-gateway/src/error.rs
@@ -14,6 +14,12 @@ pub enum ContractError {
     #[error("invalid message id {0}")]
     InvalidMessageId(String),
 
+    #[error("invalid source tx id {0}")]
+    InvalidSourceTxId(String),
+
+    #[error("invalid event index {0}")]
+    InvalidEventIndex(u64),
+
     #[error("invalid payload hash {0}")]
     InvalidMessagePayloadHash(HexBinary),
 

--- a/contracts/nexus-gateway/src/nexus.rs
+++ b/contracts/nexus-gateway/src/nexus.rs
@@ -71,6 +71,7 @@ impl From<connection_router_api::Message> for Message {
 impl TryFrom<Message> for connection_router_api::Message {
     type Error = Report<ContractError>;
     fn try_from(msg: Message) -> Result<Self, ContractError> {
+        // this string is just used in error messages
         let msg_id = format!(
             "{}-{}",
             msg.source_tx_id.as_ref().encode_hex::<String>(),

--- a/contracts/nexus-gateway/src/nexus.rs
+++ b/contracts/nexus-gateway/src/nexus.rs
@@ -1,7 +1,7 @@
-use axelar_wasm_std::nonempty;
+use axelar_wasm_std::{msg_id::tx_hash_event_index::HexTxHashAndEventIndex, nonempty};
 use connection_router_api::{Address, ChainName, CrossChainId};
 use cosmwasm_std::{CosmosMsg, CustomMsg};
-use error_stack::{Result, ResultExt};
+use error_stack::{Report, Result, ResultExt};
 use hex::{FromHex, ToHex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -68,29 +68,76 @@ impl From<connection_router_api::Message> for Message {
     }
 }
 
-impl From<Message> for connection_router_api::Message {
-    fn from(msg: Message) -> Self {
-        Self {
+impl TryFrom<Message> for connection_router_api::Message {
+    type Error = Report<ContractError>;
+    fn try_from(msg: Message) -> Result<Self, ContractError> {
+        let msg_id = format!(
+            "{}-{}",
+            msg.source_tx_id.as_ref().encode_hex::<String>(),
+            msg.source_tx_index
+        );
+        Ok(Self {
             cc_id: CrossChainId {
                 chain: msg.source_chain,
-                id: format!(
-                    "{}:{}",
-                    msg.source_tx_id.as_ref().encode_hex::<String>(),
-                    msg.source_tx_index
-                )
+                id: HexTxHashAndEventIndex {
+                    tx_hash: <[u8; 32]>::try_from(msg.source_tx_id.as_ref().as_slice())
+                        .map_err(|_| axelar_wasm_std::msg_id::Error::InvalidTxHash(msg_id.clone()))
+                        .change_context(ContractError::InvalidMessageId(msg_id.clone()))?,
+                    event_index: u32::try_from(msg.source_tx_index)
+                        .map_err(|_| {
+                            axelar_wasm_std::msg_id::Error::EventIndexOverflow(msg_id.clone())
+                        })
+                        .change_context(ContractError::InvalidMessageId(msg_id))?,
+                }
+                .to_string()
                 .try_into()
-                .expect("cannot be empty"),
+                .expect("must serialize message id to non-empty string"),
             },
             source_address: msg.source_address,
             destination_chain: msg.destination_chain,
             destination_address: msg.destination_address,
             payload_hash: msg.payload_hash,
-        }
+        })
     }
 }
 
 impl From<Message> for CosmosMsg<Message> {
     fn from(msg: Message) -> Self {
         CosmosMsg::Custom(msg)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::vec;
+
+    use cosmwasm_std::HexBinary;
+
+    use super::Message;
+
+    #[test]
+    fn should_convert_nexus_message_to_router_message() {
+        let msg = Message {
+            source_chain: "ethereum".parse().unwrap(),
+            source_address: "something".parse().unwrap(),
+            destination_chain: "polygon".parse().unwrap(),
+            destination_address: "something else".parse().unwrap(),
+            payload_hash: [1; 32],
+            source_tx_id: vec![2; 32].try_into().unwrap(),
+            source_tx_index: 1,
+        };
+
+        let router_msg = connection_router_api::Message::try_from(msg.clone());
+        assert!(router_msg.is_ok());
+        let router_msg = router_msg.unwrap();
+        assert_eq!(router_msg.cc_id.chain, msg.source_chain);
+        assert_eq!(
+            router_msg.cc_id.id.to_string(),
+            format!(
+                "0x{}-{}",
+                HexBinary::from(msg.source_tx_id.as_ref().clone()).to_hex(),
+                msg.source_tx_index
+            )
+        );
     }
 }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -22,7 +22,7 @@ impl HexTxHashAndEventIndex {
     }
 }
 
-pub const PATTERN: &str = "^(0x[0-9a-f]{64})-(0|[1-9][0-9]*)$";
+const PATTERN: &str = "^(0x[0-9a-f]{64})-(0|[1-9][0-9]*)$";
 lazy_static! {
     static ref REGEX: Regex = Regex::new(PATTERN).expect("invalid regex");
 }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -22,7 +22,7 @@ impl HexTxHashAndEventIndex {
     }
 }
 
-const PATTERN: &str = "^(0x[0-9a-f]{64})-(0|[1-9][0-9]*)$";
+pub const PATTERN: &str = "^(0x[0-9a-f]{64})-(0|[1-9][0-9]*)$";
 lazy_static! {
     static ref REGEX: Regex = Regex::new(PATTERN).expect("invalid regex");
 }


### PR DESCRIPTION
Nexus gateway was still using colon, instead of dash in message ids, and was not prefixing with 0x.

https://axelarnetwork.atlassian.net/browse/AXE-3719