### PR TITLE
fix(major-axelarnet-gateway): dummy commit to fix axelarnet-gateway bump to major

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "axelarnet-gateway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_ok",
  "axelar-core-std",

--- a/contracts/axelarnet-gateway/Cargo.toml
+++ b/contracts/axelarnet-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axelarnet-gateway"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = { workspace = true }
 edition = { workspace = true }
 description = "The Axelarnet Gateway contract allows apps on the Axelar Network to send/receive cross-chain messages to/from other chains."


### PR DESCRIPTION
previous commit was using `major-axelar-gateway` instead of `major-axelarnet-gateway`
