### PR TITLE
fix(ampd): change type to ChainName in stellar Message

### DIFF
--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -405,7 +405,7 @@ mod tests {
         let log_index = msg.message_id.event_index.into();
 
         let filter = ContractCallFilter {
-            sender: msg.source_address.clone(),
+            sender: msg.source_address,
             destination_chain: destination_chain.into(),
             destination_contract_address: msg.destination_address.clone(),
             payload_hash: msg.payload_hash.into(),

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -32,7 +32,7 @@ use crate::types::TMAddress;
 pub struct Message {
     pub message_id: HexTxHashAndEventIndex,
     pub destination_address: ScString,
-    pub destination_chain: ScString,
+    pub destination_chain: ChainName,
     #[serde_as(as = "DisplayFromStr")]
     pub source_address: ScAddress,
     pub payload_hash: ScBytes,

--- a/ampd/src/handlers/testdata/stellar_verify_msg_should_deserialize_correct_event.golden
+++ b/ampd/src/handlers/testdata/stellar_verify_msg_should_deserialize_correct_event.golden
@@ -53,8 +53,8 @@ PollStartedEvent {
             destination_address: ScString(
                 StringM(0x0000000000000000000000000000000000000000),
             ),
-            destination_chain: ScString(
-                StringM(ethereum),
+            destination_chain: ChainName(
+                "ethereum",
             ),
             source_address: Contract(
                 Hash(0202020202020202020202020202020202020202020202020202020202020202),
@@ -104,8 +104,8 @@ PollStartedEvent {
             destination_address: ScString(
                 StringM(0x0101010101010101010101010101010101010101),
             ),
-            destination_chain: ScString(
-                StringM(ethereum),
+            destination_chain: ChainName(
+                "ethereum",
             ),
             source_address: Contract(
                 Hash(0202020202020202020202020202020202020202020202020202020202020202),

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -299,6 +299,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn should_verify_msg_if_chain_uses_different_casing() {
+        let (gateway_address, tx, msg) = msg_and_tx_on_network_with_different_chain_casing();
+
+        assert_eq!(
+            verify_message(&gateway_address, &tx, &msg),
+            Vote::SucceededOnChain
+        );
+    }
+
     // test verify worker set
     #[test]
     fn should_not_verify_verifier_set_if_tx_id_does_not_match() {
@@ -410,11 +420,7 @@ mod tests {
         );
     }
 
-    fn get_matching_msg_and_tx() -> (Address, TransactionOnNetwork, Message) {
-        let gateway_address = Address::from_bech32_string(
-            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
-        )
-        .unwrap();
+    fn mock_message(destination_chain: &str) -> Message {
         let source_address = Address::from_bech32_string(
             "erd1qqqqqqqqqqqqqpgqzqvm5ywqqf524efwrhr039tjs29w0qltkklsa05pk7",
         )
@@ -422,15 +428,20 @@ mod tests {
 
         let message_id = HexTxHashAndEventIndex::new(Hash::random(), 1u64);
 
-        let msg = Message {
+        Message {
             message_id,
             source_address,
-            destination_chain: "ethereum".parse().unwrap(),
+            destination_chain: destination_chain.parse().unwrap(),
             destination_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
             payload_hash: Hash::random(),
-        };
+        }
+    }
 
-        // Only the first 32 bytes matter for data
+    fn mock_tx_on_network(
+        destination_chain: &str,
+        gateway_address: &Address,
+        msg: &Message,
+    ) -> TransactionOnNetwork {
         let payload_hash = msg.payload_hash;
 
         let wrong_event = Events {
@@ -447,7 +458,7 @@ mod tests {
             topics: Some(vec![
                 STANDARD.encode(CONTRACT_CALL_EVENT),
                 STANDARD.encode(msg.source_address.clone().to_bytes()),
-                STANDARD.encode(msg.destination_chain.to_string()),
+                STANDARD.encode(destination_chain),
                 STANDARD.encode(msg.destination_address.clone()),
                 STANDARD.encode(payload_hash),
             ]),
@@ -458,7 +469,8 @@ mod tests {
             "erd1qqqqqqqqqqqqqpgqzqvm5ywqqf524efwrhr039tjs29w0qltkklsa05pk7",
         )
         .unwrap();
-        let tx_block = TransactionOnNetwork {
+
+        TransactionOnNetwork {
             hash: Some(msg.message_id.tx_hash.encode_hex::<String>()),
             logs: Some(ApiLogs {
                 address: other_address.clone(),
@@ -492,7 +504,31 @@ mod tests {
             hyperblock_hash: Some("".into()),
             smart_contract_results: vec![],
             processing_type_on_destination: "".into(),
-        };
+        }
+    }
+
+    fn get_matching_msg_and_tx() -> (Address, TransactionOnNetwork, Message) {
+        let gateway_address = Address::from_bech32_string(
+            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
+        )
+        .unwrap();
+
+        let destination_chain = "ethereum";
+        let msg = mock_message(destination_chain);
+        let tx_block = mock_tx_on_network(destination_chain, &gateway_address, &msg);
+
+        (gateway_address, tx_block, msg)
+    }
+
+    fn msg_and_tx_on_network_with_different_chain_casing(
+    ) -> (Address, TransactionOnNetwork, Message) {
+        let gateway_address = Address::from_bech32_string(
+            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
+        )
+        .unwrap();
+
+        let msg = mock_message("ethereum");
+        let tx_block = mock_tx_on_network("Ethereum", &gateway_address, &msg);
 
         (gateway_address, tx_block, msg)
     }

--- a/ampd/src/starknet/verifier.rs
+++ b/ampd/src/starknet/verifier.rs
@@ -239,6 +239,22 @@ mod tests {
         )
     }
 
+    #[test]
+    fn shoud_verify_event_if_chain_uses_different_casing() {
+        let msg = mock_valid_message();
+        let mut event = mock_valid_event();
+        event.destination_chain = msg.destination_chain.to_string().to_uppercase();
+
+        assert_eq!(
+            verify_msg(
+                &event,
+                &msg,
+                &String::from("0x035410be6f4bf3f67f7c1bb4a93119d9d410b2f981bfafbf5dbbf5d37ae7439e"),
+            ),
+            Vote::SucceededOnChain
+        )
+    }
+
     /// Verifier set - signers rotated
 
     fn mock_valid_confirmation_signers_rotated() -> VerifierSetConfirmation {

--- a/ampd/src/sui/verifier.rs
+++ b/ampd/src/sui/verifier.rs
@@ -157,7 +157,6 @@ mod tests {
     use multisig::verifier_set::VerifierSet;
     use rand::rngs::OsRng;
     use random_string::generate;
-    use router_api::ChainName;
     use serde_json::json;
     use sui_gateway::events::{ContractCall, SignersRotated};
     use sui_gateway::{WeightedSigner, WeightedSigners};
@@ -208,7 +207,7 @@ mod tests {
     fn should_not_verify_msg_if_destination_chain_does_not_match() {
         let (gateway_address, tx_receipt, mut msg) = matching_msg_and_tx_block();
 
-        msg.destination_chain = rand_chain_name();
+        msg.destination_chain = rand_chain_name().parse().unwrap();
         assert_eq!(
             verify_message(&gateway_address, &tx_receipt, &msg),
             Vote::NotFound
@@ -240,6 +239,15 @@ mod tests {
     #[test]
     fn should_verify_msg_if_correct() {
         let (gateway_address, tx_block, msg) = matching_msg_and_tx_block();
+        assert_eq!(
+            verify_message(&gateway_address, &tx_block, &msg),
+            Vote::SucceededOnChain
+        );
+    }
+
+    #[test]
+    fn should_verify_msg_if_chain_uses_different_casing() {
+        let (gateway_address, tx_block, msg) = msg_and_tx_block_with_different_chain_casing();
         assert_eq!(
             verify_message(&gateway_address, &tx_block, &msg),
             Vote::SucceededOnChain
@@ -352,23 +360,27 @@ mod tests {
         );
     }
 
-    fn matching_msg_and_tx_block() -> (SuiAddress, SuiTransactionBlockResponse, Message) {
-        let gateway_address = SuiAddress::random_for_testing_only();
-
-        let msg = Message {
+    fn mock_message(destination_chain: &str) -> Message {
+        Message {
             message_id: Base58TxDigestAndEventIndex::new(
                 TransactionDigest::random(),
                 rand::random::<u64>(),
             ),
             source_address: SuiAddress::random_for_testing_only(),
-            destination_chain: rand_chain_name(),
+            destination_chain: destination_chain.parse().unwrap(),
             destination_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
             payload_hash: Hash::random(),
-        };
+        }
+    }
 
+    fn mock_tx_block(
+        destination_chain: &str,
+        gateway_address: SuiAddress,
+        msg: &Message,
+    ) -> SuiTransactionBlockResponse {
         let contract_call = ContractCall {
             destination_address: msg.destination_address.clone(),
-            destination_chain: msg.destination_chain.to_string(),
+            destination_chain: destination_chain.to_string(),
             payload: msg.payload_hash.to_fixed_bytes().to_vec(),
             payload_hash: msg.payload_hash.to_fixed_bytes(),
             source_id: msg.source_address.to_string().parse().unwrap(),
@@ -392,11 +404,29 @@ mod tests {
             timestamp_ms: None,
         };
 
-        let tx_block = SuiTransactionBlockResponse {
+        SuiTransactionBlockResponse {
             digest: msg.message_id.tx_digest.into(),
             events: Some(SuiTransactionBlockEvents { data: vec![event] }),
             ..Default::default()
-        };
+        }
+    }
+
+    fn matching_msg_and_tx_block() -> (SuiAddress, SuiTransactionBlockResponse, Message) {
+        let gateway_address = SuiAddress::random_for_testing_only();
+
+        let destination_chain = rand_chain_name();
+        let msg = mock_message(&destination_chain);
+        let tx_block = mock_tx_block(&destination_chain, gateway_address, &msg);
+
+        (gateway_address, tx_block, msg)
+    }
+
+    fn msg_and_tx_block_with_different_chain_casing(
+    ) -> (SuiAddress, SuiTransactionBlockResponse, Message) {
+        let gateway_address = SuiAddress::random_for_testing_only();
+
+        let msg = mock_message("ethereum");
+        let tx_block = mock_tx_block("Ethereum", gateway_address, &msg);
 
         (gateway_address, tx_block, msg)
     }
@@ -490,8 +520,8 @@ mod tests {
         (gateway_address, tx_block, verifier_set_confirmation)
     }
 
-    fn rand_chain_name() -> ChainName {
+    fn rand_chain_name() -> String {
         let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        generate(8, charset).parse().unwrap()
+        generate(8, charset)
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
