### PR TITLE
refactor(ampd): change the event_sub so that subscribers can be added at runtime

### DIFF
--- a/ampd/src/event_sub.rs
+++ b/ampd/src/event_sub.rs
@@ -1,11 +1,9 @@
-use std::convert::TryInto;
 use std::iter;
 use std::time::Duration;
 
 use error_stack::ResultExt;
 use error_stack::{FutureExt, Report, Result};
 use futures::TryStreamExt;
-use tendermint::abci;
 use tendermint::block;
 use thiserror::Error;
 use tokio::select;
@@ -22,23 +20,35 @@ use events::Event;
 use crate::asyncutil::future::{self, RetryPolicy};
 use crate::tm_client::TmClient;
 
+pub struct EventSubscriber {
+    tx: Sender<Event>,
+}
+
+impl EventSubscriber {
+    pub fn subscribe(&self) -> impl Stream<Item = Result<Event, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.tx.subscribe()).map_err(Report::from)
+    }
+}
+
 pub struct EventPublisher<T: TmClient + Sync> {
-    client: T,
+    tm_client: T,
     start_from: Option<block::Height>,
     poll_interval: Duration,
     tx: Sender<Event>,
 }
 
 impl<T: TmClient + Sync> EventPublisher<T> {
-    pub fn new(client: T, capacity: usize) -> Self {
+    pub fn new(client: T, capacity: usize) -> (Self, EventSubscriber) {
         let (tx, _) = broadcast::channel::<Event>(capacity);
-
-        EventPublisher {
-            client,
+        let publisher = EventPublisher {
+            tm_client: client,
             start_from: None,
             poll_interval: Duration::new(5, 0),
-            tx,
-        }
+            tx: tx.clone(),
+        };
+        let subscriber = EventSubscriber { tx };
+
+        (publisher, subscriber)
     }
 
     pub fn start_from(mut self, height: block::Height) -> Self {
@@ -50,10 +60,6 @@ impl<T: TmClient + Sync> EventPublisher<T> {
     pub fn poll_interval(mut self, poll_interval: Duration) -> Self {
         self.poll_interval = poll_interval;
         self
-    }
-
-    pub fn subscribe(&mut self) -> impl Stream<Item = Result<Event, BroadcastStreamRecvError>> {
-        BroadcastStream::new(self.tx.subscribe()).map_err(Report::from)
     }
 
     pub async fn run(mut self, token: CancellationToken) -> Result<(), EventSubError> {
@@ -79,7 +85,7 @@ impl<T: TmClient + Sync> EventPublisher<T> {
 
     async fn latest_block_height(&self) -> Result<block::Height, EventSubError> {
         let res = self
-            .client
+            .tm_client
             .latest_block()
             .change_context(EventSubError::Rpc)
             .await?;
@@ -112,32 +118,31 @@ impl<T: TmClient + Sync> EventPublisher<T> {
     }
 
     async fn process_block(&self, height: block::Height) -> Result<(), EventSubError> {
+        // skip processing if there are no subscribers
+        if self.tx.receiver_count() == 0 {
+            return Ok(());
+        }
+
         let events = iter::once(Event::BlockBegin(height))
-            .chain(
-                self.events(height)
-                    .await?
-                    .into_iter()
-                    .map(|event| event.try_into())
-                    .collect::<Result<Vec<_>, _>>()
-                    .change_context(EventSubError::Publish)?,
-            )
+            .chain(self.events(height).await?.into_iter())
             .chain(iter::once(Event::BlockEnd(height)));
 
         for event in events {
-            self.tx.send(event).change_context(EventSubError::Publish)?;
+            // ignore the error if there are no subscribers
+            let _ = self.tx.send(event);
         }
 
         Ok(())
     }
 
-    async fn events(&self, block_height: block::Height) -> Result<Vec<abci::Event>, EventSubError> {
+    async fn events(&self, block_height: block::Height) -> Result<Vec<Event>, EventSubError> {
         let block_results = future::with_retry(
             || {
-                self.client
-                    .block_results(block_height)
-                    .change_context(EventSubError::EventQuery {
+                self.tm_client.block_results(block_height).change_context(
+                    EventSubError::EventQuery {
                         block: block_height,
-                    })
+                    },
+                )
             },
             RetryPolicy::RepeatConstant {
                 sleep: Duration::from_secs(1),
@@ -154,10 +159,11 @@ impl<T: TmClient + Sync> EventPublisher<T> {
             .flat_map(|tx| tx.events);
         let end_block_events = block_results.end_block_events.into_iter().flatten();
 
-        Ok(begin_block_events
+        begin_block_events
             .chain(tx_events)
             .chain(end_block_events)
-            .collect())
+            .map(|event| Event::try_from(event).change_context(EventSubError::EventDecoding))
+            .collect()
     }
 }
 
@@ -172,10 +178,10 @@ pub fn skip_to_block<E>(
 pub enum EventSubError {
     #[error("querying events for block {block} failed")]
     EventQuery { block: block::Height },
-    #[error("failed to send events to subscribers")]
-    Publish,
     #[error("failed calling RPC method")]
     Rpc,
+    #[error("decoding event failed")]
+    EventDecoding,
 }
 
 #[cfg(test)]
@@ -186,11 +192,12 @@ mod tests {
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
     use futures::stream::StreamExt;
+    use mockall::predicate::eq;
     use rand::Rng;
     use random_string::generate;
     use tendermint::block;
     use tendermint::{abci, AppHash};
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, oneshot};
     use tokio::test;
     use tokio_stream::wrappers::ReceiverStream;
     use tokio_util::sync::CancellationToken;
@@ -262,12 +269,13 @@ mod tests {
             });
 
         let token = CancellationToken::new();
-        let event_publisher = EventPublisher::new(mock_client, 2 * block_count as usize);
-        let mut client = event_publisher.start_from(from_height);
-        let mut stream = client.subscribe();
+        let (event_publisher, event_subcriber) =
+            EventPublisher::new(mock_client, 2 * block_count as usize);
+        let event_publisher = event_publisher.start_from(from_height);
+        let mut stream = event_subcriber.subscribe();
 
         let child_token = token.child_token();
-        let handle = tokio::spawn(async move { client.run(child_token).await });
+        let handle = tokio::spawn(async move { event_publisher.run(child_token).await });
 
         for height in from_height.value()..to_height.value() {
             let event = stream.next().await;
@@ -321,8 +329,8 @@ mod tests {
             });
 
         let token = CancellationToken::new();
-        let mut event_publisher = EventPublisher::new(mock_client, 10);
-        let mut stream = event_publisher.subscribe();
+        let (event_publisher, event_subcriber) = EventPublisher::new(mock_client, 10);
+        let mut stream = event_subcriber.subscribe();
 
         let child_token = token.child_token();
         let handle = tokio::spawn(async move { event_publisher.run(child_token).await });
@@ -333,6 +341,78 @@ mod tests {
         token.cancel();
 
         assert!(handle.await.is_ok());
+    }
+
+    #[test]
+    async fn should_skip_processing_blocks_when_no_subscriber_exists() {
+        let latest_block: tendermint::Block =
+            serde_json::from_str(include_str!("tests/axelar_block.json")).unwrap();
+        let latest_block_height = latest_block.header.height;
+        let start_from_block_height = (latest_block.header.height.value() - 100)
+            .try_into()
+            .unwrap();
+
+        let (sub_tx, mut sub_rx) = oneshot::channel::<()>();
+        let (pub_tx, mut pub_rx) = mpsc::channel::<i32>(100);
+
+        let mut mock_client = tm_client::MockTmClient::new();
+        let mut call_count = 0;
+        mock_client.expect_latest_block().returning(move || {
+            call_count += 1;
+            let _ = pub_tx.try_send(call_count);
+
+            let mut block = latest_block.clone();
+            if sub_rx.try_recv().is_ok() {
+                block.header.height = block.header.height.increment();
+            }
+
+            Ok(tm_client::BlockResponse {
+                block_id: Default::default(),
+                block,
+            })
+        });
+        let latest_block_height = latest_block_height.increment();
+        mock_client
+            .expect_block_results()
+            .with(eq(latest_block_height))
+            .return_once(|height| {
+                Ok(tm_client::BlockResultsResponse {
+                    height,
+                    begin_block_events: None,
+                    end_block_events: None,
+                    consensus_param_updates: None,
+                    txs_results: None,
+                    validator_updates: vec![],
+                    app_hash: AppHash::default(),
+                    finalize_block_events: vec![],
+                })
+            });
+
+        let token = CancellationToken::new();
+        let (event_publisher, event_subcriber) = EventPublisher::new(mock_client, 100);
+        let event_publisher = event_publisher
+            .start_from(start_from_block_height)
+            .poll_interval(Duration::from_millis(500));
+        let handle = tokio::spawn(event_publisher.run(token.child_token()));
+
+        while let Some(call_count) = pub_rx.recv().await {
+            if call_count >= 2 {
+                break;
+            }
+        }
+        let mut stream = event_subcriber.subscribe();
+        sub_tx.send(()).unwrap();
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            Event::BlockBegin(latest_block_height)
+        );
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            Event::BlockEnd(latest_block_height)
+        );
+
+        token.cancel();
+        handle.await.unwrap().unwrap();
     }
 
     #[test]
@@ -408,14 +488,15 @@ mod tests {
             });
 
         let token = CancellationToken::new();
-        let event_publisher = EventPublisher::new(mock_client, block_count * event_count_per_block);
-        let mut client = event_publisher
+        let (event_publisher, event_subcriber) =
+            EventPublisher::new(mock_client, block_count * event_count_per_block);
+        let event_publisher = event_publisher
             .start_from(block_height)
             .poll_interval(Duration::new(0, 1e7 as u32));
-        let mut stream = client.subscribe();
+        let mut stream = event_subcriber.subscribe();
 
         let child_token = token.child_token();
-        let handle = tokio::spawn(async move { client.run(child_token).await });
+        let handle = tokio::spawn(async move { event_publisher.run(child_token).await });
 
         for i in 1..(block_count * event_count_per_block + 1) {
             let event = stream.next().await;


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
