### PR TITLE
feat(ampd-sdk): setup initial ci/cd pipeline

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -151,7 +151,7 @@ runs:
       run: |
         cargo release -p ${{ inputs.binary-to-release }} \
           ${{ steps.semantic-version.outputs.version_type }} \
-          --allow-branch "*" \
+          --allow-branch "main,releases/*" \
           -v
 
     - name: Release cargo crate

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -151,6 +151,7 @@ runs:
       run: |
         cargo release -p ${{ inputs.binary-to-release }} \
           ${{ steps.semantic-version.outputs.version_type }} \
+          --allow-branch "*" \
           -v
 
     - name: Release cargo crate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - ampd
+          - ampd-sdk
           - router
           - gateway
           - multisig
@@ -33,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.INTEROP_CI_ACTION_TOKEN }}
+      
       - name: Setup variables for sub-project to release
         id: setup-variables
         shell: bash
@@ -40,6 +42,7 @@ jobs:
           binary="${{ github.event.inputs.binary-to-release }}"
           declare -A binaries_data=(
             ["ampd"]="ampd,/\(major\)|\(major-ampd\)/,/\(minor\)|\(minor-ampd\)/,ampd packages"
+            ["ampd-sdk"]="ampd-sdk,/\(major\)|\(major-ampd-sdk\)/,/\(minor\)|\(minor-ampd-sdk\)/,packages/ampd-sdk"
             ["router"]="router,/\(major\)|\(major-router\)|\(major-contracts\)|\(major-connection-router\)/,/\(minor\)|\(minor-router\)|\(minor-contracts\)|\(minor-connection-router\)/,contracts/router packages"
             ["gateway"]="gateway,/\(major\)|\(major-gateway\)|\(major-contracts\)/,/\(minor\)|\(minor-gateway\)|\(minor-contracts\)/,contracts/gateway packages"
             ["multisig"]="multisig,/\(major\)|\(major-multisig\)|\(major-contracts\)/,/\(minor\)|\(minor-multisig\)|\(minor-contracts\)/,contracts/multisig packages"

--- a/ampd-handlers/src/main.rs
+++ b/ampd-handlers/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_greeting() {
         assert_eq!(get_greeting(), "Hello from AMPD handler!");

--- a/ampd-handlers/src/main.rs
+++ b/ampd-handlers/src/main.rs
@@ -1,3 +1,17 @@
+fn get_greeting() -> &'static str {
+    "Hello from AMPD handler!"
+}
+
 fn main() {
-    println!("Hello from AMPD handler!");
+    println!("{}", get_greeting());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_greeting() {
+        assert_eq!(get_greeting(), "Hello from AMPD handler!");
+    }
 }


### PR DESCRIPTION
## Description
AXE-8223

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
