### PR TITLE
feat(ci): add dry run option to ampd release job

### DIFF
--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -8,9 +8,9 @@ on:
         required: true
         default: latest
       dry_run:
-        description: Run in dry-run mode (no uploads to S3, no GitHub releases, no Docker pushes)
-        default: true
-        type: boolean
+        description: Run in dry-run mode (set to false to actually release)
+        required: true
+        default: 'true'
 
 jobs:
   extract-semver:
@@ -174,7 +174,7 @@ jobs:
           done
 
       - name: Upload binaries to release
-        if: ${{ !github.event.inputs.dry-run }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
           file_glob: true
 
       - name: Upload binaries to S3
-        if: ${{ !github.event.inputs.dry-run }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         env:
           S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
         run: |
@@ -200,7 +200,7 @@ jobs:
           echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
 
       - name: Upload to R2
-        if: ${{ !github.event.inputs.dry-run }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: ryand56/r2-upload-action@v1.3.2
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
@@ -217,7 +217,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    if: ${{ !github.event.inputs.dry-run }}
+    if: ${{ github.event.inputs.dry-run == 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -254,7 +254,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    if: ${{ !github.event.inputs.dry-run }}
+    if: ${{ github.event.inputs.dry-run == 'false' }}
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -10,7 +10,7 @@ on:
       dry_run:
         description: Run in dry-run mode (no uploads to S3, no GitHub releases, no Docker pushes)
         required: false
-        default: false
+        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -9,7 +9,6 @@ on:
         default: latest
       dry_run:
         description: Run in dry-run mode (no uploads to S3, no GitHub releases, no Docker pushes)
-        required: false
         default: true
         type: boolean
 

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -7,6 +7,11 @@ on:
         description: Github tag to release binaries for (reusing an existing tag will make the pipeline fail)
         required: true
         default: latest
+      dry_run:
+        description: Run in dry-run mode (no uploads to S3, no GitHub releases, no Docker pushes)
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   extract-semver:
@@ -170,6 +175,7 @@ jobs:
           done
 
       - name: Upload binaries to release
+        if: ${{ !github.event.inputs.dry-run }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -179,6 +185,7 @@ jobs:
           file_glob: true
 
       - name: Upload binaries to S3
+        if: ${{ !github.event.inputs.dry-run }}
         env:
           S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
         run: |
@@ -192,9 +199,10 @@ jobs:
           cp -R ./ampdbin/. "./${version}/"
           echo "release-dir=./${version}" >> $GITHUB_OUTPUT
           echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
-          
 
-      - uses: ryand56/r2-upload-action@latest
+      - name: Upload to R2
+        if: ${{ !github.event.inputs.dry-run }}
+        uses: ryand56/r2-upload-action@v1.3.2
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
@@ -210,6 +218,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+    if: ${{ !github.event.inputs.dry-run }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -246,6 +255,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+    if: ${{ !github.event.inputs.dry-run }}
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,10 @@ on:
         description: Dry run
         type: boolean
         default: true
+      random-token:
+        description: test out
+        default: true
+        type: boolean
 
 jobs:
   release:
@@ -65,6 +69,17 @@ jobs:
               echo "Unknown binary to release"
               exit 1
           fi
+        
+      - name: test out random token being true
+        if: ${{ github.event.inputs.random-token }}
+        run: |
+          echo "it is set to true"
+          pwd
+      
+      - name: test out random token being false
+        if: ${{ !github.event.inputs.random-token }}
+        run: |
+          echo "it is set to false"
 
       - name: Release ${{ github.event.inputs.binary-to-release }}
         uses: ./.github/actions/release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,6 @@ on:
         description: Dry run
         type: boolean
         default: true
-      random-token:
-        description: test out
-        default: true
-        type: boolean
 
 jobs:
   release:
@@ -69,17 +65,6 @@ jobs:
               echo "Unknown binary to release"
               exit 1
           fi
-        
-      - name: test out random token being true
-        if: ${{ github.event.inputs.random-token }}
-        run: |
-          echo "it is set to true"
-          pwd
-      
-      - name: test out random token being false
-        if: ${{ !github.event.inputs.random-token }}
-        run: |
-          echo "it is set to false"
 
       - name: Release ${{ github.event.inputs.binary-to-release }}
         uses: ./.github/actions/release


### PR DESCRIPTION
## Description
AXE-8416

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
