### PR TITLE
feat(minor-interchain-token-service): make decimals non optional

### DIFF
--- a/contracts/interchain-token-service/src/contract/execute/interceptors.rs
+++ b/contracts/interchain-token-service/src/contract/execute/interceptors.rs
@@ -236,12 +236,12 @@ fn destination_amount(
     let destination_token = try_load_token_instance(storage, destination_chain.clone(), token_id)?;
 
     let (source_decimals, destination_decimals) =
-        match (source_token.decimals, destination_token.decimals) {
-            (source_decimals, destination_decimals) if source_decimals == destination_decimals => {
-                return Ok(source_amount)
-            }
-            (source_decimals, destination_decimals) => (source_decimals, destination_decimals),
-        };
+        (source_token.decimals, destination_token.decimals);
+
+    if source_decimals == destination_decimals {
+        return Ok(source_amount);
+    }
+
     let destination_max_uint = state::load_chain_config(storage, destination_chain)
         .change_context(Error::State)?
         .max_uint;

--- a/contracts/interchain-token-service/src/contract/execute/interceptors.rs
+++ b/contracts/interchain-token-service/src/contract/execute/interceptors.rs
@@ -76,7 +76,7 @@ pub fn deploy_token_to_source_chain(
                 origin_chain,
                 chain,
                 deploy_token.token_id,
-                Some(deploy_token.decimals),
+                deploy_token.decimals,
             )?;
         }
         None => {
@@ -90,7 +90,7 @@ pub fn deploy_token_to_source_chain(
                         storage,
                         chain.clone(),
                         deploy_token.token_id,
-                        &TokenInstance::new_on_origin(Some(deploy_token.decimals)),
+                        &TokenInstance::new_on_origin(deploy_token.decimals),
                     )
                 })
                 .change_context(Error::State)?;
@@ -119,7 +119,7 @@ pub fn deploy_token_to_destination_chain(
         storage,
         chain.clone(),
         deploy_token.token_id,
-        &TokenInstance::new(&deploy_token.deployment_type(), Some(deploy_token.decimals)),
+        &TokenInstance::new(&deploy_token.deployment_type(), deploy_token.decimals),
     )
     .change_context(Error::State)
     .map(|_| ())
@@ -146,7 +146,7 @@ fn ensure_matching_original_deployment(
     origin_chain: ChainNameRaw,
     chain: &ChainNameRaw,
     token_id: TokenId,
-    decimals: Option<u8>,
+    decimals: u8,
 ) -> Result<(), Error> {
     ensure!(
         origin_chain == *chain,
@@ -237,18 +237,10 @@ fn destination_amount(
 
     let (source_decimals, destination_decimals) =
         match (source_token.decimals, destination_token.decimals) {
-            (Some(source_decimals), Some(destination_decimals))
-                if source_decimals == destination_decimals =>
-            {
+            (source_decimals, destination_decimals) if source_decimals == destination_decimals => {
                 return Ok(source_amount)
             }
-            (Some(source_decimals), Some(destination_decimals)) => {
-                (source_decimals, destination_decimals)
-            }
-            (None, None) => return Ok(source_amount),
-            _ => unreachable!(
-                "decimals should be set in both the source and destination, or set in neither"
-            ), // This should never happen
+            (source_decimals, destination_decimals) => (source_decimals, destination_decimals),
         };
     let destination_max_uint = state::load_chain_config(storage, destination_chain)
         .change_context(Error::State)?
@@ -339,14 +331,14 @@ mod test {
             &mut storage,
             source_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new_on_origin(Some(18)),
+            &TokenInstance::new_on_origin(18),
         )
         .unwrap();
         state::save_token_instance(
             &mut storage,
             destination_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new(&TokenDeploymentType::Trustless, Some(12)),
+            &TokenInstance::new(&TokenDeploymentType::Trustless, 12),
         )
         .unwrap();
         state::save_chain_config(
@@ -390,14 +382,14 @@ mod test {
             &mut storage,
             source_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new_on_origin(Some(12)),
+            &TokenInstance::new_on_origin(12),
         )
         .unwrap();
         state::save_token_instance(
             &mut storage,
             destination_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new(&TokenDeploymentType::Trustless, Some(18)),
+            &TokenInstance::new(&TokenDeploymentType::Trustless, 18),
         )
         .unwrap();
         state::save_chain_config(
@@ -441,14 +433,14 @@ mod test {
             &mut storage,
             source_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new_on_origin(Some(12)),
+            &TokenInstance::new_on_origin(12),
         )
         .unwrap();
         state::save_token_instance(
             &mut storage,
             destination_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new(&TokenDeploymentType::Trustless, Some(12)),
+            &TokenInstance::new(&TokenDeploymentType::Trustless, 12),
         )
         .unwrap();
         state::save_chain_config(
@@ -492,14 +484,14 @@ mod test {
             &mut storage,
             source_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new_on_origin(Some(18)),
+            &TokenInstance::new_on_origin(18),
         )
         .unwrap();
         state::save_token_instance(
             &mut storage,
             destination_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new(&TokenDeploymentType::Trustless, Some(12)),
+            &TokenInstance::new(&TokenDeploymentType::Trustless, 12),
         )
         .unwrap();
         state::save_chain_config(
@@ -543,14 +535,14 @@ mod test {
             &mut storage,
             source_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new_on_origin(Some(18)),
+            &TokenInstance::new_on_origin(18),
         )
         .unwrap();
         state::save_token_instance(
             &mut storage,
             destination_chain.clone(),
             transfer.token_id,
-            &TokenInstance::new(&TokenDeploymentType::Trustless, Some(12)),
+            &TokenInstance::new(&TokenDeploymentType::Trustless, 12),
         )
         .unwrap();
         state::save_chain_config(

--- a/contracts/interchain-token-service/src/contract/execute/mod.rs
+++ b/contracts/interchain-token-service/src/contract/execute/mod.rs
@@ -64,8 +64,8 @@ pub enum Error {
     TokenDeployedDecimalsMismatch {
         token_id: TokenId,
         chain: ChainNameRaw,
-        expected: Option<u8>,
-        actual: Option<u8>,
+        expected: u8,
+        actual: u8,
     },
     #[error("token supply invariant violated for token {token_id} on chain {chain}")]
     TokenSupplyInvariantViolated {

--- a/contracts/interchain-token-service/src/state.rs
+++ b/contracts/interchain-token-service/src/state.rs
@@ -85,18 +85,18 @@ impl TokenSupply {
 #[cw_serde]
 pub struct TokenInstance {
     pub supply: TokenSupply,
-    pub decimals: Option<u8>,
+    pub decimals: u8,
 }
 
 impl TokenInstance {
-    pub fn new_on_origin(decimals: Option<u8>) -> Self {
+    pub fn new_on_origin(decimals: u8) -> Self {
         Self {
             supply: TokenSupply::Untracked,
             decimals,
         }
     }
 
-    pub fn new(deployment_type: &TokenDeploymentType, decimals: Option<u8>) -> Self {
+    pub fn new(deployment_type: &TokenDeploymentType, decimals: u8) -> Self {
         let supply = match deployment_type {
             TokenDeploymentType::Trustless => TokenSupply::Tracked(Uint256::zero()),
             _ => TokenSupply::Untracked,


### PR DESCRIPTION
* all TokenInstance's now have decimals, since DeployTokenManager is no longer supported

