### PR TITLE
fix(ampd): use ChainNameRaw for destination chain

### DIFF
--- a/ampd/src/xrpl/verifier.rs
+++ b/ampd/src/xrpl/verifier.rs
@@ -320,7 +320,7 @@ mod test {
 
     use axelar_wasm_std::msg_id::HexTxHash;
     use axelar_wasm_std::nonempty;
-    use router_api::ChainName;
+    use router_api::ChainNameRaw;
     use xrpl_http_client::Memo;
     use xrpl_types::msg::XRPLInterchainTransferMessage;
     use xrpl_types::types::{XRPLAccountId, XRPLPaymentAmount};
@@ -342,7 +342,7 @@ mod test {
             },
             Memo {
                 memo_type: Some("64657374696E6174696F6E5F636861696E".to_string()), // destination_chain
-                memo_data: Some("657468657265756D".to_string()),
+                memo_data: Some("457468657265756D".to_string()),
                 memo_format: None,
             },
             Memo {
@@ -363,7 +363,7 @@ mod test {
                 "592639c10223c4ec6c0ffc670e94d289a25dd1ad".to_string(),
             )
             .unwrap(),
-            destination_chain: ChainName::from_str("ethereum").unwrap(),
+            destination_chain: ChainNameRaw::from_str("Ethereum").unwrap(),
             payload_hash: Some(
                 hex::decode("40e7ed31929500a6a4945765612bac44a71fe18ef7a1bf3d904811558b41354f")
                     .unwrap()
@@ -417,7 +417,7 @@ mod test {
                 "592639c10223c4ec6c0ffc670e94d289a25dd1ad".to_string(),
             )
             .unwrap(),
-            destination_chain: ChainName::from_str("ethereum").unwrap(),
+            destination_chain: ChainNameRaw::from_str("ethereum").unwrap(),
             payload_hash: None,
             transfer_amount: XRPLPaymentAmount::Drops(100000),
             gas_fee_amount: XRPLPaymentAmount::Drops(50000),

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -2,7 +2,7 @@ use axelar_wasm_std::msg_id::HexTxHash;
 use axelar_wasm_std::nonempty;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Attribute, HexBinary};
-use router_api::{ChainName, ChainNameRaw, CrossChainId, FIELD_DELIMITER};
+use router_api::{ChainNameRaw, CrossChainId, FIELD_DELIMITER};
 use sha3::{Digest, Keccak256};
 
 use crate::types::{xrpl_account_id_string, XRPLAccountId, XRPLPaymentAmount};
@@ -116,7 +116,7 @@ pub struct XRPLInterchainTransferMessage {
     #[serde(with = "xrpl_account_id_string")]
     #[schemars(with = "String")]
     pub source_address: XRPLAccountId,
-    pub destination_chain: ChainName,
+    pub destination_chain: ChainNameRaw,
     pub destination_address: nonempty::String,
     /// for better user experience, the payload hash gets encoded into hex at the edges (input/output),
     /// but internally, we treat it as raw bytes to enforce its format.
@@ -141,7 +141,7 @@ pub struct XRPLCallContractMessage {
     #[serde(with = "xrpl_account_id_string")]
     #[schemars(with = "String")]
     pub source_address: XRPLAccountId,
-    pub destination_chain: ChainName,
+    pub destination_chain: ChainNameRaw,
     pub destination_address: nonempty::String,
     /// for better user experience, the payload hash gets encoded into hex at the edges (input/output),
     /// but internally, we treat it as raw bytes to enforce its format.


### PR DESCRIPTION
## Description

Use `ChainNameRaw` instead of `ChainName` in `XRPLInterchainTransferMessage` and `XRPLCallContractMessage ` destination chain.

`test_verify_interchain_transfer_memos` fails when `ChainName` is used instead of `ChainNameRaw`, because `ChainName` converts "Ethereum" to lowercase "ethereum", while the `destination_chain` memo field has value `hex("Ethereum")`.

The same fix was applied to other intergrations' `ampd` verifiers here: https://github.com/axelarnetwork/axelar-amplifier/pull/785.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
