### PR TITLE
feat: add macro to inject contract version validation and setting the new version during migration

### DIFF
--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,11 +1,10 @@
-use axelar_wasm_std::{address, killswitch, permission_control, FnExt};
+use axelar_wasm_std::{address, killswitch, migrate_from_version, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, Storage,
 };
 use router_api::error::Error;
-use semver::{Version, VersionReq};
 
 use crate::contract::migrations::v1_1_1;
 use crate::events::RouterInstantiated;
@@ -21,21 +20,13 @@ pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
+#[migrate_from_version(">= 1.1.0, < 1.2.0")]
 pub fn migrate(
     deps: DepsMut,
     _env: Env,
     msg: MigrateMsg,
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
-    let old_version = Version::parse(&cw2::get_contract_version(deps.storage)?.version)?;
-    let version_requirement = VersionReq::parse(">= 1.1.0, < 1.2.0")?;
-    assert!(version_requirement.matches(&old_version));
-
     v1_1_1::migrate(deps.storage, msg.chains_to_remove)?;
-
-    // this needs to be the last thing to do during migration,
-    // because previous migration steps should check the old version
-    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
     Ok(Response::default())
 }
 

--- a/packages/axelar-wasm-std-derive/src/lib.rs
+++ b/packages/axelar-wasm-std-derive/src/lib.rs
@@ -309,15 +309,18 @@ pub fn migrate_from_version(input: TokenStream, item: TokenStream) -> TokenStrea
 
     let gen = quote! {
         pub fn #fn_name(#fn_inputs) #fn_output {
+            let contract_name = env!("CARGO_PKG_NAME");
+            let contract_version = env!("CARGO_PKG_VERSION");
+
             let old_version = semver::Version::parse(&cw2::get_contract_version(#deps.storage)?.version)?;
             let version_requirement = semver::VersionReq::parse(#base_version_req)?;
-            assert!(version_requirement.matches(&old_version));
+            assert!(version_requirement.matches(&old_version), "{} contract migration from version {} to {} is not supported", contract_name, old_version, contract_version);
 
             let result = (|| {
                 #fn_block
             })();
 
-            cw2::set_contract_version(#deps.storage, env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))?;
+            cw2::set_contract_version(#deps.storage, contract_name, contract_version)?;
 
             result
         }


### PR DESCRIPTION
Example usage:
```Rust
#[migrate_from_version(">= 1.1.0, < 1.2.0")]
pub fn migrate(
    deps: DepsMut,
    _env: Env,
    msg: MigrateMsg,
) -> Result<Response, axelar_wasm_std::error::ContractError> {
    v1_1_1::migrate(deps.storage, msg.chains_to_remove)?;
    Ok(Response::default())
}
```
which expands to:
```Rust
pub fn migrate(
    deps: DepsMut,
    _env: Env,
    msg: MigrateMsg,
) -> Result<Response, axelar_wasm_std::error::ContractError> {
    let contract_name = "router";
    let contract_version = "1.2.0";
    let old_version = semver::Version::parse(
        &cw2::get_contract_version(deps.storage)?.version,
    )?;
    let version_requirement = semver::VersionReq::parse(">= 1.1.0, < 1.2.0")?;
    if !version_requirement.matches(&old_version) {
        {
            ::core::panicking::panic_fmt(
                format_args!(
                    "{0} contract migration from version {1} to {2} is not supported",
                    contract_name,
                    old_version,
                    contract_version,
                ),
            );
        }
    }
    let result = (|| {
        {
            v1_1_1::migrate(deps.storage, msg.chains_to_remove)?;
            Ok(Response::default())
        }
    })();
    cw2::set_contract_version(deps.storage, contract_name, contract_version)?;
    result
}
```


https://axelarnetwork.atlassian.net/browse/AXE-4947