### PR TITLE
refactor(ampd): use typed-builder instead of derive_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,6 @@ dependencies = [
  "cosmrs",
  "cosmwasm-std",
  "deref-derive",
- "derive_builder",
  "dirs",
  "ecdsa",
  "elliptic-curve",
@@ -205,6 +204,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+ "typed-builder",
  "url",
  "valuable",
  "valuable-serde",
@@ -2184,37 +2184,6 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -8703,6 +8672,26 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -17,7 +17,7 @@ cosmos-sdk-proto = "0.16.0"
 cosmrs = { version = "0.14.0", features = ["cosmwasm"] }
 cosmwasm-std = { workspace = true, features = ["stargate"] }
 deref-derive = "0.1.0"
-derive_builder = "0.12.0"
+typed-builder = "0.18.2"
 dirs = "5.0.1"
 ecdsa = { version = "0.16.6" }
 enum-display-derive = "0.1.1"

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -17,7 +17,6 @@ cosmos-sdk-proto = "0.16.0"
 cosmrs = { version = "0.14.0", features = ["cosmwasm"] }
 cosmwasm-std = { workspace = true, features = ["stargate"] }
 deref-derive = "0.1.0"
-typed-builder = "0.18.2"
 dirs = "5.0.1"
 ecdsa = { version = "0.16.6" }
 enum-display-derive = "0.1.1"
@@ -61,6 +60,7 @@ tonic = "0.8.3"
 tracing = { version = "0.1.37", features = ["valuable", "log"] }
 tracing-core = { version = "0.1.30", features = ["valuable"] }
 tracing-subscriber = { version = "0.3.16", features = ["json", "valuable"] }
+typed-builder = "0.18.2"
 url = "2.3.1"
 valuable = { version = "0.1.0", features = ["derive"] }
 valuable-serde = { version = "0.1.0", features = ["std"] }

--- a/ampd/src/broadcaster/tx.rs
+++ b/ampd/src/broadcaster/tx.rs
@@ -7,10 +7,10 @@ use cosmrs::{
     tx::{BodyBuilder, Fee, SignDoc, SignerInfo},
     Any, Coin,
 };
-use derive_builder::Builder;
 use error_stack::{Context, Result, ResultExt};
 use report::ResultCompatExt;
 use thiserror::Error;
+use typed_builder::TypedBuilder;
 
 use crate::types::PublicKey;
 
@@ -25,7 +25,7 @@ pub enum Error {
     Marshaling,
 }
 
-#[derive(Builder)]
+#[derive(TypedBuilder)]
 pub struct Tx<M>
 where
     M: IntoIterator<Item = Any>,
@@ -33,22 +33,17 @@ where
     msgs: M,
     pub_key: PublicKey,
     acc_sequence: u64,
+    #[builder(default = zero_fee())]
     fee: Fee,
 }
-
-impl<M> TxBuilder<M>
-where
-    M: IntoIterator<Item = Any> + Clone,
-{
-    pub fn zero_fee(&mut self) -> &mut Self {
-        self.fee(Fee::from_amount_and_gas(
-            Coin {
-                denom: "".parse().unwrap(),
-                amount: 0,
-            },
-            0u64,
-        ))
-    }
+fn zero_fee() -> Fee {
+    Fee::from_amount_and_gas(
+        Coin {
+            denom: "".parse().unwrap(),
+            amount: 0,
+        },
+        0u64,
+    )
 }
 
 impl<M> Tx<M>
@@ -119,7 +114,7 @@ mod tests {
 
     use crate::types::PublicKey;
 
-    use super::{Error, TxBuilder, DUMMY_CHAIN_ID};
+    use super::{Error, Tx, DUMMY_CHAIN_ID};
 
     #[test]
     async fn sign_with_should_produce_the_correct_tx() {
@@ -131,13 +126,11 @@ mod tests {
         let chain_id: Id = DUMMY_CHAIN_ID.parse().unwrap();
         let msgs = vec![dummy_msg(), dummy_msg(), dummy_msg()];
 
-        let actual_tx = TxBuilder::default()
+        let actual_tx = Tx::builder()
             .msgs(msgs.clone())
-            .zero_fee()
             .pub_key(pub_key)
             .acc_sequence(acc_sequence)
             .build()
-            .unwrap()
             .sign_with(&chain_id, acc_number, |sign_doc| async move {
                 let mut hasher = Sha256::new();
                 hasher.update(sign_doc);
@@ -175,13 +168,11 @@ mod tests {
         let acc_sequence = 1000;
         let msgs = vec![dummy_msg(), dummy_msg(), dummy_msg()];
 
-        let actual_tx = TxBuilder::default()
+        let actual_tx = Tx::builder()
             .msgs(msgs.clone())
-            .zero_fee()
             .pub_key(pub_key)
             .acc_sequence(acc_sequence)
             .build()
-            .unwrap()
             .with_dummy_sig()
             .await
             .unwrap();

--- a/ampd/src/broadcaster/tx.rs
+++ b/ampd/src/broadcaster/tx.rs
@@ -36,6 +36,7 @@ where
     #[builder(default = zero_fee())]
     fee: Fee,
 }
+
 fn zero_fee() -> Fee {
     Fee::from_amount_and_gas(
         Coin {

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -100,7 +100,7 @@ async fn broadcast_tx(
         .expect("failed to convert to account identifier")
         .into();
 
-    broadcaster::BroadcastClientBuilder::default()
+    broadcaster::BroadcastClient::builder()
         .client(service_client)
         .signer(ecdsa_client)
         .query_client(query_client)
@@ -108,7 +108,6 @@ async fn broadcast_tx(
         .config(broadcast)
         .address(address)
         .build()
-        .change_context(Error::Broadcaster)?
         .broadcast(vec![tx])
         .await
         .change_context(Error::Broadcaster)

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -111,15 +111,14 @@ async fn prepare_app(cfg: Config, state: State) -> Result<App<impl Broadcaster>,
         .expect("failed to convert to account identifier")
         .into();
 
-    let broadcaster = broadcaster::BroadcastClientBuilder::default()
+    let broadcaster = broadcaster::BroadcastClient::builder()
         .query_client(query_client)
         .address(worker.clone())
         .client(service_client)
         .signer(ecdsa_client.clone())
         .pub_key((tofnd_config.key_uid, pub_key))
         .config(broadcast.clone())
-        .build()
-        .change_context(Error::Broadcaster)?;
+        .build();
 
     let health_check_server = health_check::Server::new(health_check_bind_addr);
 


### PR DESCRIPTION
The typed-builder crate is compile-time safe instead of just returning an error at runtime if the build fails
