### PR TITLE
feat(ampd): separate multisig config per chain

### DIFF
--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -111,7 +111,10 @@ fn multisig_address(config: &Config) -> Result<TMAddress, Error> {
         .handlers
         .iter()
         .find_map(|config| {
-            if let handlers::config::Config::MultisigSigner { cosmwasm_contract } = config {
+            if let handlers::config::Config::MultisigSigner {
+                cosmwasm_contract, ..
+            } = config
+            {
                 Some(cosmwasm_contract.clone())
             } else {
                 None

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -103,6 +103,7 @@ mod tests {
             [[handlers]]
             type = 'MultisigSigner'
             cosmwasm_contract = '{}'
+            chain_name = 'Ethereum'
 
             [[handlers]]
             type = 'SuiMsgVerifier'
@@ -324,6 +325,7 @@ mod tests {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
+                    chain_name: ChainName::from_str("Ethereum").unwrap(),
                 },
                 HandlerConfig::SuiMsgVerifier {
                     cosmwasm_contract: TMAddress::from(

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -36,6 +36,7 @@ pub enum Config {
     },
     MultisigSigner {
         cosmwasm_contract: TMAddress,
+        chain_name: ChainName,
     },
     SuiMsgVerifier {
         cosmwasm_contract: TMAddress,
@@ -201,12 +202,25 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+    use router_api::ChainName;
     use serde_json::to_value;
 
     use crate::evm::finalizer::Finalization;
     use crate::handlers::config::{deserialize_handler_configs, Chain, Config};
     use crate::types::TMAddress;
     use crate::PREFIX;
+
+    fn rand_chain_name() -> ChainName {
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect::<String>()
+            .try_into()
+            .unwrap()
+    }
 
     #[test]
     fn finalizer_should_default_to_ethereum() {
@@ -224,9 +238,11 @@ mod tests {
         let configs = vec![
             Config::MultisigSigner {
                 cosmwasm_contract: TMAddress::random(PREFIX),
+                chain_name: rand_chain_name(),
             },
             Config::MultisigSigner {
                 cosmwasm_contract: TMAddress::random(PREFIX),
+                chain_name: rand_chain_name(),
             },
         ];
 

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -278,17 +278,20 @@ where
                         event_processor_config.clone(),
                     )
                 }
-                handlers::config::Config::MultisigSigner { cosmwasm_contract } => self
-                    .create_handler_task(
-                        "multisig-signer",
-                        handlers::multisig::Handler::new(
-                            verifier.clone(),
-                            cosmwasm_contract,
-                            self.multisig_client.clone(),
-                            self.block_height_monitor.latest_block_height(),
-                        ),
-                        event_processor_config.clone(),
+                handlers::config::Config::MultisigSigner {
+                    cosmwasm_contract,
+                    chain_name,
+                } => self.create_handler_task(
+                    "multisig-signer",
+                    handlers::multisig::Handler::new(
+                        verifier.clone(),
+                        cosmwasm_contract,
+                        chain_name,
+                        self.multisig_client.clone(),
+                        self.block_height_monitor.latest_block_height(),
                     ),
+                    event_processor_config.clone(),
+                ),
                 handlers::config::Config::SuiMsgVerifier {
                     cosmwasm_contract,
                     rpc_url,

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -43,6 +43,7 @@ nanos = 0
 [[handlers]]
 type = 'MultisigSigner'
 cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'
+chain_name = 'ethereum'
 
 [[handlers]]
 type = 'SuiMsgVerifier'


### PR DESCRIPTION
## Description

Instead of using one `ampd` multisig handler for all signing sessions, switch to use a separate multisig handler per chain. Signing will run in parallel for several chains, although the number of tasks will increase dramatically. Each chain has a dedicated `ampd` voting handler already, so it makes sense to do the same for signing.

**NOTE**: This requires verifiers to update their `ampd` configs:

```diff
[[handlers]]
type = 'MultisigSigner'
cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'
+ chain_name = 'flow'
+
+ [[handlers]]
+ type = 'MultisigSigner'
+ cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'
+ chain_name = 'hedera'
```

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [x] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [x] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [x] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
