### PR TITLE
feat(minor-router)!: change u32 to u64 in message ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 #### Migration Notes
 
-The voting verifier contracts must be migrated before ampd is upgraded.
+The voting verifier contracts must be migrated before ampd is upgraded. Existing ampd instances will continue to work even after the contract migration, but we recommend upgrading ampd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased](https://github.com/axelarnetwork/axelar-amplifier/tree/HEAD)
+
+[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.2.0..HEAD)
+
+- Change event index in message ids from u32 to u64. Emit message id from voting verifier
+
+#### Migration Notes
+
+The voting verifier contracts must be migrated before ampd is upgraded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.2.0..HEAD)
 
-- Change event index in message ids from u32 to u64. Emit message id from voting verifier
+- Change event index in message ids from u32 to u64. Emit message id from voting verifier [#666](https://github.com/axelarnetwork/axelar-amplifier/pull/666)
 
 #### Migration Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "router-api",
  "serde",
  "serde_json",
- "serde_with 3.8.1",
+ "serde_with 3.11.0",
  "service-registry-api",
  "sha3",
  "stellar",
@@ -857,6 +857,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_with 3.11.0",
  "sha3",
  "stellar-xdr",
  "strum 0.25.0",
@@ -7497,9 +7498,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7509,7 +7510,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.8.1",
+ "serde_with_macros 3.11.0",
  "time",
 ]
 
@@ -7527,9 +7528,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.9",
  "proc-macro2 1.0.85",
@@ -7933,7 +7934,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "serde_with 3.8.1",
+ "serde_with 3.11.0",
  "stellar-strkey 0.0.8",
 ]
 

--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -196,6 +196,18 @@ mod tests {
     }
 
     #[test]
+    fn should_not_verify_verifier_set_if_log_index_greater_than_u32_max() {
+        let (gateway_address, tx_receipt, mut verifier_set) =
+            matching_verifier_set_and_tx_receipt();
+
+        verifier_set.message_id.event_index = u32::MAX as u64 + 1;
+        assert_eq!(
+            verify_verifier_set(&gateway_address, &tx_receipt, &verifier_set),
+            Vote::NotFound
+        );
+    }
+
+    #[test]
     fn should_not_verify_verifier_set_if_verifier_set_does_not_match() {
         let (gateway_address, tx_receipt, mut verifier_set) =
             matching_verifier_set_and_tx_receipt();
@@ -265,6 +277,17 @@ mod tests {
             Vote::NotFound
         );
         msg.message_id.event_index = 3;
+        assert_eq!(
+            verify_message(&gateway_address, &tx_receipt, &msg),
+            Vote::NotFound
+        );
+    }
+
+    #[test]
+    fn should_not_verify_msg_if_log_index_greater_than_u32_max() {
+        let (gateway_address, tx_receipt, mut msg) = matching_msg_and_tx_receipt();
+
+        msg.message_id.event_index = u32::MAX as u64 + 1;
         assert_eq!(
             verify_message(&gateway_address, &tx_receipt, &msg),
             Vote::NotFound

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -174,7 +174,8 @@ where
 
         let tx_hashes: HashSet<Hash> = messages
             .iter()
-            .map(|msg| msg.message_id.tx_hash.into()).collect();
+            .map(|msg| msg.message_id.tx_hash.into())
+            .collect();
         let finalized_tx_receipts = self
             .finalized_tx_receipts(tx_hashes, confirmation_height)
             .await?;

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -247,7 +247,7 @@ mod tests {
     use crate::PREFIX;
 
     fn poll_started_event(participants: Vec<TMAddress>, expires_at: u64) -> PollStarted {
-        let msg_ids = vec![
+        let msg_ids = [
             HexTxHashAndEventIndex::new(Hash::random(), 0u64),
             HexTxHashAndEventIndex::new(Hash::random(), 1u64),
             HexTxHashAndEventIndex::new(Hash::random(), 10u64),
@@ -266,10 +266,11 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below events use the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             messages: vec![
                 TxEventConfirmation {
                     tx_id: msg_ids[0].tx_hash_as_hex(),
-                    event_index: msg_ids[0].event_index as u32,
+                    event_index: u32::try_from(msg_ids[0].event_index).unwrap(),
                     message_id: msg_ids[0].to_string().parse().unwrap(),
                     source_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
@@ -278,7 +279,7 @@ mod tests {
                 },
                 TxEventConfirmation {
                     tx_id: msg_ids[1].tx_hash_as_hex(),
-                    event_index: msg_ids[1].event_index as u32,
+                    event_index: u32::try_from(msg_ids[1].event_index).unwrap(),
                     message_id: msg_ids[1].to_string().parse().unwrap(),
                     source_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
@@ -287,7 +288,7 @@ mod tests {
                 },
                 TxEventConfirmation {
                     tx_id: msg_ids[2].tx_hash_as_hex(),
-                    event_index: msg_ids[2].event_index as u32,
+                    event_index: u32::try_from(msg_ids[2].event_index).unwrap(),
                     message_id: msg_ids[2].to_string().parse().unwrap(),
                     source_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),

--- a/ampd/src/handlers/evm_verify_verifier_set.rs
+++ b/ampd/src/handlers/evm_verify_verifier_set.rs
@@ -272,9 +272,10 @@ mod tests {
     fn poll_started_event(participants: Vec<TMAddress>, expires_at: u64) -> PollStarted {
         let msg_id = HexTxHashAndEventIndex::new(Hash::random(), 100u64);
         PollStarted::VerifierSet {
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             verifier_set: VerifierSetConfirmation {
                 tx_id: msg_id.tx_hash_as_hex(),
-                event_index: msg_id.event_index as u32,
+                event_index: u32::try_from(msg_id.event_index).unwrap(),
                 message_id: msg_id.to_string().parse().unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ecdsa, &ecdsa_test_data::signers()),
             },

--- a/ampd/src/handlers/evm_verify_verifier_set.rs
+++ b/ampd/src/handlers/evm_verify_verifier_set.rs
@@ -30,8 +30,7 @@ type Result<T> = error_stack::Result<T, Error>;
 
 #[derive(Deserialize, Debug)]
 pub struct VerifierSetConfirmation {
-    pub tx_id: Hash,
-    pub event_index: u32,
+    pub message_id: HexTxHashAndEventIndex,
     pub verifier_set: VerifierSet,
 }
 
@@ -166,14 +165,13 @@ where
         }
 
         let tx_receipt = self
-            .finalized_tx_receipt(verifier_set.tx_id, confirmation_height)
+            .finalized_tx_receipt(verifier_set.message_id.tx_hash.into(), confirmation_height)
             .await?;
         let vote = info_span!(
             "verify a new verifier set for an EVM chain",
             poll_id = poll_id.to_string(),
             source_chain = source_chain.to_string(),
-            id = HexTxHashAndEventIndex::new(verifier_set.tx_id, verifier_set.event_index)
-                .to_string()
+            id = verifier_set.message_id.to_string()
         )
         .in_scope(|| {
             info!("ready to verify a new verifier set in poll");
@@ -201,6 +199,7 @@ mod tests {
     use std::convert::TryInto;
     use std::str::FromStr;
 
+    use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
     use error_stack::{Report, Result};
@@ -271,10 +270,12 @@ mod tests {
     }
 
     fn poll_started_event(participants: Vec<TMAddress>, expires_at: u64) -> PollStarted {
+        let msg_id = HexTxHashAndEventIndex::new(Hash::random(), 100u64);
         PollStarted::VerifierSet {
             verifier_set: VerifierSetConfirmation {
-                tx_id: format!("0x{:x}", Hash::random()).parse().unwrap(),
-                event_index: 100,
+                tx_id: msg_id.tx_hash_as_hex(),
+                event_index: msg_id.event_index as u32,
+                message_id: msg_id.to_string().parse().unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ecdsa, &ecdsa_test_data::signers()),
             },
             metadata: PollMetadata {

--- a/ampd/src/handlers/mvx_verify_msg.rs
+++ b/ampd/src/handlers/mvx_verify_msg.rs
@@ -321,6 +321,12 @@ mod tests {
                     .parse()
                     .unwrap(),
                 event_index: 1,
+                message_id: format!(
+                    "0xdfaf64de66510723f2efbacd7ead3c4f8c856aed1afc2cb30254552aeda47312-1"
+                )
+                .to_string()
+                .parse()
+                .unwrap(),
                 source_address: "erd1qqqqqqqqqqqqqpgqzqvm5ywqqf524efwrhr039tjs29w0qltkklsa05pk7"
                     .parse()
                     .unwrap(),

--- a/ampd/src/handlers/mvx_verify_msg.rs
+++ b/ampd/src/handlers/mvx_verify_msg.rs
@@ -316,14 +316,14 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             messages: vec![TxEventConfirmation {
                 tx_id: "dfaf64de66510723f2efbacd7ead3c4f8c856aed1afc2cb30254552aeda47312"
                     .parse()
                     .unwrap(),
                 event_index: 1,
-                message_id: format!(
+                message_id:
                     "0xdfaf64de66510723f2efbacd7ead3c4f8c856aed1afc2cb30254552aeda47312-1"
-                )
                 .to_string()
                 .parse()
                 .unwrap(),

--- a/ampd/src/handlers/mvx_verify_verifier_set.rs
+++ b/ampd/src/handlers/mvx_verify_verifier_set.rs
@@ -348,6 +348,10 @@ mod tests {
                     .parse()
                     .unwrap(),
                 event_index: 1,
+                message_id: "dfaf64de66510723f2efbacd7ead3c4f8c856aed1afc2cb30254552aeda47312-1"
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ed25519, &ed25519_test_data::signers()),
             },
         }

--- a/ampd/src/handlers/mvx_verify_verifier_set.rs
+++ b/ampd/src/handlers/mvx_verify_verifier_set.rs
@@ -343,6 +343,7 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             verifier_set: VerifierSetConfirmation {
                 tx_id: "dfaf64de66510723f2efbacd7ead3c4f8c856aed1afc2cb30254552aeda47312"
                     .parse()

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -318,9 +318,11 @@ mod tests {
             messages: (0..2)
                 .map(|i| {
                     let msg_id = HexTxHashAndEventIndex::new(Hash::random(), i as u64);
+                    #[allow(deprecated)]
+                    // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
                     TxEventConfirmation {
                         tx_id: msg_id.tx_hash_as_hex(),
-                        event_index: msg_id.event_index as u32,
+                        event_index: u32::try_from(msg_id.event_index).unwrap(),
                         message_id: msg_id.to_string().parse().unwrap(),
                         source_address: ScAddress::Contract(stellar_xdr::curr::Hash::from(
                             Hash::random().0,

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 
 use async_trait::async_trait;
+use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -11,8 +12,7 @@ use events::Event;
 use events_derive::try_from;
 use prost_types::Any;
 use router_api::ChainName;
-use serde::de::Error as DeserializeError;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
 use stellar_xdr::curr::{ScAddress, ScBytes, ScString};
 use tokio::sync::watch::Receiver;
@@ -27,24 +27,10 @@ use crate::stellar::http_client::Client;
 use crate::stellar::verifier::verify_message;
 use crate::types::TMAddress;
 
-pub fn deserialize_tx_id<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let tx_id = String::deserialize(deserializer)?;
-
-    tx_id
-        .strip_prefix("0x")
-        .map(String::from)
-        .ok_or(D::Error::custom(Error::DeserializeEvent))
-}
-
 #[serde_as]
 #[derive(Deserialize, Debug, Clone)]
 pub struct Message {
-    #[serde(deserialize_with = "deserialize_tx_id")]
-    pub tx_id: String,
-    pub event_index: u32,
+    pub message_id: HexTxHashAndEventIndex,
     pub destination_address: ScString,
     pub destination_chain: ScString,
     #[serde_as(as = "DisplayFromStr")]
@@ -132,7 +118,7 @@ impl EventHandler for Handler {
 
         let tx_hashes: HashSet<_> = messages
             .iter()
-            .map(|message| message.tx_id.clone())
+            .map(|message| message.message_id.tx_hash_as_hex_no_prefix().to_string())
             .collect();
 
         let transaction_responses = self
@@ -143,7 +129,7 @@ impl EventHandler for Handler {
 
         let message_ids = messages
             .iter()
-            .map(|message| format!("{}-{}", message.tx_id.clone(), message.event_index))
+            .map(|message| message.message_id.to_string())
             .collect::<Vec<_>>();
 
         let votes = info_span!(
@@ -159,7 +145,7 @@ impl EventHandler for Handler {
                 .iter()
                 .map(|msg| {
                     transaction_responses
-                        .get(&msg.tx_id)
+                        .get(&msg.message_id.tx_hash_as_hex_no_prefix().to_string())
                         .map_or(Vote::NotFound, |tx_response| {
                             verify_message(&source_gateway_address, tx_response, msg)
                         })
@@ -185,6 +171,7 @@ mod tests {
     use std::collections::HashMap;
     use std::convert::TryInto;
 
+    use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
     use cosmrs::cosmwasm::MsgExecuteContract;
     use cosmrs::tx::Msg;
     use error_stack::Result;
@@ -329,18 +316,24 @@ mod tests {
                     .collect(),
             },
             messages: (0..2)
-                .map(|i| TxEventConfirmation {
-                    tx_id: format!("0x{:x}", Hash::random()).parse().unwrap(),
-                    event_index: i,
-                    source_address: ScAddress::Contract(stellar_xdr::curr::Hash::from(
-                        Hash::random().0,
-                    ))
-                    .to_string()
-                    .try_into()
-                    .unwrap(),
-                    destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
-                    payload_hash: Hash::random().to_fixed_bytes(),
+                .map(|i| {
+                    let msg_id = HexTxHashAndEventIndex::new(Hash::random(), i as u64);
+                    TxEventConfirmation {
+                        tx_id: msg_id.tx_hash_as_hex(),
+                        event_index: msg_id.event_index as u32,
+                        message_id: msg_id.to_string().parse().unwrap(),
+                        source_address: ScAddress::Contract(stellar_xdr::curr::Hash::from(
+                            Hash::random().0,
+                        ))
+                        .to_string()
+                        .try_into()
+                        .unwrap(),
+                        destination_chain: "ethereum".parse().unwrap(),
+                        destination_address: format!("0x{:x}", EVMAddress::random())
+                            .parse()
+                            .unwrap(),
+                        payload_hash: Hash::random().to_fixed_bytes(),
+                    }
                 })
                 .collect::<Vec<_>>(),
         }

--- a/ampd/src/handlers/stellar_verify_verifier_set.rs
+++ b/ampd/src/handlers/stellar_verify_verifier_set.rs
@@ -297,9 +297,10 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             verifier_set: VerifierSetConfirmation {
                 tx_id: msg_id.tx_hash_as_hex(),
-                event_index: msg_id.event_index as u32,
+                event_index: u32::try_from(msg_id.event_index).unwrap(),
                 message_id: msg_id.to_string().parse().unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ed25519, &ed25519_test_data::signers()),
             },

--- a/ampd/src/handlers/stellar_verify_verifier_set.rs
+++ b/ampd/src/handlers/stellar_verify_verifier_set.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 
 use async_trait::async_trait;
+use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -18,7 +19,6 @@ use tracing::{info, info_span};
 use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
-use super::stellar_verify_msg::deserialize_tx_id;
 use crate::event_processor::EventHandler;
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
@@ -28,9 +28,7 @@ use crate::types::TMAddress;
 
 #[derive(Deserialize, Debug)]
 pub struct VerifierSetConfirmation {
-    #[serde(deserialize_with = "deserialize_tx_id")]
-    pub tx_id: String,
-    pub event_index: u32,
+    pub message_id: HexTxHashAndEventIndex,
     pub verifier_set: VerifierSet,
 }
 
@@ -112,14 +110,19 @@ impl EventHandler for Handler {
 
         let transaction_response = self
             .http_client
-            .transaction_response(verifier_set.tx_id.clone())
+            .transaction_response(
+                verifier_set
+                    .message_id
+                    .tx_hash_as_hex_no_prefix()
+                    .to_string(),
+            )
             .await
             .change_context(Error::TxReceipts)?;
 
         let vote = info_span!(
             "verify a new verifier set",
             poll_id = poll_id.to_string(),
-            id = format!("0x{}-{}", verifier_set.tx_id, verifier_set.event_index),
+            id = verifier_set.message_id.to_string(),
         )
         .in_scope(|| {
             info!("ready to verify verifier set in poll",);
@@ -147,6 +150,7 @@ impl EventHandler for Handler {
 mod tests {
     use std::convert::TryInto;
 
+    use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
     use cosmrs::cosmwasm::MsgExecuteContract;
     use cosmrs::tx::Msg;
     use error_stack::Result;
@@ -275,6 +279,7 @@ mod tests {
     }
 
     fn poll_started_event(participants: Vec<TMAddress>, expires_at: u64) -> PollStarted {
+        let msg_id = HexTxHashAndEventIndex::new(Hash::random(), 0u64);
         PollStarted::VerifierSet {
             metadata: PollMetadata {
                 poll_id: "100".parse().unwrap(),
@@ -293,8 +298,9 @@ mod tests {
                     .collect(),
             },
             verifier_set: VerifierSetConfirmation {
-                tx_id: format!("0x{:x}", Hash::random()).parse().unwrap(),
-                event_index: 0,
+                tx_id: msg_id.tx_hash_as_hex(),
+                event_index: msg_id.event_index as u32,
+                message_id: msg_id.to_string().parse().unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ed25519, &ed25519_test_data::signers()),
             },
         }

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -342,9 +342,10 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             messages: vec![TxEventConfirmation {
                 tx_id: msg_id.tx_digest_as_base58(),
-                event_index: msg_id.event_index as u32,
+                event_index: u32::try_from(msg_id.event_index).unwrap(),
                 message_id: msg_id.to_string().parse().unwrap(),
                 source_address: SuiAddress::random_for_testing_only()
                     .to_string()

--- a/ampd/src/handlers/sui_verify_verifier_set.rs
+++ b/ampd/src/handlers/sui_verify_verifier_set.rs
@@ -240,9 +240,10 @@ mod tests {
                     .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
                     .collect(),
             },
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
             verifier_set: VerifierSetConfirmation {
                 tx_id: msg_id.tx_digest_as_base58(),
-                event_index: msg_id.event_index as u32,
+                event_index: u32::try_from(msg_id.event_index).unwrap(),
                 message_id: msg_id.to_string().parse().unwrap(),
                 verifier_set: build_verifier_set(KeyType::Ecdsa, &ecdsa_test_data::signers()),
             },

--- a/ampd/src/stellar/http_client.rs
+++ b/ampd/src/stellar/http_client.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 
 use error_stack::{report, Result};
 use futures::future::join_all;
-use num_traits::cast;
 use stellar_rs::horizon_client::HorizonClient;
 use stellar_rs::transactions::prelude::{SingleTransactionRequest, TransactionResponse};
 use stellar_xdr::curr::{ContractEvent, Limits, ReadXdr, ScAddress, TransactionMeta, VecM};
@@ -53,10 +52,10 @@ impl TxResponse {
         !self.successful
     }
 
-    pub fn event(&self, index: u32) -> Option<&ContractEvent> {
+    pub fn event(&self, index: u64) -> Option<&ContractEvent> {
         match self.contract_events {
             Some(ref events) => {
-                let log_index: usize = cast(index).expect("event index must be a valid usize");
+                let log_index = usize::try_from(index).ok()?;
                 events.get(log_index)
             }
             None => None,

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -74,8 +74,8 @@ pub fn verify_message(gateway_address: &ScAddress, tx_receipt: &TxResponse, msg:
         gateway_address,
         tx_receipt,
         msg,
-        msg.tx_id.clone(),
-        msg.event_index,
+        msg.message_id.tx_hash_as_hex_no_prefix().to_string(),
+        msg.message_id.event_index,
     )
 }
 
@@ -88,8 +88,11 @@ pub fn verify_verifier_set(
         gateway_address,
         tx_receipt,
         verifier_set_confirmation,
-        verifier_set_confirmation.tx_id.clone(),
-        verifier_set_confirmation.event_index,
+        verifier_set_confirmation
+            .message_id
+            .tx_hash_as_hex_no_prefix()
+            .to_string(),
+        verifier_set_confirmation.message_id.event_index,
     )
 }
 
@@ -98,7 +101,7 @@ fn verify<'a>(
     tx_receipt: &'a TxResponse,
     to_verify: impl PartialEq<&'a ContractEventBody>,
     expected_tx_id: String,
-    expected_event_index: u32,
+    expected_event_index: u64,
 ) -> Vote {
     if expected_tx_id != tx_receipt.transaction_hash {
         return Vote::NotFound;
@@ -126,6 +129,7 @@ fn verify<'a>(
 mod test {
     use std::str::FromStr;
 
+    use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
     use axelar_wasm_std::voting::Vote;
     use cosmrs::tx::MessageExt;
     use cosmwasm_std::{Addr, HexBinary, Uint128};
@@ -152,7 +156,7 @@ mod test {
     #[test]
     fn should_not_verify_msg_if_tx_id_does_not_match() {
         let (gateway_address, tx_response, mut msg) = matching_msg_and_tx_block();
-        msg.tx_id = "different_tx_hash".to_string();
+        msg.message_id.tx_hash = Hash::random().into();
 
         assert_eq!(
             verify_message(&gateway_address, &tx_response, &msg),
@@ -163,7 +167,7 @@ mod test {
     #[test]
     fn should_not_verify_msg_if_event_index_does_not_match() {
         let (gateway_address, tx_response, mut msg) = matching_msg_and_tx_block();
-        msg.event_index = 1;
+        msg.message_id.event_index = 1;
 
         assert_eq!(
             verify_message(&gateway_address, &tx_response, &msg),
@@ -236,7 +240,7 @@ mod test {
     #[test]
     fn should_not_verify_verifier_set_if_tx_id_does_not_match() {
         let (gateway_address, tx_response, mut confirmation) = matching_verifier_set_and_tx_block();
-        confirmation.tx_id = "different_tx_hash".to_string();
+        confirmation.message_id.tx_hash = Hash::random().into();
 
         assert_eq!(
             verify_verifier_set(&gateway_address, &tx_response, &confirmation),
@@ -247,7 +251,7 @@ mod test {
     #[test]
     fn should_not_verify_verifier_set_if_event_index_does_not_match() {
         let (gateway_address, tx_response, mut confirmation) = matching_verifier_set_and_tx_block();
-        confirmation.event_index = 1;
+        confirmation.message_id.event_index = 1;
 
         assert_eq!(
             verify_verifier_set(&gateway_address, &tx_response, &confirmation),
@@ -292,8 +296,7 @@ mod test {
         let signing_key = SigningKey::generate(&mut OsRng);
 
         let msg = Message {
-            tx_id: format!("{:x}", Hash::random()),
-            event_index: 0,
+            message_id: HexTxHashAndEventIndex::new(Hash::random(), 0u64),
             source_address: ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(
                 Uint256::from(signing_key.verifying_key().to_bytes()),
             ))),
@@ -326,7 +329,7 @@ mod test {
         };
 
         let tx_response = TxResponse {
-            transaction_hash: msg.tx_id.clone(),
+            transaction_hash: msg.message_id.tx_hash_as_hex_no_prefix().to_string(),
             source_address: msg.source_address.clone(),
             successful: true,
             contract_events: Some(vec![event].try_into().unwrap()),
@@ -344,8 +347,7 @@ mod test {
         let threshold = Uint128::new(2u128);
 
         let verifier_set_confirmation = VerifierSetConfirmation {
-            tx_id: format!("{:x}", Hash::random()),
-            event_index: 0,
+            message_id: HexTxHashAndEventIndex::new(Hash::random(), 0u64),
             verifier_set: VerifierSet {
                 signers: signers
                     .iter()
@@ -383,7 +385,10 @@ mod test {
         };
 
         let tx_response = TxResponse {
-            transaction_hash: verifier_set_confirmation.tx_id.clone(),
+            transaction_hash: verifier_set_confirmation
+                .message_id
+                .tx_hash_as_hex_no_prefix()
+                .to_string(),
             source_address: ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(
                 Uint256::from(SigningKey::generate(&mut OsRng).verifying_key().to_bytes()),
             ))),

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -286,7 +286,7 @@ mod test {
 
         let id = HexTxHashAndEventIndex {
             tx_hash: bytes,
-            event_index: random::<u32>(),
+            event_index: random::<u64>(),
         }
         .to_string();
 

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -72,7 +72,7 @@ pub fn execute(
         } => Ok(execute::verify_verifier_set(
             deps,
             env,
-            &message_id,
+            message_id,
             new_verifier_set,
         )?),
         ExecuteMsg::UpdateVotingThreshold {
@@ -232,7 +232,7 @@ mod test {
         deps
     }
 
-    fn message_id(id: &str, index: u32, msg_id_format: &MessageIdFormat) -> nonempty::String {
+    fn message_id(id: &str, index: u64, msg_id_format: &MessageIdFormat) -> nonempty::String {
         match msg_id_format {
             MessageIdFormat::HexTxHashAndEventIndex => HexTxHashAndEventIndex {
                 tx_hash: Keccak256::digest(id.as_bytes()).into(),
@@ -266,7 +266,7 @@ mod test {
         }
     }
 
-    fn messages(len: u32, msg_id_format: &MessageIdFormat) -> Vec<Message> {
+    fn messages(len: u64, msg_id_format: &MessageIdFormat) -> Vec<Message> {
         (0..len)
             .map(|i| Message {
                 cc_id: CrossChainId::new(source_chain(), message_id("id", i, msg_id_format))
@@ -477,7 +477,7 @@ mod test {
         let mut deps = setup(verifiers.clone(), &msg_id_format);
         let messages_count = 5;
         let messages_in_progress = 3;
-        let messages = messages(messages_count as u32, &msg_id_format);
+        let messages = messages(messages_count as u64, &msg_id_format);
 
         execute(
             deps.as_mut(),

--- a/contracts/voting-verifier/src/contract/execute.rs
+++ b/contracts/voting-verifier/src/contract/execute.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use axelar_wasm_std::address::{validate_address, AddressFormat};
 use axelar_wasm_std::utils::TryMapExt;
 use axelar_wasm_std::voting::{PollId, PollResults, Vote, WeightedPoll};
-use axelar_wasm_std::{snapshot, MajorityThreshold, VerificationStatus};
+use axelar_wasm_std::{nonempty, snapshot, MajorityThreshold, VerificationStatus};
 use cosmwasm_std::{
     to_json_binary, Deps, DepsMut, Env, Event, MessageInfo, OverflowError, OverflowOperation,
     Response, Storage, WasmMsg,
@@ -43,7 +43,7 @@ pub fn update_voting_threshold(
 pub fn verify_verifier_set(
     deps: DepsMut,
     env: Env,
-    message_id: &str,
+    message_id: nonempty::String,
     new_verifier_set: VerifierSet,
 ) -> Result<Response, ContractError> {
     let status = verifier_set_status(deps.as_ref(), &new_verifier_set, env.block.height)?;

--- a/contracts/voting-verifier/src/contract/query.rs
+++ b/contracts/voting-verifier/src/contract/query.rs
@@ -300,7 +300,7 @@ mod tests {
             )
             .unwrap();
 
-        let messages = (0..poll.poll_size as u32).map(message);
+        let messages = (0..poll.poll_size as u64).map(message);
         messages.clone().enumerate().for_each(|(idx, msg)| {
             poll_messages()
                 .save(
@@ -321,7 +321,7 @@ mod tests {
         );
     }
 
-    fn message(id: u32) -> Message {
+    fn message(id: u64) -> Message {
         Message {
             cc_id: CrossChainId::new(
                 "source-chain",

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -136,12 +136,16 @@ impl From<PollStarted> for Event {
 
 #[cw_serde]
 pub struct VerifierSetConfirmation {
+    #[deprecated(since = "1.1.0", note = "use message_id field instead")]
     pub tx_id: nonempty::String,
+    #[deprecated(since = "1.1.0", note = "use message_id field instead")]
     pub event_index: u32,
+    pub message_id: nonempty::String,
     pub verifier_set: VerifierSet,
 }
 
 /// If parsing is successful, returns (tx_id, event_index). Otherwise returns ContractError::InvalidMessageID
+#[deprecated(since = "1.1.0", note = "don't parse message id, just emit as is")]
 fn parse_message_id(
     message_id: &str,
     msg_id_format: &MessageIdFormat,
@@ -150,19 +154,31 @@ fn parse_message_id(
         MessageIdFormat::Base58TxDigestAndEventIndex => {
             let id = Base58TxDigestAndEventIndex::from_str(message_id)
                 .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?;
-            Ok((id.tx_digest_as_base58(), id.event_index))
+            Ok((
+                id.tx_digest_as_base58(),
+                u32::try_from(id.event_index)
+                    .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?,
+            ))
         }
         MessageIdFormat::HexTxHashAndEventIndex => {
             let id = HexTxHashAndEventIndex::from_str(message_id)
                 .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?;
 
-            Ok((id.tx_hash_as_hex(), id.event_index))
+            Ok((
+                id.tx_hash_as_hex(),
+                u32::try_from(id.event_index)
+                    .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?,
+            ))
         }
         MessageIdFormat::Base58SolanaTxSignatureAndEventIndex => {
             let id = Base58SolanaTxSignatureAndEventIndex::from_str(message_id)
                 .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?;
 
-            Ok((id.signature_as_base58(), id.event_index))
+            Ok((
+                id.signature_as_base58(),
+                u32::try_from(id.event_index)
+                    .map_err(|_| ContractError::InvalidMessageID(message_id.to_string()))?,
+            ))
         }
         MessageIdFormat::HexTxHash => {
             let id = HexTxHash::from_str(message_id)
@@ -175,15 +191,16 @@ fn parse_message_id(
 
 impl VerifierSetConfirmation {
     pub fn new(
-        message_id: &str,
+        message_id: nonempty::String,
         msg_id_format: MessageIdFormat,
         verifier_set: VerifierSet,
     ) -> Result<Self, ContractError> {
-        let (tx_id, event_index) = parse_message_id(message_id, &msg_id_format)?;
+        let (tx_id, event_index) = parse_message_id(&message_id, &msg_id_format)?;
 
         Ok(Self {
             tx_id,
             event_index,
+            message_id,
             verifier_set,
         })
     }
@@ -191,8 +208,11 @@ impl VerifierSetConfirmation {
 
 #[cw_serde]
 pub struct TxEventConfirmation {
+    #[deprecated(since = "1.1.0", note = "use message_id field instead")]
     pub tx_id: nonempty::String,
+    #[deprecated(since = "1.1.0", note = "use message_id field instead")]
     pub event_index: u32,
+    pub message_id: nonempty::String,
     pub destination_address: Address,
     pub destination_chain: ChainName,
     pub source_address: Address,
@@ -211,6 +231,7 @@ impl TryFrom<(Message, &MessageIdFormat)> for TxEventConfirmation {
         Ok(TxEventConfirmation {
             tx_id,
             event_index,
+            message_id: msg.cc_id.message_id,
             destination_address: msg.destination_address,
             destination_chain: msg.destination_chain,
             source_address: msg.source_address,
@@ -339,7 +360,7 @@ mod test {
                 .unwrap();
 
         assert_eq!(event.tx_id, msg_id.tx_hash_as_hex());
-        assert_eq!(event.event_index, msg_id.event_index);
+        assert_eq!(event.event_index as u64, msg_id.event_index);
         compare_event_to_message(event, msg);
     }
 
@@ -373,7 +394,7 @@ mod test {
         .unwrap();
 
         assert_eq!(event.tx_id, msg_id.tx_digest_as_base58());
-        assert_eq!(event.event_index, msg_id.event_index);
+        assert_eq!(event.event_index as u64, msg_id.event_index);
         compare_event_to_message(event, msg);
     }
 
@@ -404,7 +425,7 @@ mod test {
     fn should_make_verifier_set_confirmation_with_hex_msg_id() {
         let msg_id = HexTxHashAndEventIndex {
             tx_hash: random_32_bytes(),
-            event_index: rand::random::<u32>(),
+            event_index: rand::random::<u32>() as u64,
         };
         let verifier_set = VerifierSet {
             signers: BTreeMap::new(),
@@ -412,14 +433,14 @@ mod test {
             created_at: 1,
         };
         let event = VerifierSetConfirmation::new(
-            &msg_id.to_string(),
+            msg_id.to_string().parse().unwrap(),
             MessageIdFormat::HexTxHashAndEventIndex,
             verifier_set.clone(),
         )
         .unwrap();
 
         assert_eq!(event.tx_id, msg_id.tx_hash_as_hex());
-        assert_eq!(event.event_index, msg_id.event_index);
+        assert_eq!(event.event_index as u64, msg_id.event_index);
         assert_eq!(event.verifier_set, verifier_set);
     }
 
@@ -427,7 +448,7 @@ mod test {
     fn should_make_verifier_set_confirmation_with_base58_msg_id() {
         let msg_id = Base58TxDigestAndEventIndex {
             tx_digest: random_32_bytes(),
-            event_index: rand::random::<u32>(),
+            event_index: rand::random::<u32>() as u64,
         };
         let verifier_set = VerifierSet {
             signers: BTreeMap::new(),
@@ -435,14 +456,14 @@ mod test {
             created_at: 1,
         };
         let event = VerifierSetConfirmation::new(
-            &msg_id.to_string(),
+            msg_id.to_string().parse().unwrap(),
             MessageIdFormat::Base58TxDigestAndEventIndex,
             verifier_set.clone(),
         )
         .unwrap();
 
         assert_eq!(event.tx_id, msg_id.tx_digest_as_base58());
-        assert_eq!(event.event_index, msg_id.event_index);
+        assert_eq!(event.event_index as u64, msg_id.event_index);
         assert_eq!(event.verifier_set, verifier_set);
     }
 
@@ -456,7 +477,7 @@ mod test {
         };
 
         let event = VerifierSetConfirmation::new(
-            msg_id,
+            msg_id.to_string().parse().unwrap(),
             MessageIdFormat::Base58TxDigestAndEventIndex,
             verifier_set,
         );
@@ -467,7 +488,7 @@ mod test {
     fn make_verifier_set_confirmation_should_fail_with_different_msg_id_format() {
         let msg_id = HexTxHashAndEventIndex {
             tx_hash: random_32_bytes(),
-            event_index: rand::random::<u32>(),
+            event_index: rand::random::<u64>(),
         };
         let verifier_set = VerifierSet {
             signers: BTreeMap::new(),
@@ -476,7 +497,7 @@ mod test {
         };
 
         let event = VerifierSetConfirmation::new(
-            &msg_id.to_string(),
+            msg_id.to_string().parse().unwrap(),
             MessageIdFormat::Base58TxDigestAndEventIndex,
             verifier_set,
         );

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -195,8 +195,11 @@ impl VerifierSetConfirmation {
         msg_id_format: MessageIdFormat,
         verifier_set: VerifierSet,
     ) -> Result<Self, ContractError> {
+        #[allow(deprecated)]
         let (tx_id, event_index) = parse_message_id(&message_id, &msg_id_format)?;
 
+        #[allow(deprecated)]
+        // TODO: remove this attribute when tx_id and event_index are removed from the event
         Ok(Self {
             tx_id,
             event_index,
@@ -226,8 +229,11 @@ pub struct TxEventConfirmation {
 impl TryFrom<(Message, &MessageIdFormat)> for TxEventConfirmation {
     type Error = ContractError;
     fn try_from((msg, msg_id_format): (Message, &MessageIdFormat)) -> Result<Self, Self::Error> {
+        #[allow(deprecated)]
         let (tx_id, event_index) = parse_message_id(&msg.cc_id.message_id, msg_id_format)?;
 
+        #[allow(deprecated)]
+        // TODO: remove this attribute when tx_id and event_index are removed from the event
         Ok(TxEventConfirmation {
             tx_id,
             event_index,
@@ -359,8 +365,7 @@ mod test {
             TxEventConfirmation::try_from((msg.clone(), &MessageIdFormat::HexTxHashAndEventIndex))
                 .unwrap();
 
-        assert_eq!(event.tx_id, msg_id.tx_hash_as_hex());
-        assert_eq!(event.event_index as u64, msg_id.event_index);
+        assert_eq!(event.message_id, msg.cc_id.message_id);
         compare_event_to_message(event, msg);
     }
 
@@ -374,8 +379,7 @@ mod test {
         let event =
             TxEventConfirmation::try_from((msg.clone(), &MessageIdFormat::HexTxHash)).unwrap();
 
-        assert_eq!(event.tx_id, msg_id.tx_hash_as_hex());
-        assert_eq!(event.event_index, 0);
+        assert_eq!(event.message_id, msg.cc_id.message_id);
         compare_event_to_message(event, msg);
     }
 
@@ -393,8 +397,7 @@ mod test {
         ))
         .unwrap();
 
-        assert_eq!(event.tx_id, msg_id.tx_digest_as_base58());
-        assert_eq!(event.event_index as u64, msg_id.event_index);
+        assert_eq!(event.message_id, msg.cc_id.message_id);
         compare_event_to_message(event, msg);
     }
 
@@ -439,8 +442,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.tx_id, msg_id.tx_hash_as_hex());
-        assert_eq!(event.event_index as u64, msg_id.event_index);
+        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
         assert_eq!(event.verifier_set, verifier_set);
     }
 
@@ -462,8 +464,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.tx_id, msg_id.tx_digest_as_base58());
-        assert_eq!(event.event_index as u64, msg_id.event_index);
+        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
         assert_eq!(event.verifier_set, verifier_set);
     }
 

--- a/packages/axelar-core-std/src/nexus/execute.rs
+++ b/packages/axelar-core-std/src/nexus/execute.rs
@@ -102,7 +102,7 @@ mod test {
             destination_address: "something else".parse().unwrap(),
             payload_hash: [1; 32],
             source_tx_id: msg_id.tx_hash.to_vec().try_into().unwrap(),
-            source_tx_index: msg_id.event_index as u64,
+            source_tx_index: msg_id.event_index,
             id: msg_id.to_string(),
         };
 

--- a/packages/axelar-core-std/src/nexus/execute.rs
+++ b/packages/axelar-core-std/src/nexus/execute.rs
@@ -34,7 +34,7 @@ fn parse_message_id(message_id: &str) -> Result<(nonempty::Vec<u8>, u64), Error>
     let tx_id = nonempty::Vec::<u8>::try_from(id.tx_hash.to_vec())
         .change_context(Error::InvalidMessageId(message_id.into()))?;
 
-    Ok((tx_id, id.event_index.into()))
+    Ok((tx_id, id.event_index))
 }
 
 impl From<router_api::Message> for Message {

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -44,6 +44,7 @@ regex = { version = "1.10.0", default-features = false, features = ["perf", "std
 report = { workspace = true }
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+serde_with = { version = "3.11.0", features = ["macros"]}
 serde_json = "1.0.89"
 sha3 = { workspace = true }
 stellar-xdr = { workspace = true }

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -44,8 +44,8 @@ regex = { version = "1.10.0", default-features = false, features = ["perf", "std
 report = { workspace = true }
 schemars = "0.8.10"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
-serde_with = { version = "3.11.0", features = ["macros"]}
 serde_json = "1.0.89"
+serde_with = { version = "3.11.0", features = ["macros"] }
 sha3 = { workspace = true }
 stellar-xdr = { workspace = true }
 strum = { workspace = true }

--- a/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
@@ -5,14 +5,16 @@ use std::str::FromStr;
 use error_stack::{Report, ResultExt};
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde_with::DeserializeFromStr;
 
 use super::Error;
 use crate::hash::Hash;
 use crate::nonempty;
 
+#[derive(Debug, DeserializeFromStr)]
 pub struct Base58TxDigestAndEventIndex {
     pub tx_digest: Hash,
-    pub event_index: u32,
+    pub event_index: u64,
 }
 
 impl Base58TxDigestAndEventIndex {
@@ -23,7 +25,7 @@ impl Base58TxDigestAndEventIndex {
             .expect("failed to convert tx hash to non-empty string")
     }
 
-    pub fn new(tx_id: impl Into<[u8; 32]>, event_index: impl Into<u32>) -> Self {
+    pub fn new(tx_id: impl Into<[u8; 32]>, event_index: impl Into<u64>) -> Self {
         Self {
             tx_digest: tx_id.into(),
             event_index: event_index.into(),
@@ -96,7 +98,7 @@ mod tests {
         bs58::encode(random_bytes()).into_string()
     }
 
-    fn random_event_index() -> u32 {
+    fn random_event_index() -> u64 {
         rand::random()
     }
 
@@ -285,7 +287,7 @@ mod tests {
     fn should_not_parse_msg_id_with_overflowing_event_index() {
         let event_index: u64 = u64::MAX;
         let tx_digest = random_tx_digest();
-        let res = Base58TxDigestAndEventIndex::from_str(&format!("{}-{}", tx_digest, event_index));
+        let res = Base58TxDigestAndEventIndex::from_str(&format!("{}-{}1", tx_digest, event_index));
         assert!(res.is_err());
     }
 

--- a/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
@@ -14,7 +14,7 @@ type RawSignature = [u8; 64];
 pub struct Base58SolanaTxSignatureAndEventIndex {
     // Base58 decoded bytes of the Solana signature.
     pub raw_signature: RawSignature,
-    pub event_index: u32,
+    pub event_index: u64,
 }
 
 impl Base58SolanaTxSignatureAndEventIndex {
@@ -25,7 +25,7 @@ impl Base58SolanaTxSignatureAndEventIndex {
             .expect("failed to convert tx hash to non-empty string")
     }
 
-    pub fn new(tx_id: impl Into<RawSignature>, event_index: impl Into<u32>) -> Self {
+    pub fn new(tx_id: impl Into<RawSignature>, event_index: impl Into<u64>) -> Self {
         Self {
             raw_signature: tx_id.into(),
             event_index: event_index.into(),
@@ -102,7 +102,7 @@ mod tests {
         bs58::encode(random_bytes()).into_string()
     }
 
-    fn random_event_index() -> u32 {
+    fn random_event_index() -> u64 {
         rand::random()
     }
 
@@ -327,7 +327,7 @@ mod tests {
         let event_index: u64 = u64::MAX;
         let tx_digest = random_tx_digest();
         let res = Base58SolanaTxSignatureAndEventIndex::from_str(&format!(
-            "{}-{}",
+            "{}-{}1",
             tx_digest, event_index
         ));
         assert!(res.is_err());

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -6,24 +6,32 @@ use cosmwasm_std::HexBinary;
 use error_stack::{Report, ResultExt};
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde_with::DeserializeFromStr;
 
 use super::Error;
 use crate::hash::Hash;
 use crate::nonempty;
 
+#[derive(Debug, DeserializeFromStr, Clone)]
 pub struct HexTxHashAndEventIndex {
     pub tx_hash: Hash,
-    pub event_index: u32,
+    pub event_index: u64,
 }
 
 impl HexTxHashAndEventIndex {
     pub fn tx_hash_as_hex(&self) -> nonempty::String {
-        format!("0x{}", HexBinary::from(self.tx_hash).to_hex())
+        format!("0x{}", self.tx_hash_as_hex_no_prefix())
             .try_into()
             .expect("failed to convert tx hash to non-empty string")
     }
 
-    pub fn new(tx_id: impl Into<[u8; 32]>, event_index: impl Into<u32>) -> Self {
+    pub fn tx_hash_as_hex_no_prefix(&self) -> nonempty::String {
+        format!("{}", HexBinary::from(self.tx_hash).to_hex())
+            .try_into()
+            .expect("failed to convert tx hash to non-empty string")
+    }
+
+    pub fn new(tx_id: impl Into<[u8; 32]>, event_index: impl Into<u64>) -> Self {
         Self {
             tx_hash: tx_id.into(),
             event_index: event_index.into(),
@@ -98,7 +106,7 @@ mod tests {
         format!("0x{}", HexBinary::from(bytes).to_hex())
     }
 
-    fn random_event_index() -> u32 {
+    fn random_event_index() -> u64 {
         rand::random()
     }
 
@@ -223,7 +231,7 @@ mod tests {
     fn should_not_parse_msg_id_with_overflowing_event_index() {
         let event_index: u64 = u64::MAX;
         let tx_hash = random_hash();
-        let res = HexTxHashAndEventIndex::from_str(&format!("{}-{}", tx_hash, event_index));
+        let res = HexTxHashAndEventIndex::from_str(&format!("{}-{}1", tx_hash, event_index));
         assert!(res.is_err());
     }
 }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -26,7 +26,9 @@ impl HexTxHashAndEventIndex {
     }
 
     pub fn tx_hash_as_hex_no_prefix(&self) -> nonempty::String {
-        format!("{}", HexBinary::from(self.tx_hash).to_hex())
+        HexBinary::from(self.tx_hash)
+            .to_hex()
+            .to_string()
             .try_into()
             .expect("failed to convert tx hash to non-empty string")
     }


### PR DESCRIPTION
* This change also affects axelarnet-gateway, voting-verifier, and ampd
* In some cases, ampd will automatically vote NotFound if the u64 overflows u32 (since some RPC interfaces do not allow indexing events via u64)
* Emit message id in poll started event. Ampd parses message id.
* Deprecate emitting tx id and event index in poll started event.

https://axelarnetwork.atlassian.net/browse/AXE-4627
