### PR TITLE
feat: add support for XRPL message ID

### DIFF
--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -99,7 +99,7 @@ pub fn migrate(
 mod test {
     use axelar_wasm_std::msg_id::{
         Base58SolanaTxSignatureAndEventIndex, Base58TxDigestAndEventIndex, HexTxHashAndEventIndex,
-        MessageIdFormat,
+        HexTxHash, MessageIdFormat,
     };
     use axelar_wasm_std::voting::Vote;
     use axelar_wasm_std::{nonempty, MajorityThreshold, Threshold, VerificationStatus};
@@ -207,6 +207,12 @@ mod test {
             MessageIdFormat::HexTxHashAndEventIndex => HexTxHashAndEventIndex {
                 tx_hash: Keccak256::digest(id.as_bytes()).into(),
                 event_index: index,
+            }
+            .to_string()
+            .parse()
+            .unwrap(),
+            MessageIdFormat::HexTxHash => HexTxHash {
+                tx_hash: Keccak256::digest(id.as_bytes()).into(),
             }
             .to_string()
             .parse()

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -3,7 +3,7 @@ use std::vec::Vec;
 
 use axelar_wasm_std::msg_id::{
     Base58SolanaTxSignatureAndEventIndex, Base58TxDigestAndEventIndex, HexTxHashAndEventIndex,
-    MessageIdFormat,
+    HexTxHash, MessageIdFormat,
 };
 use axelar_wasm_std::voting::{PollId, Vote};
 use axelar_wasm_std::{nonempty, VerificationStatus};
@@ -136,6 +136,12 @@ fn parse_message_id(
                 .map_err(|_| ContractError::InvalidMessageID(message_id.into()))?;
 
             Ok((id.tx_hash_as_hex(), id.event_index))
+        }
+        MessageIdFormat::HexTxHash => {
+            let id = HexTxHash::from_str(&message_id)
+                .map_err(|_| ContractError::InvalidMessageID(message_id.into()))?;
+
+            Ok((id.tx_hash_as_hex(), 0))
         }
         MessageIdFormat::Base58SolanaTxSignatureAndEventIndex => {
             let id = Base58SolanaTxSignatureAndEventIndex::from_str(&message_id)

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
@@ -1,0 +1,141 @@
+use core::fmt;
+use std::{fmt::Display, str::FromStr};
+
+use cosmwasm_std::HexBinary;
+use error_stack::{Report, ResultExt};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use super::Error;
+use crate::{hash::Hash, nonempty};
+
+pub struct HexTxHash {
+    pub tx_hash: Hash,
+}
+
+impl HexTxHash {
+    pub fn tx_hash_as_hex(&self) -> nonempty::String {
+        HexBinary::from(self.tx_hash).to_hex()
+            .try_into()
+            .expect("failed to convert tx hash to non-empty string")
+    }
+
+    pub fn new(tx_id: impl Into<[u8; 32]>) -> Self {
+        Self {
+            tx_hash: tx_id.into(),
+        }
+    }
+}
+
+const PATTERN: &str = "^([0-9a-f]{64})$";
+lazy_static! {
+    static ref REGEX: Regex = Regex::new(PATTERN).expect("invalid regex");
+}
+
+impl FromStr for HexTxHash {
+    type Err = Report<Error>;
+
+    fn from_str(message_id: &str) -> Result<Self, Self::Err>
+    where
+        Self: Sized,
+    {
+        // the PATTERN has exactly one capture group, so the group can be extracted safely
+        let (_, [tx_id]) = REGEX
+            .captures(message_id)
+            .ok_or(Error::InvalidMessageID {
+                id: message_id.to_string(),
+                expected_format: PATTERN.to_string(),
+            })?
+            .extract();
+        Ok(HexTxHash {
+            tx_hash: HexBinary::from_hex(&tx_id)
+                .change_context(Error::InvalidTxHash(message_id.to_string()))?
+                .as_slice()
+                .try_into()
+                .map_err(|_| Error::InvalidTxHash(message_id.to_string()))?,
+        })
+    }
+}
+
+impl Display for HexTxHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            HexBinary::from(self.tx_hash).to_hex(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn random_hash() -> String {
+        let mut bytes = vec![];
+        for _ in 0..32 {
+            let byte: u8 = rand::random();
+            bytes.push(byte)
+        }
+        HexBinary::from(bytes).to_hex()
+    }
+
+    #[test]
+    fn should_parse_msg_id() {
+        let res = HexTxHash::from_str(
+            "7cedbb3799cd99636045c84c5c55aef8a138f107ac8ba53a08cad1070ba4385b",
+        );
+        assert!(res.is_ok());
+
+        for _ in 0..1000 {
+            let msg_id = random_hash();
+
+            let res = HexTxHash::from_str(&msg_id);
+            let parsed = res.unwrap();
+            assert_eq!(parsed.tx_hash_as_hex(), msg_id.clone().try_into().unwrap());
+            assert_eq!(parsed.to_string(), msg_id);
+        }
+    }
+
+    #[test]
+    fn should_not_parse_msg_id_with_wrong_length_tx_hash() {
+        let tx_hash = random_hash();
+        // too long
+        let res = HexTxHash::from_str(&format!("{}ff", tx_hash));
+        assert!(res.is_err());
+
+        // too short
+        let res =
+            HexTxHash::from_str(&format!("{}", &tx_hash[..tx_hash.len() - 2]));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn should_not_parse_msg_id_with_uppercase_tx_hash() {
+        let tx_hash = &random_hash();
+        let res = HexTxHash::from_str(&tx_hash.to_uppercase());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn should_not_parse_msg_id_with_non_hex_tx_hash() {
+        let msg_id = "82GKYvWv5EKm7jnYksHoh3u5M2RxHN2boPreM8Df4ej9";
+        let res = HexTxHash::from_str(msg_id);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn should_not_parse_msg_id_with_0x() {
+        let msg_id = "0x7cedbb3799cd99636045c84c5c55aef8a138f107ac8ba53a08cad1070ba4385b-1";
+        let res = HexTxHash::from_str(msg_id);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn should_not_parse_msg_id_with_event_index() {
+        let tx_hash = random_hash();
+        let res = HexTxHash::from_str(&format!("{}-1", tx_hash));
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for a custom XRPL message ID, which comprises of just a 32-byte hash.
To initiate bridging from XRPL, a [`Payment`](https://xrpl.org/docs/references/protocol/transactions/types/payment/) transaction is made into an XRPL multisig (which can be though of as a replacement for the `AxelarGateway`).
Since XRPL does not support batched transactions, there can only be one bridging transaction per XRPL transaction, so an event index is redundant.

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes

We do not have full context of all the moving pieces that this PR affects. Please review and let us know if you see any issues or recommend any changes.