### PR TITLE
feat(minor-multisig)!: add command to disable all signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,6 +4609,7 @@ dependencies = [
  "getrandom",
  "itertools 0.11.0",
  "k256",
+ "msgs-derive",
  "report",
  "rewards",
  "router-api",

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -54,6 +54,7 @@ error-stack = { workspace = true }
 getrandom = { version = "0.2", default-features = false, features = ["custom"] }
 itertools = "0.11.0"
 k256 = { version = "0.13.1", features = ["ecdsa"] }
+msgs-derive = { workspace = true }
 report = { workspace = true }
 rewards = { workspace = true, features = ["library"] }
 router-api = { workspace = true }

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -1,3 +1,4 @@
+use axelar_wasm_std::{killswitch, permission_control};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -42,8 +43,15 @@ pub fn instantiate(
 ) -> Result<Response, axelar_wasm_std::ContractError> {
     cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
+    let admin = deps.api.addr_validate(&msg.admin_address)?;
+    let governance = deps.api.addr_validate(&msg.governance_address)?;
+
+    permission_control::set_admin(deps.storage, &admin)?;
+    permission_control::set_governance(deps.storage, &governance)?;
+
+    killswitch::init(deps.storage, killswitch::State::Disengaged)?;
+
     let config = Config {
-        governance: deps.api.addr_validate(&msg.governance_address)?,
         rewards_contract: deps.api.addr_validate(&msg.rewards_address)?,
         block_expiry: msg.block_expiry,
     };
@@ -61,13 +69,14 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, axelar_wasm_std::ContractError> {
-    match msg {
+    match msg.ensure_permissions(deps.storage, &info.sender)? {
         ExecuteMsg::StartSigningSession {
             verifier_set_id,
             msg,
             chain_name,
             sig_verifier,
         } => {
+            // TODO: use new permission model
             execute::require_authorized_caller(&deps, info.sender)?;
 
             let sig_verifier = sig_verifier
@@ -95,13 +104,13 @@ pub fn execute(
             signed_sender_address,
         } => execute::register_pub_key(deps, info, public_key, signed_sender_address),
         ExecuteMsg::AuthorizeCaller { contract_address } => {
-            execute::require_governance(&deps, info.sender)?;
             execute::authorize_caller(deps, contract_address)
         }
         ExecuteMsg::UnauthorizeCaller { contract_address } => {
-            execute::require_governance(&deps, info.sender)?;
             execute::unauthorize_caller(deps, contract_address)
         }
+        ExecuteMsg::DisableSigning => execute::disable_signing(deps),
+        ExecuteMsg::EnableSigning => execute::enable_signing(deps),
     }
     .map_err(axelar_wasm_std::ContractError::from)
 }
@@ -139,6 +148,7 @@ mod tests {
         testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage},
         Addr, Empty, OwnedDeps, WasmMsg,
     };
+    use permission_control::Permission;
     use serde_json::from_str;
 
     use router_api::ChainName;
@@ -158,6 +168,8 @@ mod tests {
     const INSTANTIATOR: &str = "inst";
     const PROVER: &str = "prover";
     const REWARDS_CONTRACT: &str = "rewards";
+    const GOVERNANCE: &str = "governance";
+    const ADMIN: &str = "admin";
 
     const SIGNATURE_BLOCK_EXPIRY: u64 = 100;
 
@@ -166,7 +178,8 @@ mod tests {
         let env = mock_env();
 
         let msg = InstantiateMsg {
-            governance_address: "governance".parse().unwrap(),
+            governance_address: GOVERNANCE.parse().unwrap(),
+            admin_address: ADMIN.parse().unwrap(),
             rewards_address: REWARDS_CONTRACT.to_string(),
             block_expiry: SIGNATURE_BLOCK_EXPIRY,
         };
@@ -254,8 +267,7 @@ mod tests {
         deps: DepsMut,
         contract_address: Addr,
     ) -> Result<Response, axelar_wasm_std::ContractError> {
-        let config = CONFIG.load(deps.storage)?;
-        let info = mock_info(config.governance.as_str(), &[]);
+        let info = mock_info(GOVERNANCE, &[]);
         let env = mock_env();
 
         let msg = ExecuteMsg::AuthorizeCaller { contract_address };
@@ -266,11 +278,32 @@ mod tests {
         deps: DepsMut,
         contract_address: Addr,
     ) -> Result<Response, axelar_wasm_std::ContractError> {
-        let config = CONFIG.load(deps.storage)?;
-        let info = mock_info(config.governance.as_str(), &[]);
+        let info = mock_info(GOVERNANCE, &[]);
         let env = mock_env();
 
         let msg = ExecuteMsg::UnauthorizeCaller { contract_address };
+        execute(deps, env, info, msg)
+    }
+
+    fn do_disable_signing(
+        deps: DepsMut,
+        sender: &str,
+    ) -> Result<Response, axelar_wasm_std::ContractError> {
+        let info = mock_info(sender, &[]);
+        let env = mock_env();
+
+        let msg = ExecuteMsg::DisableSigning;
+        execute(deps, env, info, msg)
+    }
+
+    fn do_enable_signing(
+        deps: DepsMut,
+        sender: &str,
+    ) -> Result<Response, axelar_wasm_std::ContractError> {
+        let info = mock_info(sender, &[]);
+        let env = mock_env();
+
+        let msg = ExecuteMsg::EnableSigning;
         execute(deps, env, info, msg)
     }
 
@@ -1025,7 +1058,11 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            axelar_wasm_std::ContractError::from(ContractError::Unauthorized).to_string()
+            axelar_wasm_std::permission_control::Error::PermissionDenied {
+                expected: Permission::Governance.into(),
+                actual: Permission::NoPrivilege.into()
+            }
+            .to_string()
         );
     }
 
@@ -1043,7 +1080,90 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            axelar_wasm_std::ContractError::from(ContractError::Unauthorized).to_string()
+            axelar_wasm_std::permission_control::Error::PermissionDenied {
+                expected: Permission::Governance.into(),
+                actual: Permission::NoPrivilege.into()
+            }
+            .to_string()
         );
+    }
+
+    #[test]
+    fn disable_enable_signing() {
+        let (mut deps, ecdsa_subkey, ed25519_subkey) = setup();
+        let prover_address = Addr::unchecked(PROVER);
+
+        // authorize
+        do_authorize_caller(deps.as_mut(), prover_address.clone()).unwrap();
+
+        do_disable_signing(deps.as_mut(), ADMIN).unwrap();
+
+        for verifier_set_id in [ecdsa_subkey.clone(), ed25519_subkey.clone()] {
+            let res = do_start_signing_session(
+                deps.as_mut(),
+                PROVER,
+                &verifier_set_id,
+                "mock-chain".parse().unwrap(),
+            );
+
+            assert_eq!(
+                res.unwrap_err().to_string(),
+                ContractError::SigningDisabled.to_string()
+            );
+        }
+
+        do_enable_signing(deps.as_mut(), ADMIN).unwrap();
+
+        for verifier_set_id in [ecdsa_subkey.clone(), ed25519_subkey.clone()] {
+            let res = do_start_signing_session(
+                deps.as_mut(),
+                PROVER,
+                &verifier_set_id,
+                "mock-chain".parse().unwrap(),
+            );
+
+            assert!(res.is_ok());
+        }
+    }
+
+    #[test]
+    fn disable_signing_after_session_creation() {
+        let (mut deps, ecdsa_subkey, ed25519_subkey) = setup();
+        do_authorize_caller(deps.as_mut(), Addr::unchecked(PROVER)).unwrap();
+
+        let chain_name: ChainName = "mock-chain".parse().unwrap();
+
+        for (_, verifier_set_id, signers, session_id) in
+            signature_test_data(&ecdsa_subkey, &ed25519_subkey)
+        {
+            do_start_signing_session(deps.as_mut(), PROVER, verifier_set_id, chain_name.clone())
+                .unwrap();
+
+            do_disable_signing(deps.as_mut(), ADMIN).unwrap();
+
+            let signer = signers.first().unwrap().to_owned();
+
+            let res = do_sign(deps.as_mut(), mock_env(), session_id, &signer);
+
+            assert_eq!(
+                res.unwrap_err().to_string(),
+                ContractError::SigningDisabled.to_string()
+            );
+
+            do_enable_signing(deps.as_mut(), ADMIN).unwrap();
+            assert!(do_sign(deps.as_mut(), mock_env(), session_id, &signer).is_ok());
+        }
+    }
+
+    #[test]
+    fn disable_enable_signing_has_correct_permissions() {
+        let mut deps = setup().0;
+
+        assert!(do_disable_signing(deps.as_mut(), "user1").is_err());
+        assert!(do_disable_signing(deps.as_mut(), ADMIN).is_ok());
+        assert!(do_enable_signing(deps.as_mut(), "user").is_err());
+        assert!(do_enable_signing(deps.as_mut(), ADMIN).is_ok());
+        assert!(do_disable_signing(deps.as_mut(), GOVERNANCE).is_ok());
+        assert!(do_enable_signing(deps.as_mut(), GOVERNANCE).is_ok());
     }
 }

--- a/contracts/multisig/src/contract/execute.rs
+++ b/contracts/multisig/src/contract/execute.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{OverflowError, OverflowOperation, WasmMsg};
+use cosmwasm_std::{ensure, OverflowError, OverflowOperation, WasmMsg};
 use router_api::ChainName;
 use sha3::{Digest, Keccak256};
 use signature_verifier_api::client::SignatureVerifier;
@@ -23,7 +23,13 @@ pub fn start_signing_session(
     chain_name: ChainName,
     sig_verifier: Option<Addr>,
 ) -> Result<Response, ContractError> {
+    ensure!(
+        killswitch::is_contract_active(deps.storage),
+        ContractError::SigningDisabled
+    );
+
     let config = CONFIG.load(deps.storage)?;
+
     let verifier_set = get_verifier_set(deps.storage, &verifier_set_id)?;
 
     let session_id = SIGNING_SESSION_COUNTER.update(
@@ -80,6 +86,11 @@ pub fn submit_signature(
     session_id: Uint64,
     signature: HexBinary,
 ) -> Result<Response, ContractError> {
+    ensure!(
+        killswitch::is_contract_active(deps.storage),
+        ContractError::SigningDisabled
+    );
+
     let config = CONFIG.load(deps.storage)?;
     let mut session = SIGNING_SESSIONS
         .load(deps.storage, session_id.into())
@@ -194,12 +205,12 @@ pub fn unauthorize_caller(
     Ok(Response::new().add_event(Event::CallerUnauthorized { contract_address }.into()))
 }
 
-pub fn require_governance(deps: &DepsMut, sender: Addr) -> Result<(), ContractError> {
-    let config = CONFIG.load(deps.storage)?;
-    if config.governance != sender {
-        return Err(ContractError::Unauthorized);
-    }
-    Ok(())
+pub fn enable_signing(deps: DepsMut) -> Result<Response, ContractError> {
+    killswitch::disengage(deps.storage, Event::SigningEnabled).map_err(|err| err.into())
+}
+
+pub fn disable_signing(deps: DepsMut) -> Result<Response, ContractError> {
+    killswitch::engage(deps.storage, Event::SigningDisabled).map_err(|err| err.into())
 }
 
 fn signing_response(

--- a/contracts/multisig/src/error.rs
+++ b/contracts/multisig/src/error.rs
@@ -57,4 +57,7 @@ pub enum ContractError {
 
     #[error("caller is not authorized")]
     Unauthorized,
+
+    #[error("signing is disabled")]
+    SigningDisabled,
 }

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -40,6 +40,8 @@ pub enum Event {
     CallerUnauthorized {
         contract_address: Addr,
     },
+    SigningEnabled,
+    SigningDisabled,
 }
 
 impl From<Event> for cosmwasm_std::Event {
@@ -97,6 +99,8 @@ impl From<Event> for cosmwasm_std::Event {
                 cosmwasm_std::Event::new("caller_unauthorized")
                     .add_attribute("contract_address", contract_address)
             }
+            Event::SigningEnabled => cosmwasm_std::Event::new("signing_enabled"),
+            Event::SigningDisabled => cosmwasm_std::Event::new("signing_disabled"),
         }
     }
 }

--- a/contracts/multisig/src/msg.rs
+++ b/contracts/multisig/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, HexBinary, Uint128, Uint64};
+use msgs_derive::EnsurePermissions;
 use router_api::ChainName;
 
 use crate::{
@@ -12,13 +13,17 @@ use crate::{
 pub struct InstantiateMsg {
     // the governance address is allowed to modify the authorized caller list for this contract
     pub governance_address: String,
+    // The admin address (or governance) is allowed to disable signing. Only governance can re-enable
+    pub admin_address: String,
     pub rewards_address: String,
     pub block_expiry: u64,
 }
 
 #[cw_serde]
+#[derive(EnsurePermissions)]
 pub enum ExecuteMsg {
     // Can only be called by an authorized contract.
+    #[permission(Any)]
     StartSigningSession {
         verifier_set_id: String,
         msg: HexBinary,
@@ -31,13 +36,14 @@ pub enum ExecuteMsg {
         /// [signature_verifier_api::msg]
         sig_verifier: Option<String>,
     },
+    #[permission(Any)]
     SubmitSignature {
         session_id: Uint64,
         signature: HexBinary,
     },
-    RegisterVerifierSet {
-        verifier_set: VerifierSet,
-    },
+    #[permission(Any)]
+    RegisterVerifierSet { verifier_set: VerifierSet },
+    #[permission(Any)]
     RegisterPublicKey {
         public_key: PublicKey,
         /* To prevent anyone from registering a public key that belongs to someone else, we require the sender
@@ -45,13 +51,19 @@ pub enum ExecuteMsg {
         signed_sender_address: HexBinary,
     },
     // Authorizes a contract to call StartSigningSession. Callable only by governance
-    AuthorizeCaller {
-        contract_address: Addr,
-    },
+    #[permission(Governance)]
+    AuthorizeCaller { contract_address: Addr },
     // Unauthorizes a contract, so it can no longer call StartSigningSession. Callable only by governance
-    UnauthorizeCaller {
-        contract_address: Addr,
-    },
+    #[permission(Governance)]
+    UnauthorizeCaller { contract_address: Addr },
+
+    /// Emergency command to stop all amplifier signing
+    #[permission(Elevated)]
+    DisableSigning,
+
+    /// Resumes routing after an emergency shutdown
+    #[permission(Elevated)]
+    EnableSigning,
 }
 
 #[cw_serde]

--- a/contracts/multisig/src/state.rs
+++ b/contracts/multisig/src/state.rs
@@ -13,7 +13,6 @@ use crate::{
 
 #[cw_serde]
 pub struct Config {
-    pub governance: Addr,
     pub rewards_contract: Addr,
     pub block_expiry: u64, // number of blocks after which a signing session expires
 }

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::vec;
 
-use cosmwasm_std::{to_json_binary, Addr, Event, Response, StdError, StdResult, Storage, WasmMsg};
+use axelar_wasm_std::killswitch;
+use cosmwasm_std::{to_json_binary, Addr, Event, Response, StdResult, Storage, WasmMsg};
 use error_stack::{ensure, report, ResultExt};
 use itertools::Itertools;
 
@@ -13,7 +14,7 @@ use router_api::{ChainEndpoint, ChainName, Gateway, GatewayDirection, Message};
 use crate::events::{
     ChainFrozen, ChainRegistered, ChainUnfrozen, GatewayInfo, GatewayUpgraded, MessageRouted,
 };
-use crate::state::{chain_endpoints, Config, State, STATE};
+use crate::state::{chain_endpoints, Config};
 use crate::{events, state};
 
 pub fn register_chain(
@@ -140,41 +141,12 @@ pub fn unfreeze_chains(
     Ok(Response::new().add_events(events))
 }
 
-#[derive(thiserror::Error, Debug)]
-enum StateUpdateError {
-    #[error("router is already in the same state")]
-    SameState,
-    #[error(transparent)]
-    Std(#[from] StdError),
-}
-
 pub fn disable_routing(storage: &mut dyn Storage) -> Result<Response, Error> {
-    let state = STATE.update(storage, |state| match state {
-        State::Enabled => Ok(State::Disabled),
-        State::Disabled => Err(StateUpdateError::SameState),
-    });
-
-    state_toggle_response(state, events::RoutingDisabled)
+    killswitch::engage(storage, events::RoutingDisabled).map_err(|err| err.into())
 }
 
 pub fn enable_routing(storage: &mut dyn Storage) -> Result<Response, Error> {
-    let state = STATE.update(storage, |state| match state {
-        State::Disabled => Ok(State::Enabled),
-        State::Enabled => Err(StateUpdateError::SameState),
-    });
-
-    state_toggle_response(state, events::RoutingEnabled)
-}
-
-fn state_toggle_response(
-    state: Result<State, StateUpdateError>,
-    event: impl Into<Event>,
-) -> Result<Response, Error> {
-    match state {
-        Ok(_) => Ok(Response::new().add_event(event.into())),
-        Err(StateUpdateError::SameState) => Ok(Response::new()),
-        Err(StateUpdateError::Std(err)) => Err(err.into()),
-    }
+    killswitch::disengage(storage, events::RoutingEnabled).map_err(|err| err.into())
 }
 
 fn verify_msg_ids(
@@ -222,7 +194,10 @@ pub fn route_messages(
     sender: Addr,
     msgs: Vec<Message>,
 ) -> error_stack::Result<Response, Error> {
-    ensure!(state::is_enabled(storage), Error::RoutingDisabled);
+    ensure!(
+        killswitch::is_contract_active(storage),
+        Error::RoutingDisabled
+    );
 
     let config = state::load_config(storage)?;
 

--- a/contracts/router/src/contract/query.rs
+++ b/contracts/router/src/contract/query.rs
@@ -37,8 +37,7 @@ pub fn chains(
 
 #[cfg(test)]
 mod test {
-    use crate::state;
-    use crate::state::{chain_endpoints, State, STATE};
+    use crate::state::chain_endpoints;
     use axelar_wasm_std::flagset::FlagSet;
     use cosmwasm_std::{testing::mock_dependencies, Addr};
     use router_api::error::Error;
@@ -130,17 +129,5 @@ mod test {
         let result =
             super::chains(deps.as_ref(), Some("e-chain".parse().unwrap()), Some(2)).unwrap();
         assert_eq!(result.len(), 0);
-    }
-
-    #[test]
-    fn is_enabled() {
-        let mut deps = mock_dependencies();
-        assert!(!state::is_enabled(deps.as_ref().storage));
-
-        STATE.save(deps.as_mut().storage, &State::Disabled).unwrap();
-        assert!(!state::is_enabled(deps.as_ref().storage));
-
-        STATE.save(deps.as_mut().storage, &State::Enabled).unwrap();
-        assert!(state::is_enabled(deps.as_ref().storage));
     }
 }

--- a/contracts/router/src/state.rs
+++ b/contracts/router/src/state.rs
@@ -45,17 +45,6 @@ pub struct Config {
 
 pub const CONFIG: Item<Config> = Item::new("config");
 
-#[cw_serde]
-pub enum State {
-    Enabled,
-    Disabled,
-}
-pub const STATE: Item<State> = Item::new("state");
-
-pub fn is_enabled(storage: &dyn Storage) -> bool {
-    STATE.load(storage).unwrap_or(State::Disabled) == State::Enabled
-}
-
 pub struct ChainEndpointIndexes<'a> {
     pub gateway: GatewayIndex<'a>,
 }

--- a/integration-tests/src/multisig_contract.rs
+++ b/integration-tests/src/multisig_contract.rs
@@ -11,6 +11,7 @@ impl MultisigContract {
     pub fn instantiate_contract(
         app: &mut App,
         governance: Addr,
+        admin: Addr,
         rewards_address: Addr,
         block_expiry: u64,
     ) -> Self {
@@ -28,6 +29,7 @@ impl MultisigContract {
                 &multisig::msg::InstantiateMsg {
                     rewards_address: rewards_address.to_string(),
                     governance_address: governance.to_string(),
+                    admin_address: admin.to_string(),
                     block_expiry,
                 },
                 &[],

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -363,13 +363,13 @@ pub fn setup_protocol(service_name: nonempty::String) -> Protocol {
             .init_balance(storage, &genesis, coins(u128::MAX, AXL_DENOMINATION))
             .unwrap()
     });
-    let router_admin_address = Addr::unchecked("admin");
+    let admin_address = Addr::unchecked("admin");
     let governance_address = Addr::unchecked("governance");
     let nexus_gateway = Addr::unchecked("nexus_gateway");
 
     let router = RouterContract::instantiate_contract(
         &mut app,
-        router_admin_address.clone(),
+        admin_address.clone(),
         governance_address.clone(),
         nexus_gateway.clone(),
     );
@@ -389,6 +389,7 @@ pub fn setup_protocol(service_name: nonempty::String) -> Protocol {
     let multisig = MultisigContract::instantiate_contract(
         &mut app,
         governance_address.clone(),
+        admin_address.clone(),
         rewards.contract_addr.clone(),
         SIGNATURE_BLOCK_EXPIRY,
     );
@@ -403,7 +404,7 @@ pub fn setup_protocol(service_name: nonempty::String) -> Protocol {
         genesis_address: genesis,
         governance_address,
         router,
-        router_admin_address,
+        router_admin_address: admin_address,
         multisig,
         coordinator,
         service_registry,

--- a/packages/axelar-wasm-std/src/killswitch.rs
+++ b/packages/axelar-wasm-std/src/killswitch.rs
@@ -1,0 +1,220 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Event, Response, StdError, StdResult, Storage};
+use cw_storage_plus::Item;
+
+/// This is a generic module to be used as a "killswitch" for any contract.
+/// The killswitch can be set to "engaged" or "disengaged". The contract
+/// can then call `is_contract_active`, which will return true if the killswitch
+/// is disengaged. `init` should be called at contract instantiation to set
+/// the initial state of the killswitch.
+
+#[cw_serde]
+pub enum State {
+    Engaged,
+    Disengaged,
+}
+
+/// Sets the initial state of the killswitch. Should be called during contract instantiation
+pub fn init(storage: &mut dyn cosmwasm_std::Storage, initial_state: State) -> StdResult<()> {
+    STATE.save(storage, &initial_state)
+}
+
+/// Sets the killswitch state to `Engaged`. If the state was previously `Disengaged`,
+/// adds the on_state_changed event to the response. Returns an error if the killswitch
+/// was not initialized via `init`
+pub fn engage(
+    storage: &mut dyn cosmwasm_std::Storage,
+    on_state_change: impl Into<Event>,
+) -> StdResult<Response> {
+    let state = STATE.update(storage, |state| match state {
+        State::Disengaged => Ok(State::Engaged),
+        State::Engaged => Err(KillSwitchUpdateError::SameState),
+    });
+
+    killswitch_update_response(state, on_state_change)
+}
+
+/// Sets the killswitch state to `Disengaged`. If the state was previously `Engaged`,
+/// adds the on_state_changed event to the response. Returns an error if the killswitch
+/// was not initialized via `init`
+pub fn disengage(
+    storage: &mut dyn cosmwasm_std::Storage,
+    on_state_change: impl Into<Event>,
+) -> StdResult<Response> {
+    let state = STATE.update(storage, |state| match state {
+        State::Engaged => Ok(State::Disengaged),
+        State::Disengaged => Err(KillSwitchUpdateError::SameState),
+    });
+
+    killswitch_update_response(state, on_state_change)
+}
+
+/// Returns true if the killswitch state is `Disengaged`. Otherwise returns false.
+/// Returns false if the killswitch was not initialized
+pub fn is_contract_active(storage: &dyn Storage) -> bool {
+    STATE.load(storage).unwrap_or(State::Engaged) == State::Disengaged
+}
+
+#[derive(thiserror::Error, Debug)]
+enum KillSwitchUpdateError {
+    #[error("killswitch is already in the same state")]
+    SameState,
+    #[error(transparent)]
+    Std(#[from] StdError),
+}
+
+fn killswitch_update_response(
+    state: Result<State, KillSwitchUpdateError>,
+    on_state_change: impl Into<Event>,
+) -> StdResult<Response> {
+    match state {
+        Ok(_) => Ok(Response::new().add_event(on_state_change.into())),
+        Err(KillSwitchUpdateError::SameState) => Ok(Response::new()),
+        Err(KillSwitchUpdateError::Std(err)) => Err(err),
+    }
+}
+
+const STATE: Item<State> = Item::new("state");
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{testing::mock_dependencies, Event};
+
+    use crate::killswitch::{disengage, engage, init, is_contract_active, State, STATE};
+
+    enum Events {
+        Engaged,
+        Disengaged,
+    }
+
+    impl From<Events> for Event {
+        fn from(val: Events) -> Event {
+            match val {
+                Events::Engaged => Event::new("engaged"),
+                Events::Disengaged => Event::new("disengaged"),
+            }
+        }
+    }
+
+    #[test]
+    fn init_should_be_able_to_set_state_to_engaged() {
+        let mut deps = mock_dependencies();
+        assert!(STATE.may_load(&deps.storage).unwrap().is_none());
+
+        init(deps.as_mut().storage, State::Engaged).unwrap();
+
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Engaged);
+        assert!(!is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn init_should_be_able_to_set_state_to_disengaged() {
+        let mut deps = mock_dependencies();
+        assert!(STATE.may_load(&deps.storage).unwrap().is_none());
+
+        init(deps.as_mut().storage, State::Disengaged).unwrap();
+
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Disengaged);
+        assert!(is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn is_contract_active_should_return_true_when_disengaged() {
+        let mut deps = mock_dependencies();
+
+        assert!(!is_contract_active(&deps.storage));
+
+        STATE.save(deps.as_mut().storage, &State::Engaged).unwrap();
+
+        assert!(!is_contract_active(&deps.storage));
+
+        STATE
+            .save(deps.as_mut().storage, &State::Disengaged)
+            .unwrap();
+
+        assert!(is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn engage_should_error_when_unset() {
+        let mut deps = mock_dependencies();
+
+        assert!(engage(deps.as_mut().storage, Events::Engaged).is_err());
+    }
+
+    #[test]
+    fn engage_should_correctly_set_state_when_disengaged() {
+        let mut deps = mock_dependencies();
+
+        STATE
+            .save(deps.as_mut().storage, &State::Disengaged)
+            .unwrap();
+        engage(deps.as_mut().storage, Events::Engaged).unwrap();
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Engaged);
+        assert!(!is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn engage_should_correctly_set_state_when_engaged() {
+        let mut deps = mock_dependencies();
+
+        STATE.save(deps.as_mut().storage, &State::Engaged).unwrap();
+        engage(deps.as_mut().storage, Events::Engaged).unwrap();
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Engaged);
+        assert!(!is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn disengage_should_error_when_unset() {
+        let mut deps = mock_dependencies();
+
+        assert!(disengage(deps.as_mut().storage, Events::Disengaged).is_err());
+    }
+
+    #[test]
+    fn disengage_should_correctly_set_state_when_disengaged() {
+        let mut deps = mock_dependencies();
+
+        STATE
+            .save(deps.as_mut().storage, &State::Disengaged)
+            .unwrap();
+        disengage(deps.as_mut().storage, Events::Disengaged).unwrap();
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Disengaged);
+        assert!(is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn disengage_should_correctly_set_state_when_engaged() {
+        let mut deps = mock_dependencies();
+
+        STATE.save(deps.as_mut().storage, &State::Engaged).unwrap();
+        disengage(deps.as_mut().storage, Events::Engaged).unwrap();
+        assert_eq!(STATE.load(&deps.storage).unwrap(), State::Disengaged);
+        assert!(is_contract_active(&deps.storage));
+    }
+
+    #[test]
+    fn engage_and_disengage_should_emit_event_when_state_changes() {
+        let mut deps = mock_dependencies();
+
+        init(deps.as_mut().storage, State::Disengaged).unwrap();
+
+        let engaged_event: Event = Events::Engaged.into();
+        let disengaged_event: Event = Events::Disengaged.into();
+
+        let res = engage(deps.as_mut().storage, Events::Engaged).unwrap();
+        assert!(res.events.into_iter().any(|event| event == engaged_event));
+
+        let res = engage(deps.as_mut().storage, Events::Engaged).unwrap();
+        assert_eq!(res.events.len(), 0);
+
+        let res = disengage(deps.as_mut().storage, Events::Disengaged).unwrap();
+        assert!(res
+            .events
+            .into_iter()
+            .any(|event| event == disengaged_event));
+
+        let res = disengage(deps.as_mut().storage, Events::Disengaged).unwrap();
+        assert_eq!(res.events.len(), 0);
+    }
+}

--- a/packages/axelar-wasm-std/src/lib.rs
+++ b/packages/axelar-wasm-std/src/lib.rs
@@ -12,6 +12,7 @@ pub mod flagset;
 mod fn_ext;
 pub mod hash;
 pub mod hex;
+pub mod killswitch;
 pub mod msg_id;
 pub mod nonempty;
 pub mod permission_control;


### PR DESCRIPTION
adds a generic killswitch module that can be used by any contract (currently router and multisig)

Followups:
- Allow authorize and unauthorize caller to take a list of addresses
- migration of multisig
- use callback in permission control for start signing session, submit signature, and register verifier set

https://axelarnetwork.atlassian.net/browse/AXE-4359
