### PR TITLE
refactor(minor-interchain-token-service)!: refactor register token

### DIFF
--- a/contracts/interchain-token-service/src/contract/execute/interceptors.rs
+++ b/contracts/interchain-token-service/src/contract/execute/interceptors.rs
@@ -296,12 +296,12 @@ pub fn register_custom_token(
     let existing_token = state::may_load_custom_token(
         storage,
         source_chain.clone(),
-        register_token.address.clone(),
+        register_token.token_address.clone(),
     )
     .change_context(Error::State)?;
     ensure!(
         existing_token.is_none(),
-        Error::TokenAlreadyRegistered(register_token.address)
+        Error::TokenAlreadyRegistered(register_token.token_address)
     );
 
     state::save_custom_token(storage, source_chain, register_token).change_context(Error::State)

--- a/contracts/interchain-token-service/src/primitives.rs
+++ b/contracts/interchain-token-service/src/primitives.rs
@@ -31,8 +31,6 @@ pub enum Message {
     /// Deploy a new interchain token on the destination chain
     DeployInterchainToken(DeployInterchainToken),
 
-    RegisterTokenMetadata(RegisterTokenMetadata),
-
     LinkToken(LinkToken),
 }
 
@@ -83,13 +81,7 @@ impl From<DeployInterchainToken> for Message {
 #[derive(Eq)]
 pub struct RegisterTokenMetadata {
     pub decimals: u8,
-    pub address: nonempty::HexBinary,
-}
-
-impl From<RegisterTokenMetadata> for Message {
-    fn from(value: RegisterTokenMetadata) -> Self {
-        Message::RegisterTokenMetadata(value)
-    }
+    pub token_address: nonempty::HexBinary,
 }
 
 #[cw_serde]
@@ -125,6 +117,7 @@ pub enum HubMessage {
         source_chain: ChainNameRaw,
         message: Message,
     },
+    RegisterTokenMetadata(RegisterTokenMetadata),
 }
 
 impl HubMessage {
@@ -132,6 +125,9 @@ impl HubMessage {
         match self {
             HubMessage::SendToHub { message, .. } => message,
             HubMessage::ReceiveFromHub { message, .. } => message,
+            HubMessage::RegisterTokenMetadata { .. } => {
+                panic!("no message associated with this hub message type")
+            }
         }
     }
 
@@ -146,9 +142,6 @@ impl Message {
             Message::InterchainTransfer(InterchainTransfer { token_id, .. })
             | Message::DeployInterchainToken(DeployInterchainToken { token_id, .. })
             | Message::LinkToken(LinkToken { token_id, .. }) => *token_id,
-            Message::RegisterTokenMetadata(_) => {
-                panic!("no token id associated with this message type")
-            }
         }
     }
 }

--- a/contracts/interchain-token-service/src/state.rs
+++ b/contracts/interchain-token-service/src/state.rs
@@ -294,7 +294,10 @@ pub fn save_token_config(
 pub fn save_custom_token(
     storage: &mut dyn Storage,
     chain: ChainNameRaw,
-    RegisterTokenMetadata { address, decimals }: RegisterTokenMetadata,
+    RegisterTokenMetadata {
+        token_address: address,
+        decimals,
+    }: RegisterTokenMetadata,
 ) -> Result<(), Error> {
     CUSTOM_TOKENS
         .save(

--- a/contracts/interchain-token-service/tests/execute.rs
+++ b/contracts/interchain-token-service/tests/execute.rs
@@ -10,7 +10,8 @@ use interchain_token_service::contract::{self, ExecuteError};
 use interchain_token_service::events::Event;
 use interchain_token_service::msg::{self, ExecuteMsg, TruncationConfig};
 use interchain_token_service::{
-    DeployInterchainToken, HubMessage, InterchainTransfer, TokenId, TokenSupply,
+    DeployInterchainToken, HubMessage, InterchainTransfer, LinkToken, RegisterTokenMetadata,
+    TokenId, TokenSupply,
 };
 use router_api::{Address, ChainName, ChainNameRaw, CrossChainId};
 use serde_json::json;
@@ -226,6 +227,125 @@ fn execute_hub_message_succeeds() {
         .collect();
 
     goldie::assert_json!(responses);
+}
+
+#[test]
+fn execute_message_interchain_transfer_should_scale_custom_tokens_when_decimals_are_different() {
+    let (
+        mut deps,
+        TestMessage {
+            router_message,
+            source_its_contract,
+            source_its_chain,
+            destination_its_chain,
+            destination_its_contract,
+            ..
+        },
+    ) = utils::setup_with_chain_configs(
+        Uint256::MAX.try_into().unwrap(),
+        6,
+        u64::MAX.try_into().unwrap(),
+        6,
+    );
+    let token_id = TokenId::new([1; 32]);
+    let hub_message = HubMessage::RegisterTokenMetadata(RegisterTokenMetadata {
+        decimals: 6,
+        token_address: HexBinary::from([1; 32]).try_into().unwrap(),
+    });
+    let cc_id = CrossChainId {
+        source_chain: source_its_chain.clone(),
+        message_id: router_message.cc_id.message_id.clone(),
+    };
+    assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        cc_id,
+        source_its_contract.clone(),
+        hub_message,
+    ));
+
+    let hub_message = HubMessage::RegisterTokenMetadata(RegisterTokenMetadata {
+        decimals: 18,
+        token_address: HexBinary::from([1; 32]).try_into().unwrap(),
+    });
+    let cc_id = CrossChainId {
+        source_chain: destination_its_chain.clone(),
+        message_id: router_message.cc_id.message_id.clone(),
+    };
+    assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        cc_id,
+        destination_its_contract.clone(),
+        hub_message,
+    ));
+
+    let hub_message = HubMessage::SendToHub {
+        destination_chain: destination_its_chain.clone(),
+        message: LinkToken {
+            token_id,
+            token_manager_type: Uint256::zero(),
+            source_token_address: HexBinary::from([1; 32]).try_into().unwrap(),
+            destination_token_address: HexBinary::from([1; 32]).try_into().unwrap(),
+            params: None,
+        }
+        .into(),
+    };
+
+    let cc_id = CrossChainId {
+        source_chain: source_its_chain.clone(),
+        message_id: router_message.cc_id.message_id.clone(),
+    };
+    assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        cc_id,
+        source_its_contract.clone(),
+        hub_message,
+    ));
+
+    // send from source to destination
+    let transfer = InterchainTransfer {
+        token_id,
+        source_address: HexBinary::from([1; 32]).try_into().unwrap(),
+        destination_address: HexBinary::from([2; 32]).try_into().unwrap(),
+        amount: Uint256::from_u128(1_000_000u128).try_into().unwrap(),
+        data: None,
+    };
+    let hub_message = HubMessage::SendToHub {
+        destination_chain: destination_its_chain.clone(),
+        message: transfer.into(),
+    };
+    let response_to_destination = assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        router_message.cc_id.clone(),
+        source_its_contract,
+        hub_message,
+    ));
+
+    // send back from destination to source
+    let transfer = InterchainTransfer {
+        token_id,
+        source_address: HexBinary::from([2; 32]).try_into().unwrap(),
+        destination_address: HexBinary::from([1; 32]).try_into().unwrap(),
+        amount: Uint256::from_u128(1_000_000_000_000_000_000u128)
+            .try_into()
+            .unwrap(),
+        data: None,
+    };
+    let mut cc_id = router_message.cc_id.clone();
+    cc_id.source_chain = destination_its_chain.clone();
+    let hub_message = HubMessage::SendToHub {
+        destination_chain: source_its_chain,
+        message: transfer.into(),
+    };
+    let response_to_source = assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        cc_id,
+        destination_its_contract,
+        hub_message,
+    ));
+
+    goldie::assert_json!(
+        json!({"response_to_destination": response_to_destination, "response_to_source": response_to_source})
+    );
 }
 
 #[test]

--- a/contracts/interchain-token-service/tests/testdata/execute_message_interchain_transfer_should_scale_custom_tokens_when_decimals_are_different.golden
+++ b/contracts/interchain-token-service/tests/testdata/execute_message_interchain_transfer_should_scale_custom_tokens_when_decimals_are_different.golden
@@ -1,0 +1,114 @@
+{
+  "response_to_destination": {
+    "attributes": [],
+    "data": null,
+    "events": [
+      {
+        "attributes": [
+          {
+            "key": "cc_id",
+            "value": "source-its-chain_message-id"
+          },
+          {
+            "key": "destination_chain",
+            "value": "dest-its-chain"
+          },
+          {
+            "key": "message_type",
+            "value": "InterchainTransfer"
+          },
+          {
+            "key": "token_id",
+            "value": "0101010101010101010101010101010101010101010101010101010101010101"
+          },
+          {
+            "key": "source_address",
+            "value": "0101010101010101010101010101010101010101010101010101010101010101"
+          },
+          {
+            "key": "destination_address",
+            "value": "0202020202020202020202020202020202020202020202020202020202020202"
+          },
+          {
+            "key": "amount",
+            "value": "1000000000000000000"
+          }
+        ],
+        "type": "message_received"
+      }
+    ],
+    "messages": [
+      {
+        "gas_limit": null,
+        "id": 0,
+        "msg": {
+          "wasm": {
+            "execute": {
+              "contract_addr": "cosmwasm1f6j7u6875p2cvyrgjr0d2uecyzah0kgeek38h39czwdhe5em3zys78pcnl",
+              "funds": [],
+              "msg": "eyJjYWxsX2NvbnRyYWN0Ijp7ImRlc3RpbmF0aW9uX2NoYWluIjoiZGVzdC1pdHMtY2hhaW4iLCJkZXN0aW5hdGlvbl9hZGRyZXNzIjoiZGVzdC1pdHMtY29udHJhY3QiLCJwYXlsb2FkIjoiMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMGEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDczNmY3NTcyNjM2NTJkNjk3NDczMmQ2MzY4NjE2OTZlMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMGMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBkZTBiNmIzYTc2NDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDIwMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAifX0="
+            }
+          }
+        },
+        "payload": "",
+        "reply_on": "never"
+      }
+    ]
+  },
+  "response_to_source": {
+    "attributes": [],
+    "data": null,
+    "events": [
+      {
+        "attributes": [
+          {
+            "key": "cc_id",
+            "value": "dest-its-chain_message-id"
+          },
+          {
+            "key": "destination_chain",
+            "value": "source-its-chain"
+          },
+          {
+            "key": "message_type",
+            "value": "InterchainTransfer"
+          },
+          {
+            "key": "token_id",
+            "value": "0101010101010101010101010101010101010101010101010101010101010101"
+          },
+          {
+            "key": "source_address",
+            "value": "0202020202020202020202020202020202020202020202020202020202020202"
+          },
+          {
+            "key": "destination_address",
+            "value": "0101010101010101010101010101010101010101010101010101010101010101"
+          },
+          {
+            "key": "amount",
+            "value": "1000000"
+          }
+        ],
+        "type": "message_received"
+      }
+    ],
+    "messages": [
+      {
+        "gas_limit": null,
+        "id": 0,
+        "msg": {
+          "wasm": {
+            "execute": {
+              "contract_addr": "cosmwasm1f6j7u6875p2cvyrgjr0d2uecyzah0kgeek38h39czwdhe5em3zys78pcnl",
+              "funds": [],
+              "msg": "eyJjYWxsX2NvbnRyYWN0Ijp7ImRlc3RpbmF0aW9uX2NoYWluIjoic291cmNlLWl0cy1jaGFpbiIsImRlc3RpbmF0aW9uX2FkZHJlc3MiOiJzb3VyY2UtaXRzLWNvbnRyYWN0IiwicGF5bG9hZCI6IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBhMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMGU2NDY1NzM3NDJkNjk3NDczMmQ2MzY4NjE2OTZlMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDE2MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDBjMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMGY0MjQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDE0MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjAwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn19"
+            }
+          }
+        },
+        "payload": "",
+        "reply_on": "never"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
* no longer pass RegisterTokenMetadata nested within SendToHub. Instead, pass as its own message type.
