### PR TITLE
chore: add flag --no-fail-fast to the gh action so that it reports all failing tests

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --locked
+          args: --locked --no-fail-fast
         env:
           RUSTFLAGS: --cfg tracing_unstable
           RUST_BACKTRACE: 1


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
