### PR TITLE
fix(ampd): chain name comparison

### DIFF
--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -21,7 +21,7 @@ impl PartialEq<IAxelarGatewayEventsWithLog<'_>> for &Message {
                 {
                     Ok(chain) => chain,
                     Err(e) => {
-                        debug!(error = e, "failed to parse destination chain");
+                        debug!(error = ?e, "failed to parse destination chain");
                         return false;
                     }
                 };

--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -22,7 +22,7 @@ impl PartialEq<IAxelarGatewayEventsWithLog<'_>> for &Message {
                         Ok(chain) => self.destination_chain == chain,
                         Err(e) => {
                             debug!(error = ?e, "failed to parse destination chain");
-                            return false;
+                            false
                         }
                     };
 

--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -17,18 +17,18 @@ impl PartialEq<IAxelarGatewayEventsWithLog<'_>> for &Message {
 
         match event {
             IAxelarAmplifierGatewayEvents::ContractCallFilter(event) => {
-                let destination_chain = match ChainName::try_from(event.destination_chain.as_ref())
-                {
-                    Ok(chain) => chain,
-                    Err(e) => {
-                        debug!(error = ?e, "failed to parse destination chain");
-                        return false;
-                    }
-                };
+                let matches_destination_chain =
+                    match ChainName::try_from(event.destination_chain.as_ref()) {
+                        Ok(chain) => self.destination_chain == chain,
+                        Err(e) => {
+                            debug!(error = ?e, "failed to parse destination chain");
+                            return false;
+                        }
+                    };
 
-                log.transaction_hash == Some(self.message_id.tx_hash.into())
+                matches_destination_chain
+                    && log.transaction_hash == Some(self.message_id.tx_hash.into())
                     && event.sender == self.source_address
-                    && self.destination_chain == destination_chain
                     && event.destination_contract_address == self.destination_address
                     && event.payload_hash == self.payload_hash.as_bytes()
             }

--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -21,7 +21,7 @@ impl PartialEq<IAxelarGatewayEventsWithLog<'_>> for &Message {
                 {
                     Ok(chain) => chain,
                     Err(e) => {
-                        debug!("failed to parse destination chain {:?}", e);
+                        debug!(error = e, "failed to parse destination chain");
                         return false;
                     }
                 };

--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -2,6 +2,7 @@ use axelar_wasm_std::voting::Vote;
 use ethers_contract::EthLogDecode;
 use ethers_core::types::{Log, TransactionReceipt, H256};
 use evm_gateway::{IAxelarAmplifierGatewayEvents, WeightedSigners};
+use router_api::ChainName;
 
 use crate::handlers::evm_verify_msg::Message;
 use crate::handlers::evm_verify_verifier_set::VerifierSetConfirmation;
@@ -17,7 +18,9 @@ impl PartialEq<IAxelarGatewayEventsWithLog<'_>> for &Message {
             IAxelarAmplifierGatewayEvents::ContractCallFilter(event) => {
                 log.transaction_hash == Some(self.message_id.tx_hash.into())
                     && event.sender == self.source_address
-                    && self.destination_chain == event.destination_chain
+                    && self.destination_chain
+                        == ChainName::try_from(event.destination_chain.as_ref())
+                            .expect("failed to parse to ChainName")
                     && event.destination_contract_address == self.destination_address
                     && event.payload_hash == self.payload_hash.as_bytes()
             }

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -43,13 +43,8 @@ impl Message {
         let destination_chain = topics.get(2).ok_or(Error::PropertyEmpty)?;
         let destination_chain = STANDARD.decode(destination_chain)?;
         let destination_chain = String::from_utf8(destination_chain)?;
-        let destination_chain = match ChainName::try_from(destination_chain) {
-            Ok(chain) => chain,
-            Err(e) => {
-                debug!(error = ?e, "failed to parse destination chain");
-                return Ok(false);
-            }
-        };
+        let destination_chain = ChainName::try_from(destination_chain)
+            .inspect_err(|e| debug!(error = ?e, "failed to parse destination chain"))?;
         if destination_chain != self.destination_chain.as_ref() {
             return Ok(false);
         }

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -46,7 +46,7 @@ impl Message {
         let destination_chain = match ChainName::try_from(destination_chain) {
             Ok(chain) => chain,
             Err(e) => {
-                debug!(error = e, "failed to parse destination chain");
+                debug!(error = ?e, "failed to parse destination chain");
                 return Ok(false);
             }
         };

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -5,6 +5,7 @@ use hex::ToHex;
 use multiversx_sdk::data::address::Address;
 use multiversx_sdk::data::transaction::{Events, TransactionOnNetwork};
 use num_traits::cast;
+use router_api::ChainName;
 
 use crate::handlers::mvx_verify_msg::Message;
 use crate::handlers::mvx_verify_verifier_set::VerifierSetConfirmation;
@@ -41,7 +42,9 @@ impl Message {
         let destination_chain = topics.get(2).ok_or(Error::PropertyEmpty)?;
         let destination_chain = STANDARD.decode(destination_chain)?;
         let destination_chain = String::from_utf8(destination_chain)?;
-        if destination_chain != self.destination_chain.as_ref() {
+        if ChainName::try_from(destination_chain).expect("failed to parse to ChainName")
+            != self.destination_chain.as_ref()
+        {
             return Ok(false);
         }
 

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -42,9 +42,7 @@ impl Message {
         let destination_chain = topics.get(2).ok_or(Error::PropertyEmpty)?;
         let destination_chain = STANDARD.decode(destination_chain)?;
         let destination_chain = String::from_utf8(destination_chain)?;
-        if ChainName::try_from(destination_chain).expect("failed to parse to ChainName")
-            != self.destination_chain.as_ref()
-        {
+        if ChainName::try_from(destination_chain)? != self.destination_chain.as_ref() {
             return Ok(false);
         }
 

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -6,6 +6,7 @@ use multiversx_sdk::data::address::Address;
 use multiversx_sdk::data::transaction::{Events, TransactionOnNetwork};
 use num_traits::cast;
 use router_api::ChainName;
+use tracing::debug;
 
 use crate::handlers::mvx_verify_msg::Message;
 use crate::handlers::mvx_verify_verifier_set::VerifierSetConfirmation;
@@ -42,7 +43,14 @@ impl Message {
         let destination_chain = topics.get(2).ok_or(Error::PropertyEmpty)?;
         let destination_chain = STANDARD.decode(destination_chain)?;
         let destination_chain = String::from_utf8(destination_chain)?;
-        if ChainName::try_from(destination_chain)? != self.destination_chain.as_ref() {
+        let destination_chain = match ChainName::try_from(destination_chain) {
+            Ok(chain) => chain,
+            Err(e) => {
+                debug!("failed to parse destination chain {:?}", e);
+                return Ok(false);
+            }
+        };
+        if destination_chain != self.destination_chain.as_ref() {
             return Ok(false);
         }
 

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -46,7 +46,7 @@ impl Message {
         let destination_chain = match ChainName::try_from(destination_chain) {
             Ok(chain) => chain,
             Err(e) => {
-                debug!("failed to parse destination chain {:?}", e);
+                debug!(error = e, "failed to parse destination chain");
                 return Ok(false);
             }
         };

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -32,7 +32,7 @@ impl PartialEq<Message> for ContractCallEvent {
         let destination_chain = match ChainName::try_from(self.destination_chain.as_ref()) {
             Ok(chain) => chain,
             Err(e) => {
-                debug!(error = e, "failed to parse destination chain");
+                debug!(error = ?e, "failed to parse destination chain");
                 return false;
             }
         };

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -29,16 +29,16 @@ pub fn verify_msg(
 
 impl PartialEq<Message> for ContractCallEvent {
     fn eq(&self, axl_msg: &Message) -> bool {
-        let destination_chain = match ChainName::try_from(self.destination_chain.as_ref()) {
-            Ok(chain) => chain,
+        let matches_destination_chain = match ChainName::try_from(self.destination_chain.as_ref()) {
+            Ok(chain) => axl_msg.destination_chain == chain,
             Err(e) => {
                 debug!(error = ?e, "failed to parse destination chain");
                 return false;
             }
         };
 
-        Felt::from(axl_msg.source_address.clone()) == self.source_address
-            && axl_msg.destination_chain == destination_chain
+        matches_destination_chain
+            && Felt::from(axl_msg.source_address.clone()) == self.source_address
             && axl_msg.destination_address == self.destination_address
             && axl_msg.payload_hash == self.payload_hash
     }

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -32,7 +32,7 @@ impl PartialEq<Message> for ContractCallEvent {
         let destination_chain = match ChainName::try_from(self.destination_chain.as_ref()) {
             Ok(chain) => chain,
             Err(e) => {
-                debug!("failed to parse destination chain {:?}", e);
+                debug!(error = e, "failed to parse destination chain");
                 return false;
             }
         };

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -33,7 +33,7 @@ impl PartialEq<Message> for ContractCallEvent {
             Ok(chain) => axl_msg.destination_chain == chain,
             Err(e) => {
                 debug!(error = ?e, "failed to parse destination chain");
-                return false;
+                false
             }
         };
 

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -1,5 +1,6 @@
 use axelar_wasm_std::voting::Vote;
 use cosmwasm_std::HexBinary;
+use router_api::ChainName;
 use starknet_core::types::Felt;
 
 use crate::handlers::starknet_verify_msg::Message;
@@ -28,7 +29,9 @@ pub fn verify_msg(
 impl PartialEq<Message> for ContractCallEvent {
     fn eq(&self, axl_msg: &Message) -> bool {
         Felt::from(axl_msg.source_address.clone()) == self.source_address
-            && axl_msg.destination_chain == self.destination_chain
+            && axl_msg.destination_chain
+                == ChainName::try_from(self.destination_chain.as_ref())
+                    .expect("failed to parse to ChainName")
             && axl_msg.destination_address == self.destination_address
             && axl_msg.payload_hash == self.payload_hash
     }

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -36,7 +36,7 @@ impl PartialEq<ContractEventBody> for Message {
             ScVal::String(s) => match ChainName::try_from(s.to_string()) {
                 Ok(chain) => chain.to_string(),
                 Err(e) => {
-                    debug!("failed to parse destination chain {:?}", e);
+                    debug!(error = e, "failed to parse destination chain");
                     return false;
                 }
             },

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -37,10 +37,10 @@ impl PartialEq<ContractEventBody> for Message {
                 Ok(chain) => self.destination_chain.to_string() == chain.to_string(),
                 Err(e) => {
                     debug!(error = ?e, "failed to parse destination chain");
-                    return false;
+                    false
                 }
             },
-            _ => return false,
+            _ => false,
         };
 
         matches_destination_chain

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -34,7 +34,7 @@ impl PartialEq<ContractEventBody> for Message {
 
         let matches_destination_chain = match destination_chain {
             ScVal::String(s) => match ChainName::try_from(s.to_string()) {
-                Ok(chain) => self.destination_chain.to_string() == chain.to_string(),
+                Ok(chain) => chain == self.destination_chain.to_string(),
                 Err(e) => {
                     debug!(error = ?e, "failed to parse destination chain");
                     false

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -36,7 +36,7 @@ impl PartialEq<ContractEventBody> for Message {
             ScVal::String(s) => match ChainName::try_from(s.to_string()) {
                 Ok(chain) => chain.to_string(),
                 Err(e) => {
-                    debug!(error = e, "failed to parse destination chain");
+                    debug!(error = ?e, "failed to parse destination chain");
                     return false;
                 }
             },

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -32,9 +32,9 @@ impl PartialEq<ContractEventBody> for Message {
         )
         .into();
 
-        let destination_chain = match destination_chain {
+        let matches_destination_chain = match destination_chain {
             ScVal::String(s) => match ChainName::try_from(s.to_string()) {
-                Ok(chain) => chain.to_string(),
+                Ok(chain) => self.destination_chain.to_string() == chain.to_string(),
                 Err(e) => {
                     debug!(error = ?e, "failed to parse destination chain");
                     return false;
@@ -43,10 +43,10 @@ impl PartialEq<ContractEventBody> for Message {
             _ => return false,
         };
 
-        expected_topic == *symbol
+        matches_destination_chain
+            && expected_topic == *symbol
             && (ScVal::Address(self.source_address.clone()) == *source_address)
             && (ScVal::Bytes(self.payload_hash.clone()) == *payload_hash)
-            && self.destination_chain.to_string() == destination_chain
             && (ScVal::String(self.destination_address.clone()) == *destination_address)
     }
 }

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -2,6 +2,7 @@ use axelar_wasm_std::voting::Vote;
 use axelar_wasm_std::{self};
 use cosmwasm_std::HexBinary;
 use move_core_types::language_storage::StructTag;
+use router_api::ChainName;
 use sui_gateway::events::{ContractCall, SignersRotated};
 use sui_gateway::{WeightedSigner, WeightedSigners};
 use sui_json_rpc_types::{SuiEvent, SuiTransactionBlockResponse};
@@ -41,7 +42,9 @@ impl PartialEq<&Message> for &SuiEvent {
                 ..
             }) => {
                 msg.source_address.as_ref() == source_id.as_bytes()
-                    && msg.destination_chain == destination_chain
+                    && msg.destination_chain
+                        == ChainName::try_from(destination_chain)
+                            .expect("failed to parse to ChainName")
                     && msg.destination_address == destination_address
                     && msg.payload_hash.to_fixed_bytes().to_vec() == payload_hash.to_vec()
             }

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -46,7 +46,7 @@ impl PartialEq<&Message> for &SuiEvent {
                     Ok(chain) => msg.destination_chain == chain,
                     Err(e) => {
                         debug!(error = ?e, "failed to parse destination chain");
-                        return false;
+                        false
                     }
                 };
 

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -42,16 +42,16 @@ impl PartialEq<&Message> for &SuiEvent {
                 payload_hash,
                 ..
             }) => {
-                let destination_chain = match ChainName::try_from(destination_chain) {
-                    Ok(chain) => chain,
+                let matches_destination_chain = match ChainName::try_from(destination_chain) {
+                    Ok(chain) => msg.destination_chain == chain,
                     Err(e) => {
                         debug!(error = ?e, "failed to parse destination chain");
                         return false;
                     }
                 };
 
-                msg.source_address.as_ref() == source_id.as_bytes()
-                    && msg.destination_chain == destination_chain
+                matches_destination_chain
+                    && msg.source_address.as_ref() == source_id.as_bytes()
                     && msg.destination_address == destination_address
                     && msg.payload_hash.to_fixed_bytes().to_vec() == payload_hash.to_vec()
             }

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -45,7 +45,7 @@ impl PartialEq<&Message> for &SuiEvent {
                 let destination_chain = match ChainName::try_from(destination_chain) {
                     Ok(chain) => chain,
                     Err(e) => {
-                        debug!("failed to parse destination chain {:?}", e);
+                        debug!(error = e, "failed to parse destination chain");
                         return false;
                     }
                 };

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -45,7 +45,7 @@ impl PartialEq<&Message> for &SuiEvent {
                 let destination_chain = match ChainName::try_from(destination_chain) {
                     Ok(chain) => chain,
                     Err(e) => {
-                        debug!(error = e, "failed to parse destination chain");
+                        debug!(error = ?e, "failed to parse destination chain");
                         return false;
                     }
                 };


### PR DESCRIPTION
## Description

fixes chain name comparison to make it case insensitive

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
