### PR TITLE
fix(ampd): backport chain name case insensitive comparisons

### DIFF
--- a/ampd/src/evm/verifier.rs
+++ b/ampd/src/evm/verifier.rs
@@ -133,6 +133,8 @@ pub fn verify_verifier_set(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
     use axelar_wasm_std::voting::Vote;
     use cosmwasm_std::Uint128;
@@ -326,6 +328,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn should_verify_msg_if_chain_uses_different_casing() {
+        let (gateway_address, tx_receipt, msg) = msg_and_tx_receipt_with_different_chain_casing();
+
+        assert_eq!(
+            verify_message(&gateway_address, &tx_receipt, &msg),
+            Vote::SucceededOnChain
+        );
+    }
+
     fn matching_verifier_set_and_tx_receipt(
     ) -> (EVMAddress, TransactionReceipt, VerifierSetConfirmation) {
         let tx_id = Hash::random();
@@ -364,12 +376,11 @@ mod tests {
         (gateway_address, tx_receipt, verifier_set)
     }
 
-    fn matching_msg_and_tx_receipt() -> (EVMAddress, TransactionReceipt, Message) {
+    fn mock_message(destination_chain: &str) -> Message {
         let tx_id = Hash::random();
         let log_index = 1;
-        let gateway_address = EVMAddress::random();
 
-        let msg = Message {
+        Message {
             message_id: HexTxHashAndEventIndex::new(tx_id, log_index as u64)
                 .to_string()
                 .parse()
@@ -377,30 +388,73 @@ mod tests {
             source_address: "0xd48e199950589a4336e4dc43bd2c72ba0c0baa86"
                 .parse()
                 .unwrap(),
-            destination_chain: "ethereum-2".parse().unwrap(),
+            destination_chain: destination_chain.parse().unwrap(),
             destination_address: "0xb9845f9247a85Ee592273a79605f34E8607d7e75".into(),
             payload_hash: "0x9fcef596d62dca8e51b6ba3414901947c0e6821d4483b2f3327ce87c2d4e662e"
                 .parse()
                 .unwrap(),
+        }
+    }
+
+    fn mock_tx_receipt(
+        destination_chain: &str,
+        gateway_address: ethers_core::types::H160,
+        msg: &Message,
+    ) -> TransactionReceipt {
+        let tx_id = msg.message_id.tx_hash.into();
+        let log_index = msg.message_id.event_index.into();
+
+        let filter = ContractCallFilter {
+            sender: msg.source_address,
+            destination_chain: destination_chain.into(),
+            destination_contract_address: msg.destination_address.clone(),
+            payload_hash: msg.payload_hash.into(),
+            payload: ethers_core::types::Bytes::from_str("0x627566666572").unwrap(),
         };
-        let log = Log{
+
+        let data = ethers_core::abi::encode(&[
+            Token::String(filter.destination_chain.clone()),
+            Token::String(filter.destination_contract_address.clone()),
+            Token::Bytes(filter.payload.to_vec()),
+        ]);
+
+        let log = Log {
             transaction_hash: Some(tx_id),
-            log_index: Some(log_index.into()),
+            log_index: Some(log_index),
             address: gateway_address,
             topics: vec![
                 ContractCallFilter::signature(),
-                "0x000000000000000000000000d48e199950589a4336e4dc43bd2c72ba0c0baa86".parse().unwrap(),
-                "0x9fcef596d62dca8e51b6ba3414901947c0e6821d4483b2f3327ce87c2d4e662e".parse().unwrap(),
+                H256::from(filter.sender),
+                filter.payload_hash.into(),
             ],
-            data : "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000a657468657265756d2d3200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a3078623938343566393234376138354565353932323733613739363035663334453836303764376537350000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066275666665720000000000000000000000000000000000000000000000000000".parse().unwrap(),
+            data: data.into(),
             ..Default::default()
         };
-        let tx_receipt = TransactionReceipt {
+
+        TransactionReceipt {
             transaction_hash: tx_id,
             status: Some(1u64.into()),
             logs: vec![Log::default(), log, Log::default()],
             ..Default::default()
-        };
+        }
+    }
+
+    fn matching_msg_and_tx_receipt() -> (EVMAddress, TransactionReceipt, Message) {
+        let gateway_address = EVMAddress::random();
+
+        let destination_chain = "ethereum-2";
+        let msg = mock_message(destination_chain);
+        let tx_receipt = mock_tx_receipt(destination_chain, gateway_address, &msg);
+
+        (gateway_address, tx_receipt, msg)
+    }
+
+    fn msg_and_tx_receipt_with_different_chain_casing() -> (EVMAddress, TransactionReceipt, Message)
+    {
+        let gateway_address = EVMAddress::random();
+
+        let msg = mock_message("ethereum-2");
+        let tx_receipt = mock_tx_receipt("Ethereum-2", gateway_address, &msg);
 
         (gateway_address, tx_receipt, msg)
     }

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -32,7 +32,7 @@ use crate::types::TMAddress;
 pub struct Message {
     pub message_id: HexTxHashAndEventIndex,
     pub destination_address: ScString,
-    pub destination_chain: ScString,
+    pub destination_chain: ChainName,
     #[serde_as(as = "DisplayFromStr")]
     pub source_address: ScAddress,
     pub payload_hash: ScBytes,

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -424,7 +424,7 @@ mod tests {
             .parse()
             .unwrap();
 
-        let msg = Message {
+        Message {
             tx_id,
             event_index: 1,
             source_address,

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -5,6 +5,8 @@ use hex::ToHex;
 use multiversx_sdk::data::address::Address;
 use multiversx_sdk::data::transaction::{Events, TransactionOnNetwork};
 use num_traits::cast;
+use router_api::ChainName;
+use tracing::debug;
 
 use crate::handlers::mvx_verify_msg::Message;
 use crate::handlers::mvx_verify_verifier_set::VerifierSetConfirmation;
@@ -41,6 +43,8 @@ impl Message {
         let destination_chain = topics.get(2).ok_or(Error::PropertyEmpty)?;
         let destination_chain = STANDARD.decode(destination_chain)?;
         let destination_chain = String::from_utf8(destination_chain)?;
+        let destination_chain = ChainName::try_from(destination_chain)
+            .inspect_err(|e| debug!(error = ?e, "failed to parse destination chain"))?;
         if destination_chain != self.destination_chain.as_ref() {
             return Ok(false);
         }

--- a/ampd/src/mvx/verifier.rs
+++ b/ampd/src/mvx/verifier.rs
@@ -292,6 +292,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn should_verify_msg_if_chain_uses_different_casing() {
+        let (gateway_address, tx, msg) = msg_and_tx_on_network_with_different_chain_casing();
+
+        assert_eq!(
+            verify_message(&gateway_address, &tx, &msg),
+            Vote::SucceededOnChain
+        );
+    }
+
     // test verify worker set
     #[test]
     fn should_not_verify_verifier_set_if_tx_id_does_not_match() {
@@ -405,11 +415,7 @@ mod tests {
         );
     }
 
-    fn get_matching_msg_and_tx() -> (Address, TransactionOnNetwork, Message) {
-        let gateway_address = Address::from_bech32_string(
-            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
-        )
-        .unwrap();
+    fn mock_message(destination_chain: &str) -> Message {
         let source_address = Address::from_bech32_string(
             "erd1qqqqqqqqqqqqqpgqzqvm5ywqqf524efwrhr039tjs29w0qltkklsa05pk7",
         )
@@ -422,12 +428,17 @@ mod tests {
             tx_id,
             event_index: 1,
             source_address,
-            destination_chain: "ethereum".parse().unwrap(),
+            destination_chain: destination_chain.parse().unwrap(),
             destination_address: format!("0x{:x}", EVMAddress::random()).parse().unwrap(),
             payload_hash: Hash::random(),
-        };
+        }
+    }
 
-        // Only the first 32 bytes matter for data
+    fn mock_tx_on_network(
+        destination_chain: &str,
+        gateway_address: &Address,
+        msg: &Message,
+    ) -> TransactionOnNetwork {
         let payload_hash = msg.payload_hash;
 
         let wrong_event = Events {
@@ -444,7 +455,7 @@ mod tests {
             topics: Some(vec![
                 STANDARD.encode(CONTRACT_CALL_EVENT),
                 STANDARD.encode(msg.source_address.clone().to_bytes()),
-                STANDARD.encode(msg.destination_chain.to_string()),
+                STANDARD.encode(destination_chain),
                 STANDARD.encode(msg.destination_address.clone()),
                 STANDARD.encode(payload_hash),
             ]),
@@ -455,7 +466,8 @@ mod tests {
             "erd1qqqqqqqqqqqqqpgqzqvm5ywqqf524efwrhr039tjs29w0qltkklsa05pk7",
         )
         .unwrap();
-        let tx_block = TransactionOnNetwork {
+
+        TransactionOnNetwork {
             hash: Some(msg.tx_id.encode_hex::<String>()),
             logs: Some(ApiLogs {
                 address: other_address.clone(),
@@ -489,7 +501,31 @@ mod tests {
             hyperblock_hash: Some("".into()),
             smart_contract_results: vec![],
             processing_type_on_destination: "".into(),
-        };
+        }
+    }
+
+    fn get_matching_msg_and_tx() -> (Address, TransactionOnNetwork, Message) {
+        let gateway_address = Address::from_bech32_string(
+            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
+        )
+        .unwrap();
+
+        let destination_chain = "ethereum";
+        let msg = mock_message(destination_chain);
+        let tx_block = mock_tx_on_network(destination_chain, &gateway_address, &msg);
+
+        (gateway_address, tx_block, msg)
+    }
+
+    fn msg_and_tx_on_network_with_different_chain_casing(
+    ) -> (Address, TransactionOnNetwork, Message) {
+        let gateway_address = Address::from_bech32_string(
+            "erd1qqqqqqqqqqqqqpgqsvzyz88e8v8j6x3wquatxuztnxjwnw92kkls6rdtzx",
+        )
+        .unwrap();
+
+        let msg = mock_message("ethereum");
+        let tx_block = mock_tx_on_network("Ethereum", &gateway_address, &msg);
 
         (gateway_address, tx_block, msg)
     }

--- a/ampd/src/stellar/verifier.rs
+++ b/ampd/src/stellar/verifier.rs
@@ -1,8 +1,10 @@
 use std::str::FromStr;
 
 use axelar_wasm_std::voting::Vote;
+use router_api::ChainName;
 use stellar::WeightedSigners;
 use stellar_xdr::curr::{BytesM, ContractEventBody, ScAddress, ScBytes, ScSymbol, ScVal, StringM};
+use tracing::debug;
 
 use crate::handlers::stellar_verify_msg::Message;
 use crate::handlers::stellar_verify_verifier_set::VerifierSetConfirmation;
@@ -30,10 +32,21 @@ impl PartialEq<ContractEventBody> for Message {
         )
         .into();
 
-        expected_topic == *symbol
+        let matches_destination_chain = match destination_chain {
+            ScVal::String(s) => match ChainName::try_from(s.to_string()) {
+                Ok(chain) => chain == self.destination_chain.to_string(),
+                Err(e) => {
+                    debug!(error = ?e, "failed to parse destination chain");
+                    false
+                }
+            },
+            _ => false,
+        };
+
+        matches_destination_chain
+            && expected_topic == *symbol
             && (ScVal::Address(self.source_address.clone()) == *source_address)
             && (ScVal::Bytes(self.payload_hash.clone()) == *payload_hash)
-            && (ScVal::String(self.destination_chain.clone()) == *destination_chain)
             && (ScVal::String(self.destination_address.clone()) == *destination_address)
     }
 }


### PR DESCRIPTION
## Description

This cherrypicks these PRs:
https://github.com/axelarnetwork/axelar-amplifier/pull/785
https://github.com/axelarnetwork/axelar-amplifier/pull/787

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
