### PR TITLE
refactor(minor-axelarnet-gateway): msg and state separation

### DIFF
--- a/contracts/axelarnet-gateway/src/msg.rs
+++ b/contracts/axelarnet-gateway/src/msg.rs
@@ -4,17 +4,6 @@ use cosmwasm_std::HexBinary;
 use msgs_derive::EnsurePermissions;
 use router_api::{Address, ChainName, CrossChainId, Message};
 
-use crate::state;
-
-impl From<state::ExecutableMessage> for ExecutableMessage {
-    fn from(value: state::ExecutableMessage) -> Self {
-        match value {
-            state::ExecutableMessage::Approved(msg) => ExecutableMessage::Approved(msg),
-            state::ExecutableMessage::Executed(msg) => ExecutableMessage::Executed(msg),
-        }
-    }
-}
-
 #[cw_serde]
 pub enum ExecutableMessage {
     /// A message that has been sent by the router, but not executed yet.

--- a/contracts/axelarnet-gateway/src/state.rs
+++ b/contracts/axelarnet-gateway/src/state.rs
@@ -5,6 +5,8 @@ use cw_storage_plus::{Item, Map};
 use error_stack::report;
 use router_api::{ChainName, CrossChainId, Message};
 
+use crate::msg;
+
 const CONFIG: Item<Config> = Item::new("config");
 const ROUTABLE_MESSAGES: Map<&CrossChainId, Message> = Map::new("routable_messages");
 const EXECUTABLE_MESSAGES: Map<&CrossChainId, ExecutableMessage> = Map::new("executable_messages");
@@ -48,6 +50,15 @@ impl ExecutableMessage {
     pub fn msg(&self) -> &Message {
         match self {
             ExecutableMessage::Approved(msg) | ExecutableMessage::Executed(msg) => msg,
+        }
+    }
+}
+
+impl From<ExecutableMessage> for msg::ExecutableMessage {
+    fn from(value: ExecutableMessage) -> Self {
+        match value {
+            ExecutableMessage::Approved(msg) => msg::ExecutableMessage::Approved(msg),
+            ExecutableMessage::Executed(msg) => msg::ExecutableMessage::Executed(msg),
         }
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
