### PR TITLE
fix(release): add pat for checkout token

### DIFF
--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -60,6 +60,7 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
+          token: ${{ secrets.AMPLIFIER_ACCESS_TOKEN }}
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
-          token: ${{ secrets.AMPLIFIER_ACCESS_TOKEN }}
+          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -217,7 +217,7 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
-          token: ${{ secrets.AMPLIFIER_ACCESS_TOKEN }}
+          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -217,6 +217,7 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
+          token: ${{ secrets.AMPLIFIER_ACCESS_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
