### PR TITLE
Router contract msg_id_format upgrade

### DIFF
--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -98,6 +98,10 @@ pub fn execute(
                 msg_id_format,
             )?)
         }
+        ExecuteMsg::UpgradeMessageIdFormat {
+            chain,
+            msg_id_format,
+        } => execute::upgrade_message_id_format(deps.storage, chain, msg_id_format),
         ExecuteMsg::UpgradeGateway {
             chain,
             contract_address,

--- a/contracts/router/src/events.rs
+++ b/contracts/router/src/events.rs
@@ -1,3 +1,4 @@
+use axelar_wasm_std::msg_id::MessageIdFormat;
 use cosmwasm_std::{Addr, Attribute, Event};
 use router_api::{ChainName, GatewayDirection, Message};
 
@@ -10,6 +11,11 @@ pub struct RouterInstantiated {
 pub struct ChainRegistered {
     pub name: ChainName,
     pub gateway: Addr,
+}
+
+pub struct MessageIdFormatUpgraded {
+    pub chain: ChainName,
+    pub msg_id_format: MessageIdFormat,
 }
 
 pub struct GatewayInfo {
@@ -51,6 +57,18 @@ impl From<ChainRegistered> for Event {
         Event::new("chain_registered")
             .add_attribute("name", other.name)
             .add_attribute("gateway", other.gateway)
+    }
+}
+
+impl From<MessageIdFormatUpgraded> for Event {
+    fn from(other: MessageIdFormatUpgraded) -> Self {
+        let msg_id_format = format!("{:?}", other.msg_id_format);
+        let attrs: Vec<Attribute> = vec![
+            ("chain", other.chain.clone()).into(),
+            ("msg_id_format", &msg_id_format).into(),
+        ];
+
+        Event::new("message_id_format_upgraded").add_attributes(attrs)
     }
 }
 

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -16,6 +16,12 @@ pub enum ExecuteMsg {
         gateway_address: Address,
         msg_id_format: MessageIdFormat,
     },
+    /// Changes the message id format associated with a particular chain
+    #[permission(Governance)]
+    UpgradeMessageIdFormat {
+        chain: ChainName,
+        msg_id_format: MessageIdFormat,
+    },
     /// Changes the gateway address associated with a particular chain
     #[permission(Governance)]
     UpgradeGateway {


### PR DESCRIPTION
The router contract allows for the update of the gateway address associated with a chain, this PR adds that same functionality also for the MessageIdFormat. If the incorrect MessageIdFormat gets specified during contract instantiation then it can never be corrected.