### PR TITLE
feat: add contracts migration remover tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -192,7 +192,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -208,7 +208,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "syn-solidity",
 ]
 
@@ -768,7 +768,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -779,7 +779,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ dependencies = [
  "semver 1.0.24",
  "serde",
  "serde_json",
- "syn 2.0.92",
+ "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
@@ -1040,7 +1040,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1638,7 +1638,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1906,7 +1906,7 @@ checksum = "ae47fa8399bfe9a5b92a6312a1144912231fa1665759562dddb0497c1c917712"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ checksum = "8ae75370266380e777f075be5a0e092792af69469ed1231825505f9c4bd17e54"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2072,7 +2072,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2114,7 +2114,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90e7828ea0175c45743178f8b0290513752e949b2fdfa5bda52a7389d732610"
 dependencies = [
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2202,7 +2202,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "strsim 0.11.1",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2224,7 +2224,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2311,7 +2311,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2356,7 +2356,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "rustc_version 0.4.1",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2376,7 +2376,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "unicode-xid 0.2.6",
 ]
 
@@ -2469,7 +2469,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2499,7 +2499,7 @@ dependencies = [
  "optfield",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2800,13 +2800,13 @@ dependencies = [
  "dunce",
  "ethers-core",
  "eyre",
- "prettyplease 0.2.25",
+ "prettyplease 0.2.29",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.92",
+ "syn 2.0.96",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2824,7 +2824,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "serde_json",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2850,7 +2850,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.92",
+ "syn 2.0.96",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -2928,7 +2928,7 @@ dependencies = [
  "quote 1.0.38",
  "serde",
  "serde_json",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3115,7 +3115,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "uuid",
 ]
 
@@ -3332,7 +3332,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4075,7 +4075,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4172,7 +4172,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ dependencies = [
  "error-stack",
  "quote 1.0.38",
  "report",
- "syn 2.0.92",
+ "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
@@ -4801,6 +4801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "migration-remover"
+version = "1.0.0"
+dependencies = [
+ "clap",
+ "error-stack",
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,7 +4903,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5152,7 +5162,7 @@ source = "git+https://github.com/mystenlabs/sui?tag=testnet-v1.39.1#e2a147185dbe
 dependencies = [
  "enum-compat-util",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5223,7 +5233,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5612,7 +5622,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5693,7 +5703,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5705,7 +5715,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5797,7 +5807,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5836,7 +5846,7 @@ checksum = "fa59f025cde9c698fcb4fcb3533db4621795374065bee908215263488f2d2a1d"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5876,7 +5886,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6162,7 +6172,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6236,7 +6246,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6265,7 +6275,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6407,12 +6417,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2 1.0.92",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6642,7 +6652,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6655,7 +6665,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6890,7 +6900,7 @@ checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6930,7 +6940,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7531,7 +7541,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7565,7 +7575,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "serde_derive_internals",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7769,7 +7779,7 @@ checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7780,7 +7790,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7814,7 +7824,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7865,7 +7875,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8380,7 +8390,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "rustversion",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8393,7 +8403,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "rustversion",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8530,7 +8540,7 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "sui-enum-compat-util",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8724,9 +8734,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.92"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
@@ -8742,7 +8752,7 @@ dependencies = [
  "paste",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8780,7 +8790,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9078,7 +9088,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9089,7 +9099,7 @@ checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9233,7 +9243,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9560,7 +9570,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9701,7 +9711,7 @@ checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9738,7 +9748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10040,7 +10050,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -10075,7 +10085,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10497,7 +10507,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "synstructure 0.13.1",
 ]
 
@@ -10519,7 +10529,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10539,7 +10549,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
  "synstructure 0.13.1",
 ]
 
@@ -10560,7 +10570,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10582,7 +10592,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,10 +4804,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "migration-remover"
 version = "1.0.0"
 dependencies = [
+ "axelar-wasm-std",
  "clap",
+ "cosmwasm-std",
+ "cw2",
  "error-stack",
- "regex",
+ "semver 1.0.24",
  "thiserror 1.0.69",
+ "toml 0.8.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "external-gateways/*",
   "integration-tests",
   "packages/*",
+  "tools/*",
 ]
 resolver = "2"
 

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -12,7 +12,7 @@ use crate::state;
 use crate::state::{load_chain_by_gateway, load_config, Config};
 
 mod execute;
-mod migrations;
+pub(crate) mod migrations;
 mod query;
 
 pub use migrations::migrate;

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -12,10 +12,10 @@ use crate::state;
 use crate::state::{load_chain_by_gateway, load_config, Config};
 
 mod execute;
-pub(crate) mod migrations;
+mod migrations;
 mod query;
 
-pub use migrations::migrate;
+pub use migrations::{migrate, MigrateMsg};
 
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,4 +1,4 @@
-use axelar_wasm_std::{address, killswitch, migrate_from_version, permission_control, FnExt};
+use axelar_wasm_std::{address, killswitch, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -6,9 +6,8 @@ use cosmwasm_std::{
 };
 use router_api::error::Error;
 
-use crate::contract::migrations::v1_1_1;
 use crate::events::RouterInstantiated;
-use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state;
 use crate::state::{load_chain_by_gateway, load_config, Config};
 
@@ -16,19 +15,10 @@ mod execute;
 mod migrations;
 mod query;
 
+pub use migrations::migrate;
+
 pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-#[cfg_attr(not(feature = "library"), entry_point)]
-#[migrate_from_version("1.1")]
-pub fn migrate(
-    deps: DepsMut,
-    _env: Env,
-    msg: MigrateMsg,
-) -> Result<Response, axelar_wasm_std::error::ContractError> {
-    v1_1_1::migrate(deps.storage, msg.chains_to_remove)?;
-    Ok(Response::default())
-}
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/router/src/contract/migrations/mod.rs
+++ b/contracts/router/src/contract/migrations/mod.rs
@@ -1,1 +1,23 @@
-pub mod v1_1_1;
+use axelar_wasm_std::migrate_from_version;
+use cosmwasm_schema::cw_serde;
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{DepsMut, Env, Response};
+
+mod v1_1_1;
+
+#[cw_serde]
+pub struct MigrateMsg {
+    pub chains_to_remove: Vec<String>,
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+#[migrate_from_version("1.1")]
+pub fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, axelar_wasm_std::error::ContractError> {
+    v1_1_1::migrate(deps.storage, msg.chains_to_remove)?;
+    Ok(Response::default())
+}

--- a/contracts/router/src/msg.rs
+++ b/contracts/router/src/msg.rs
@@ -10,10 +10,5 @@ pub struct InstantiateMsg {
     pub axelarnet_gateway: String,
 }
 
-#[cw_serde]
-pub struct MigrateMsg {
-    pub chains_to_remove: Vec<String>,
-}
-
 // these messages are extracted into a separate package to avoid circular dependencies
 pub use router_api::msg::{ExecuteMsg, QueryMsg};

--- a/contracts/router/src/msg.rs
+++ b/contracts/router/src/msg.rs
@@ -13,4 +13,4 @@ pub struct InstantiateMsg {
 // these messages are extracted into a separate package to avoid circular dependencies
 pub use router_api::msg::{ExecuteMsg, QueryMsg};
 
-pub use crate::contract::migrations::MigrateMsg;
+pub use crate::contract::MigrateMsg;

--- a/contracts/router/src/msg.rs
+++ b/contracts/router/src/msg.rs
@@ -12,3 +12,5 @@ pub struct InstantiateMsg {
 
 // these messages are extracted into a separate package to avoid circular dependencies
 pub use router_api::msg::{ExecuteMsg, QueryMsg};
+
+pub use crate::contract::migrations::MigrateMsg;

--- a/tools/migration-remover/Cargo.toml
+++ b/tools/migration-remover/Cargo.toml
@@ -8,8 +8,14 @@ description = "Tool to remove a contract's migration code and reset the `migrate
 [dependencies]
 clap = { version = "4.2.7", features = ["derive", "cargo"] }
 error-stack = { workspace = true }
-regex = "1.10"
 thiserror = { workspace = true }
+toml = "0.8.19"
+
+[dev-dependencies]
+axelar-wasm-std = { workspace = true, features = ["derive"] }
+cosmwasm-std = { workspace = true }
+cw2 = { workspace = true }
+semver = { workspace = true }
 
 [lints]
 workspace = true

--- a/tools/migration-remover/Cargo.toml
+++ b/tools/migration-remover/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "migration-remover"
+version = "1.0.0"
+rust-version = { workspace = true }
+edition = { workspace = true }
+description = "Tool to remove a contract's migration code and reset the `migrate` entry point"
+
+[dependencies]
+clap = { version = "4.2.7", features = ["derive", "cargo"] }
+error-stack = { workspace = true }
+regex = "1.10"
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/migration-remover/Cargo.toml
+++ b/tools/migration-remover/Cargo.toml
@@ -5,6 +5,9 @@ rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Tool to remove a contract's migration code and reset the `migrate` entry point"
 
+[features]
+library = []
+
 [dependencies]
 clap = { version = "4.2.7", features = ["derive", "cargo"] }
 error-stack = { workspace = true }

--- a/tools/migration-remover/README.md
+++ b/tools/migration-remover/README.md
@@ -1,0 +1,17 @@
+# Migration Remover Tool
+
+This tool cleans up a contract's `migrations` module and resets its content using the `template.rs` file.
+
+The substring `#[migrate_from_version("0.0")]` in the template is automatically replaced with the current `major.minor` version from the contract's `Cargo.toml` file.
+
+### Usage
+
+```bash
+cargo run --bin migration-remover -- -c <CONTRACT>
+```
+
+### Example
+
+```bash
+cargo run --bin migration-remover -- -c axelarnet-gateway
+```

--- a/tools/migration-remover/README.md
+++ b/tools/migration-remover/README.md
@@ -4,6 +4,8 @@ This tool cleans up a contract's `migrations` module and resets its content usin
 
 The substring `#[migrate_from_version("0.0")]` in the template is automatically replaced with the current `major.minor` version from the contract's `Cargo.toml` file.
 
+For best results, all migration-related code (e.g. `migrate` entry-point, `MigrateMsg`) should be inside the `migrations` module and the entry point re-exported in the contract's module using `pub use migrations::migrate;`
+
 ### Usage
 
 ```bash

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -79,6 +79,10 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
-// tests that `template.rs` compiles correctly
+// tests that `template.rs` compiles correctly and content can be re-exported
 #[cfg(test)]
 mod template;
+#[cfg(test)]
+pub use template::migrate;
+#[cfg(test)]
+pub use template::MigrateMsg;

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -1,11 +1,21 @@
 use clap::{arg, Parser};
 use error_stack::{Result, ResultExt};
-use std::{env, fs, path::Path};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
+use toml::Table;
 
 #[derive(Error, Debug)]
-#[error("failed to remove migration code")]
-struct Error;
+enum Error {
+    #[error("failed to parse contract's Cargo.toml")]
+    Cargo,
+    #[error("failed to read template file")]
+    Template,
+    #[error("failed to reset contract's 'migrations' module")]
+    MigrationMod,
+}
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -17,20 +27,59 @@ struct Args {
 const CONTRACTS_RELATIVE_PATH: &str = "../../contracts/";
 const TEMPLATE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/template.rs");
 
+fn next_migrate_version_req(cargo_toml_path: &PathBuf) -> Result<String, Error> {
+    let content = fs::read_to_string(cargo_toml_path).change_context(Error::Cargo)?;
+    let parsed_toml = content.parse::<Table>().change_context(Error::Cargo)?;
+
+    let version = parsed_toml
+        .get("package")
+        .and_then(|package| package.get("version"))
+        .and_then(|version| version.as_str())
+        .ok_or(Error::Cargo)?;
+
+    Ok(version.split(".").take(2).collect::<Vec<_>>().join("."))
+}
+
+fn read_template(contract_root_dir: &PathBuf) -> Result<String, Error> {
+    let from_version = next_migrate_version_req(&contract_root_dir.join("Cargo.toml"))?;
+
+    let template = fs::read_to_string(TEMPLATE_PATH)
+        .change_context(Error::Template)?
+        .replace(
+            r#"#[migrate_from_version("0.0")]"#,
+            &format!(r#"#[migrate_from_version("{}")]"#, from_version),
+        );
+
+    Ok(template)
+}
+
+fn reset_migration_mod(contract_root_dir: &PathBuf, content: &str) -> Result<(), Error> {
+    let migrations_mod_dir = contract_root_dir.join("src/contract/migrations");
+
+    fs::remove_dir_all(&migrations_mod_dir)
+        .and_then(|_| fs::create_dir(&migrations_mod_dir))
+        .and_then(|_| fs::write(&migrations_mod_dir.join("mod.rs"), content))
+        .change_context(Error::MigrationMod)
+}
+
 fn main() -> Result<(), Error> {
     let args = Args::parse();
-    println!("Removing migration code from {} contract", args.contract);
 
-    let migrations_mod_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let contract_root_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join(CONTRACTS_RELATIVE_PATH)
-        .join(&args.contract)
-        .join("src/contract/migrations");
+        .join(&args.contract);
 
-    fs::remove_dir_all(&migrations_mod_dir).change_context(Error)?;
-    fs::create_dir(&migrations_mod_dir).change_context(Error)?;
+    read_template(&contract_root_dir)
+        .and_then(|template| reset_migration_mod(&contract_root_dir, &template))?;
 
-    let template = fs::read_to_string(TEMPLATE_PATH).change_context(Error)?;
-    fs::write(&migrations_mod_dir.join("mod.rs"), template).change_context(Error)?;
+    println!(
+        "Migration code removed successfully from contract `{}`",
+        args.contract
+    );
 
     Ok(())
 }
+
+// tests that `template.rs` compiles correctly
+#[cfg(test)]
+mod template;

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -1,0 +1,36 @@
+use clap::{arg, Parser};
+use error_stack::{Result, ResultExt};
+use std::{env, fs, path::Path};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("failed to remove migration code")]
+struct Error;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Name of contract's crate, e.g. "axelarnet-gateway"
+    #[arg(short, long)]
+    pub contract: String,
+}
+
+const CONTRACTS_RELATIVE_PATH: &str = "../../contracts/";
+const TEMPLATE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/template.rs");
+
+fn main() -> Result<(), Error> {
+    let args = Args::parse();
+    println!("Removing migration code from {} contract", args.contract);
+
+    let migrations_mod_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(CONTRACTS_RELATIVE_PATH)
+        .join(&args.contract)
+        .join("src/contract/migrations");
+
+    fs::remove_dir_all(&migrations_mod_dir).change_context(Error)?;
+    fs::create_dir(&migrations_mod_dir).change_context(Error)?;
+
+    let template = fs::read_to_string(TEMPLATE_PATH).change_context(Error)?;
+    fs::write(&migrations_mod_dir.join("mod.rs"), template).change_context(Error)?;
+
+    Ok(())
+}

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -36,7 +36,7 @@ fn next_migrate_version_req(cargo_toml_path: PathBuf) -> Result<String, Error> {
         .and_then(|version| version.as_str())
         .ok_or(Error::Cargo)?;
 
-    Ok(version.split(".").take(2).collect::<Vec<_>>().join("."))
+    Ok(version.split('.').take(2).collect::<Vec<_>>().join("."))
 }
 
 fn read_template(contract_root_dir: &Path) -> Result<String, Error> {

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -24,6 +24,7 @@ struct Args {
 }
 
 const CONTRACTS_RELATIVE_PATH: &str = "../../contracts/";
+const MIGRATIONS_MOD_RELATIVE_PATH: &str = "src/contract/migrations";
 const TEMPLATE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/template.rs");
 
 fn next_migrate_version_req(cargo_toml_path: PathBuf) -> Result<String, Error> {
@@ -53,7 +54,7 @@ fn read_template(contract_root_dir: &Path) -> Result<String, Error> {
 }
 
 fn reset_migration_mod(contract_root_dir: &Path, content: &str) -> Result<(), Error> {
-    let migrations_mod_dir = contract_root_dir.join("src/contract/migrations");
+    let migrations_mod_dir = contract_root_dir.join(MIGRATIONS_MOD_RELATIVE_PATH);
 
     fs::remove_dir_all(&migrations_mod_dir)
         .and_then(|_| fs::create_dir(&migrations_mod_dir))

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -80,9 +80,13 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
-// tests that `template.rs` compiles correctly and content can be re-exported
+// Tests that `template.rs` compiles correctly
 #[cfg(test)]
 mod template;
+
+// Re-exports template content to:
+// 1. Test that content can be re-exported
+// 2. Prevent dead_code warnings in `template.rs`
 #[cfg(test)]
 pub use template::migrate;
 #[cfg(test)]

--- a/tools/migration-remover/src/template.rs
+++ b/tools/migration-remover/src/template.rs
@@ -1,0 +1,14 @@
+use axelar_wasm_std::migrate_from_version;
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{DepsMut, Empty, Env, Response};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+#[migrate_from_version("0.0")]
+pub fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    _msg: Empty,
+) -> Result<Response, axelar_wasm_std::error::ContractError> {
+    Ok(Response::default())
+}

--- a/tools/migration-remover/src/template.rs
+++ b/tools/migration-remover/src/template.rs
@@ -3,12 +3,14 @@ use axelar_wasm_std::migrate_from_version;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{DepsMut, Empty, Env, Response};
 
+pub type MigrateMsg = Empty;
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 #[migrate_from_version("0.0")]
 pub fn migrate(
     deps: DepsMut,
     _env: Env,
-    _msg: Empty,
+    _msg: MigrateMsg,
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
     Ok(Response::default())
 }


### PR DESCRIPTION
This tool assumes the contrac's migration code follows the same directory structure as the router contract on this PR, i.e. all migration-related code must be inside `src/contract/migrations`

More info in README

How to test:
```
cargo run --bin migration-remover -- -c router
```

https://axelarnetwork.atlassian.net/browse/AXE-7389

