### PR TITLE
refactor(minor-axelarnet-gateway): msg and state separation

### DIFF
--- a/contracts/axelarnet-gateway/src/contract/query.rs
+++ b/contracts/axelarnet-gateway/src/contract/query.rs
@@ -2,7 +2,8 @@ use cosmwasm_std::Storage;
 use itertools::Itertools;
 use router_api::{ChainName, CrossChainId, Message};
 
-use crate::state::{self, ExecutableMessage};
+use crate::msg::ExecutableMessage;
+use crate::state;
 
 pub fn routable_messages(
     storage: &dyn Storage,
@@ -18,10 +19,12 @@ pub fn executable_messages(
     storage: &dyn Storage,
     cc_ids: Vec<CrossChainId>,
 ) -> Result<Vec<ExecutableMessage>, state::Error> {
-    cc_ids
+    let results: Vec<_> = cc_ids
         .into_iter()
         .map(|cc_id| state::load_executable_msg(storage, &cc_id))
-        .try_collect()
+        .try_collect()?;
+
+    Ok(results.into_iter().map(Into::into).collect())
 }
 
 pub fn chain_name(storage: &dyn Storage) -> ChainName {

--- a/contracts/axelarnet-gateway/src/msg.rs
+++ b/contracts/axelarnet-gateway/src/msg.rs
@@ -4,7 +4,24 @@ use cosmwasm_std::HexBinary;
 use msgs_derive::EnsurePermissions;
 use router_api::{Address, ChainName, CrossChainId, Message};
 
-use crate::state::ExecutableMessage;
+use crate::state;
+
+impl From<state::ExecutableMessage> for ExecutableMessage {
+    fn from(value: state::ExecutableMessage) -> Self {
+        match value {
+            state::ExecutableMessage::Approved(msg) => ExecutableMessage::Approved(msg),
+            state::ExecutableMessage::Executed(msg) => ExecutableMessage::Executed(msg),
+        }
+    }
+}
+
+#[cw_serde]
+pub enum ExecutableMessage {
+    /// A message that has been sent by the router, but not executed yet.
+    Approved(Message),
+    /// An approved message that has been executed.
+    Executed(Message),
+}
 
 #[cw_serde]
 pub struct InstantiateMsg {


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
