### PR TITLE
fix(ampd): directly pass interval to queued broadcaster and ignore first tick

### DIFF
--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -12,6 +12,7 @@ use evm::json_rpc::EthereumClient;
 use router_api::ChainName;
 use thiserror::Error;
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -178,7 +179,7 @@ where
             broadcaster,
             broadcast_cfg.batch_gas_limit,
             broadcast_cfg.queue_cap,
-            broadcast_cfg.broadcast_interval,
+            interval(broadcast_cfg.broadcast_interval),
         );
 
         Self {

--- a/ampd/src/queue/queued_broadcaster.rs
+++ b/ampd/src/queue/queued_broadcaster.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use axelar_wasm_std::FnExt;
 use cosmrs::{Any, Gas};
 use error_stack::{self, Report, ResultExt};
 use mockall::automock;
@@ -94,9 +93,8 @@ where
                     Some(msg_and_res_chan) => self.handle_msg(msg_and_res_chan).await?,
                 },
                 _ = self.broadcast_interval.tick() => {
-                    self.broadcast_all().await?.then(|_| {
-                        self.broadcast_interval.reset();
-                    });
+                    self.broadcast_all().await?;
+                    self.broadcast_interval.reset();
                 },
             }
         }


### PR DESCRIPTION
AXE-4240

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
