### PR TITLE
fix(ci): ampd dry run release condition 

### DIFF
--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -7,7 +7,7 @@ on:
         description: Github tag to release binaries for (reusing an existing tag will make the pipeline fail)
         required: true
         default: latest
-      dry_run:
+      dry-run:
         description: Run in dry-run mode (set to false to actually release)
         required: true
         default: 'true'
@@ -177,7 +177,7 @@ jobs:
           done
 
       - name: Upload binaries to release
-        if: github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry-run == 'false'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -187,7 +187,7 @@ jobs:
           file_glob: true
 
       - name: Upload binaries to S3
-        if: github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry-run == 'false'
         env:
           S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
         run: |
@@ -203,7 +203,7 @@ jobs:
           echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
 
       - name: Upload to R2
-        if: github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry-run == 'false'
         uses: ryand56/r2-upload-action@v1.3.2
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
@@ -220,7 +220,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    if: github.event.inputs.dry_run == 'false'
+    if: github.event.inputs.dry-run == 'false'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -257,7 +257,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    if: github.event.inputs.dry_run == 'false'
+    if: github.event.inputs.dry-run == 'false'
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -13,304 +13,272 @@ on:
         default: 'true'
 
 jobs:
-  debug-inputs:
+  extract-semver:
     runs-on: ubuntu-22.04
-    name: Debug workflow inputs
+    name: Validate tag and extract semver
+    outputs:
+      semver: ${{ steps.extract_semver.outputs.semver }}
+      version: ${{ steps.extract_semver.outputs.version }}
     steps:
-      - name: Debug dry_run input
+      - name: Extract semver from tag
+        id: extract_semver
         run: |
-          echo "Raw dry_run input: '${{ github.event.inputs.dry_run }}'"
-          echo "Type of dry_run input: $(typeof '${{ github.event.inputs.dry_run }}')"
+          full_semver=$(echo ${{ github.event.inputs.tag }} | sed 's/ampd-//')
+          version_number=$(echo $full_semver | sed 's/^v//')
+          echo "semver=$full_semver" >> $GITHUB_OUTPUT
+          echo "version=$version_number" >> $GITHUB_OUTPUT
+
+      - name: Validate tag
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          SEMVER: ${{ steps.extract_semver.outputs.semver }}
+        run: |
+          if [[ $TAG =~ ampd-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
+          aws s3 ls s3://axelar-releases/ampd/"$SEMVER" && echo "tag already exists, use a new one" && exit 1
+
+
+
+  release-binaries:
+    runs-on: ${{ matrix.os }}
+    needs: extract-semver
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, macos-14 ]
+        arch: [ amd64, arm64 ]
+        exclude:
+          - os: macos-14
+            arch: amd64
+
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          ref: ${{ github.event.inputs.tag }}
+          submodules: recursive
+          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81.0
+          override: true
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: build and sign darwin binaries
+        env:
+          SEMVER: ${{ needs.extract-semver.outputs.semver }}
+        if: matrix.os == 'macos-14'
+        run: |
+          OS="darwin"
+          ARCH="${{ matrix.arch }}"
           
-          echo "Testing dry_run == 'false': $([ '${{ github.event.inputs.dry_run }}' == 'false' ] && echo 'true' || echo 'false')"
-          echo "Testing dry_run != 'true': $([ '${{ github.event.inputs.dry_run }}' != 'true' ] && echo 'true' || echo 'false')"
+          brew install protobuf
           
-          if [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
-            echo "dry_run is exactly the string 'false'"
+          if [ "$ARCH" == "arm64" ]
+          then
+            rustup target add aarch64-apple-darwin
+            cargo build --release --target aarch64-apple-darwin
+            mkdir ampdbin
+            mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-apple-darwin/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
           else
-            echo "dry_run is NOT the string 'false', it is: '${{ github.event.inputs.dry_run }}'"
+            cargo build --release
+            mkdir ampdbin
+            mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
           fi
           
-          # Try lowercase conversion in case of capitalization issues
-          LOWERCASE_DRY_RUN=$(echo "${{ github.event.inputs.dry_run }}" | tr '[:upper:]' '[:lower:]')
-          echo "Lowercase version: '$LOWERCASE_DRY_RUN'"
-          if [ "$LOWERCASE_DRY_RUN" = "false" ]; then
-            echo "Lowercase dry_run is 'false'"
+          gpg --armor --detach-sign "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+
+      - name: build and sign linux binaries
+        env:
+          SEMVER: ${{ needs.extract-semver.outputs.semver }}
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          OS="linux"
+          ARCH="${{ matrix.arch }}"
+          sudo apt-get install protobuf-compiler
+          
+          if [ "$ARCH" == "arm64" ]
+          then
+            sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            rustup target add aarch64-unknown-linux-gnu
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            cargo build --release --target aarch64-unknown-linux-gnu
+            mkdir ampdbin
+            mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-unknown-linux-gnu/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"            
           else
-            echo "Lowercase dry_run is not 'false'"
+            cargo build --release
+            mkdir ampdbin
+            mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+          fi     
+          
+           gpg --armor --detach-sign  "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+
+
+      - name: Test Binary Format
+        working-directory: ./ampdbin
+        run: |
+          for binary in ./ampd-*; do
+          if [[ "$binary" != *.asc ]]; then
+            echo "Testing binary: $binary"
+            OUTPUT=$(file "$binary" | cut -d: -f2- | awk -F, '{print $1"," $2}')
+            if [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
+              if [[ "${{ matrix.arch }}" == "amd64" ]]; then
+                EXPECTED="ELF 64-bit LSB pie executable, x86-64"
+              elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+                EXPECTED="ELF 64-bit LSB pie executable, ARM aarch64"
+              fi
+            elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+              OUTPUT=$(file "$binary" | cut -d: -f2-)
+              if [[ "${{ matrix.arch }}" == "amd64" ]]; then
+                EXPECTED="Mach-O 64-bit executable x86_64"
+              elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+                EXPECTED="Mach-O 64-bit executable arm64"
+              fi
+            fi
+
+            echo "Output: $OUTPUT"
+            echo "Expected: $EXPECTED"
+
+            if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+              echo "The binary format is correct."
+            else
+              echo "Error: The binary format does not match the expected format."
+              exit 1
+            fi
           fi
-      
-      - name: Random step
+          done
+
+      - name: Create zip and sha256 files
+        working-directory: ./ampdbin
+        run: |
+          for i in `ls | grep -v .asc`
+          do
+            shasum -a 256 $i | awk '{print $1}' > $i.sha256
+            zip $i.zip $i
+            shasum -a 256 $i.zip | awk '{print $1}' > $i.zip.sha256
+          done
+
+      - name: Upload binaries to release
         if: github.event.inputs.dry_run == 'false'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./ampdbin/*
+          tag: ${{ github.event.inputs.tag }}
+          overwrite: true
+          file_glob: true
+
+      - name: Upload binaries to S3
+        if: github.event.inputs.dry_run == 'false'
+        env:
+          S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
         run: |
-         echo "This step will only run if dry_run is 'false'"
+          aws s3 cp ./ampdbin ${S3_PATH}/ --recursive
 
-  # extract-semver:
-  #   runs-on: ubuntu-22.04
-  #   name: Validate tag and extract semver
-  #   outputs:
-  #     semver: ${{ steps.extract_semver.outputs.semver }}
-  #     version: ${{ steps.extract_semver.outputs.version }}
-  #   steps:
-  #     - name: Extract semver from tag
-  #       id: extract_semver
-  #       run: |
-  #         full_semver=$(echo ${{ github.event.inputs.tag }} | sed 's/ampd-//')
-  #         version_number=$(echo $full_semver | sed 's/^v//')
-  #         echo "semver=$full_semver" >> $GITHUB_OUTPUT
-  #         echo "version=$version_number" >> $GITHUB_OUTPUT
+      - name: Prepare source directory structure for r2 upload
+        id: prepare-r2-release
+        run: |
+          version="${{ needs.extract-semver.outputs.version }}"
+          mkdir -p "./${version}"
+          cp -R ./ampdbin/. "./${version}/"
+          echo "release-dir=./${version}" >> $GITHUB_OUTPUT
+          echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
 
-  #     - name: Validate tag
-  #       env:
-  #         TAG: ${{ github.event.inputs.tag }}
-  #         SEMVER: ${{ steps.extract_semver.outputs.semver }}
-  #       run: |
-  #         if [[ $TAG =~ ampd-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
-  #         aws s3 ls s3://axelar-releases/ampd/"$SEMVER" && echo "tag already exists, use a new one" && exit 1
+      - name: Upload to R2
+        if: github.event.inputs.dry_run == 'false'
+        uses: ryand56/r2-upload-action@v1.3.2
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
+          r2-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CF }}
+          r2-bucket: ${{ secrets.R2_BUCKET }}
+          source-dir: ${{ steps.prepare-r2-release.outputs.release-dir }}
+          destination-dir: ${{ steps.prepare-r2-release.outputs.r2-destination-dir }}
 
+  release-docker:
+    runs-on: ubuntu-22.04
+    needs: extract-semver
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    if: github.event.inputs.dry_run == 'false'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          ref: ${{ github.event.inputs.tag }}
+          submodules: recursive
+          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-  # release-binaries:
-  #   runs-on: ${{ matrix.os }}
-  #   needs: extract-semver
-  #   strategy:
-  #     matrix:
-  #       os: [ ubuntu-22.04, macos-14 ]
-  #       arch: [ amd64, arm64 ]
-  #       exclude:
-  #         - os: macos-14
-  #           arch: amd64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
 
-  #   permissions:
-  #     contents: write
-  #     packages: write
-  #     id-token: write
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-  #   steps:
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         aws-region: us-east-2
-  #         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
+      - name: Build and push docker images
+        env:
+          PLATFORM: linux/amd64
+          SEMVER: ${{ needs.extract-semver.outputs.semver }}
+        run: |
+          make build-push-docker-images
 
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: '0'
-  #         ref: ${{ github.event.inputs.tag }}
-  #         submodules: recursive
-  #         token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
+  combine-sign:
+    needs: [ release-docker, extract-semver ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    if: github.event.inputs.dry_run == 'false'
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.3.0
+        with:
+          cosign-release: 'v2.2.2'
 
-  #     - name: Set up Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: 1.81.0
-  #         override: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-  #     - name: Import GPG key
-  #       id: import_gpg
-  #       uses: crazy-max/ghaction-import-gpg@v6
-  #       with:
-  #         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-  #         passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Create multiarch manifest
+        env:
+          SEMVER: ${{ needs.extract-semver.outputs.semver }}
+        run: |
+          docker buildx imagetools create -t axelarnet/axelar-ampd:${SEMVER} \
+            axelarnet/axelar-ampd-linux-amd64:${SEMVER}
 
-  #     - name: build and sign darwin binaries
-  #       env:
-  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
-  #       if: matrix.os == 'macos-14'
-  #       run: |
-  #         OS="darwin"
-  #         ARCH="${{ matrix.arch }}"
-          
-  #         brew install protobuf
-          
-  #         if [ "$ARCH" == "arm64" ]
-  #         then
-  #           rustup target add aarch64-apple-darwin
-  #           cargo build --release --target aarch64-apple-darwin
-  #           mkdir ampdbin
-  #           mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-apple-darwin/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-  #         else
-  #           cargo build --release
-  #           mkdir ampdbin
-  #           mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-  #         fi
-          
-  #         gpg --armor --detach-sign "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-
-  #     - name: build and sign linux binaries
-  #       env:
-  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
-  #       if: matrix.os == 'ubuntu-22.04'
-  #       run: |
-  #         OS="linux"
-  #         ARCH="${{ matrix.arch }}"
-  #         sudo apt-get install protobuf-compiler
-          
-  #         if [ "$ARCH" == "arm64" ]
-  #         then
-  #           sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-  #           rustup target add aarch64-unknown-linux-gnu
-  #           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-  #           cargo build --release --target aarch64-unknown-linux-gnu
-  #           mkdir ampdbin
-  #           mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-unknown-linux-gnu/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"            
-  #         else
-  #           cargo build --release
-  #           mkdir ampdbin
-  #           mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-  #         fi     
-          
-  #          gpg --armor --detach-sign  "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-
-
-  #     - name: Test Binary Format
-  #       working-directory: ./ampdbin
-  #       run: |
-  #         for binary in ./ampd-*; do
-  #         if [[ "$binary" != *.asc ]]; then
-  #           echo "Testing binary: $binary"
-  #           OUTPUT=$(file "$binary" | cut -d: -f2- | awk -F, '{print $1"," $2}')
-  #           if [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
-  #             if [[ "${{ matrix.arch }}" == "amd64" ]]; then
-  #               EXPECTED="ELF 64-bit LSB pie executable, x86-64"
-  #             elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
-  #               EXPECTED="ELF 64-bit LSB pie executable, ARM aarch64"
-  #             fi
-  #           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
-  #             OUTPUT=$(file "$binary" | cut -d: -f2-)
-  #             if [[ "${{ matrix.arch }}" == "amd64" ]]; then
-  #               EXPECTED="Mach-O 64-bit executable x86_64"
-  #             elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
-  #               EXPECTED="Mach-O 64-bit executable arm64"
-  #             fi
-  #           fi
-
-  #           echo "Output: $OUTPUT"
-  #           echo "Expected: $EXPECTED"
-
-  #           if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
-  #             echo "The binary format is correct."
-  #           else
-  #             echo "Error: The binary format does not match the expected format."
-  #             exit 1
-  #           fi
-  #         fi
-  #         done
-
-  #     - name: Create zip and sha256 files
-  #       working-directory: ./ampdbin
-  #       run: |
-  #         for i in `ls | grep -v .asc`
-  #         do
-  #           shasum -a 256 $i | awk '{print $1}' > $i.sha256
-  #           zip $i.zip $i
-  #           shasum -a 256 $i.zip | awk '{print $1}' > $i.zip.sha256
-  #         done
-
-  #     - name: Upload binaries to release
-  #       if: ${{ github.event.inputs.dry-run == 'false' }}
-  #       uses: svenstaro/upload-release-action@v2
-  #       with:
-  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #         file: ./ampdbin/*
-  #         tag: ${{ github.event.inputs.tag }}
-  #         overwrite: true
-  #         file_glob: true
-
-  #     - name: Upload binaries to S3
-  #       if: ${{ github.event.inputs.dry-run == 'false' }}
-  #       env:
-  #         S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
-  #       run: |
-  #         aws s3 cp ./ampdbin ${S3_PATH}/ --recursive
-
-  #     - name: Prepare source directory structure for r2 upload
-  #       id: prepare-r2-release
-  #       run: |
-  #         version="${{ needs.extract-semver.outputs.version }}"
-  #         mkdir -p "./${version}"
-  #         cp -R ./ampdbin/. "./${version}/"
-  #         echo "release-dir=./${version}" >> $GITHUB_OUTPUT
-  #         echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
-
-  #     - name: Upload to R2
-  #       if: ${{ github.event.inputs.dry-run == 'false' }}
-  #       uses: ryand56/r2-upload-action@v1.3.2
-  #       with:
-  #         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-  #         r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
-  #         r2-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CF }}
-  #         r2-bucket: ${{ secrets.R2_BUCKET }}
-  #         source-dir: ${{ steps.prepare-r2-release.outputs.release-dir }}
-  #         destination-dir: ${{ steps.prepare-r2-release.outputs.r2-destination-dir }}
-
-  # release-docker:
-  #   runs-on: ubuntu-22.04
-  #   needs: extract-semver
-  #   permissions:
-  #     contents: write
-  #     packages: write
-  #     id-token: write
-  #   if: ${{ github.event.inputs.dry-run == 'false' }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: '0'
-  #         ref: ${{ github.event.inputs.tag }}
-  #         submodules: recursive
-  #         token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
-
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
-
-  #     - name: Set up Docker Buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@v3
-
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-  #     - name: Build and push docker images
-  #       env:
-  #         PLATFORM: linux/amd64
-  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
-  #       run: |
-  #         make build-push-docker-images
-
-  # combine-sign:
-  #   needs: [ release-docker, extract-semver ]
-  #   runs-on: ubuntu-22.04
-  #   permissions:
-  #     contents: write
-  #     packages: write
-  #     id-token: write
-  #   if: ${{ github.event.inputs.dry-run == 'false' }}
-  #   steps:
-  #     - name: Install Cosign
-  #       uses: sigstore/cosign-installer@v3.3.0
-  #       with:
-  #         cosign-release: 'v2.2.2'
-
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-  #     - name: Create multiarch manifest
-  #       env:
-  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
-  #       run: |
-  #         docker buildx imagetools create -t axelarnet/axelar-ampd:${SEMVER} \
-  #           axelarnet/axelar-ampd-linux-amd64:${SEMVER}
-
-  #     - name: Sign the images with GitHub OIDC
-  #       run: cosign sign -y --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
-  #       env:
-  #         TAGS: axelarnet/axelar-ampd:${{ needs.extract-semver.outputs.semver }}
-  #         COSIGN_EXPERIMENTAL: 1
+      - name: Sign the images with GitHub OIDC
+        run: cosign sign -y --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
+        env:
+          TAGS: axelarnet/axelar-ampd:${{ needs.extract-semver.outputs.semver }}
+          COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -39,7 +39,11 @@ jobs:
           else
             echo "Lowercase dry_run is not 'false'"
           fi
-
+      
+      - name: Random step
+        if: github.event.inputs.dry_run == 'false'
+        run: |
+         echo "This step will only run if dry_run is 'false'"
 
   # extract-semver:
   #   runs-on: ubuntu-22.04

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -13,272 +13,300 @@ on:
         default: 'true'
 
 jobs:
-  extract-semver:
+  debug-inputs:
     runs-on: ubuntu-22.04
-    name: Validate tag and extract semver
-    outputs:
-      semver: ${{ steps.extract_semver.outputs.semver }}
-      version: ${{ steps.extract_semver.outputs.version }}
+    name: Debug workflow inputs
     steps:
-      - name: Extract semver from tag
-        id: extract_semver
+      - name: Debug dry_run input
         run: |
-          full_semver=$(echo ${{ github.event.inputs.tag }} | sed 's/ampd-//')
-          version_number=$(echo $full_semver | sed 's/^v//')
-          echo "semver=$full_semver" >> $GITHUB_OUTPUT
-          echo "version=$version_number" >> $GITHUB_OUTPUT
-
-      - name: Validate tag
-        env:
-          TAG: ${{ github.event.inputs.tag }}
-          SEMVER: ${{ steps.extract_semver.outputs.semver }}
-        run: |
-          if [[ $TAG =~ ampd-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
-          aws s3 ls s3://axelar-releases/ampd/"$SEMVER" && echo "tag already exists, use a new one" && exit 1
-
-
-
-  release-binaries:
-    runs-on: ${{ matrix.os }}
-    needs: extract-semver
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04, macos-14 ]
-        arch: [ amd64, arm64 ]
-        exclude:
-          - os: macos-14
-            arch: amd64
-
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-          ref: ${{ github.event.inputs.tag }}
-          submodules: recursive
-          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.81.0
-          override: true
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: build and sign darwin binaries
-        env:
-          SEMVER: ${{ needs.extract-semver.outputs.semver }}
-        if: matrix.os == 'macos-14'
-        run: |
-          OS="darwin"
-          ARCH="${{ matrix.arch }}"
+          echo "Raw dry_run input: '${{ github.event.inputs.dry_run }}'"
+          echo "Type of dry_run input: $(typeof '${{ github.event.inputs.dry_run }}')"
           
-          brew install protobuf
+          echo "Testing dry_run == 'false': $([ '${{ github.event.inputs.dry_run }}' == 'false' ] && echo 'true' || echo 'false')"
+          echo "Testing dry_run != 'true': $([ '${{ github.event.inputs.dry_run }}' != 'true' ] && echo 'true' || echo 'false')"
           
-          if [ "$ARCH" == "arm64" ]
-          then
-            rustup target add aarch64-apple-darwin
-            cargo build --release --target aarch64-apple-darwin
-            mkdir ampdbin
-            mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-apple-darwin/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+          if [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+            echo "dry_run is exactly the string 'false'"
           else
-            cargo build --release
-            mkdir ampdbin
-            mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+            echo "dry_run is NOT the string 'false', it is: '${{ github.event.inputs.dry_run }}'"
           fi
           
-          gpg --armor --detach-sign "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-
-      - name: build and sign linux binaries
-        env:
-          SEMVER: ${{ needs.extract-semver.outputs.semver }}
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          OS="linux"
-          ARCH="${{ matrix.arch }}"
-          sudo apt-get install protobuf-compiler
-          
-          if [ "$ARCH" == "arm64" ]
-          then
-            sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-            rustup target add aarch64-unknown-linux-gnu
-            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-            cargo build --release --target aarch64-unknown-linux-gnu
-            mkdir ampdbin
-            mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-unknown-linux-gnu/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"            
+          # Try lowercase conversion in case of capitalization issues
+          LOWERCASE_DRY_RUN=$(echo "${{ github.event.inputs.dry_run }}" | tr '[:upper:]' '[:lower:]')
+          echo "Lowercase version: '$LOWERCASE_DRY_RUN'"
+          if [ "$LOWERCASE_DRY_RUN" = "false" ]; then
+            echo "Lowercase dry_run is 'false'"
           else
-            cargo build --release
-            mkdir ampdbin
-            mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-          fi     
-          
-           gpg --armor --detach-sign  "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
-
-
-      - name: Test Binary Format
-        working-directory: ./ampdbin
-        run: |
-          for binary in ./ampd-*; do
-          if [[ "$binary" != *.asc ]]; then
-            echo "Testing binary: $binary"
-            OUTPUT=$(file "$binary" | cut -d: -f2- | awk -F, '{print $1"," $2}')
-            if [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
-              if [[ "${{ matrix.arch }}" == "amd64" ]]; then
-                EXPECTED="ELF 64-bit LSB pie executable, x86-64"
-              elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
-                EXPECTED="ELF 64-bit LSB pie executable, ARM aarch64"
-              fi
-            elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
-              OUTPUT=$(file "$binary" | cut -d: -f2-)
-              if [[ "${{ matrix.arch }}" == "amd64" ]]; then
-                EXPECTED="Mach-O 64-bit executable x86_64"
-              elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
-                EXPECTED="Mach-O 64-bit executable arm64"
-              fi
-            fi
-
-            echo "Output: $OUTPUT"
-            echo "Expected: $EXPECTED"
-
-            if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
-              echo "The binary format is correct."
-            else
-              echo "Error: The binary format does not match the expected format."
-              exit 1
-            fi
+            echo "Lowercase dry_run is not 'false'"
           fi
-          done
 
-      - name: Create zip and sha256 files
-        working-directory: ./ampdbin
-        run: |
-          for i in `ls | grep -v .asc`
-          do
-            shasum -a 256 $i | awk '{print $1}' > $i.sha256
-            zip $i.zip $i
-            shasum -a 256 $i.zip | awk '{print $1}' > $i.zip.sha256
-          done
 
-      - name: Upload binaries to release
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./ampdbin/*
-          tag: ${{ github.event.inputs.tag }}
-          overwrite: true
-          file_glob: true
+  # extract-semver:
+  #   runs-on: ubuntu-22.04
+  #   name: Validate tag and extract semver
+  #   outputs:
+  #     semver: ${{ steps.extract_semver.outputs.semver }}
+  #     version: ${{ steps.extract_semver.outputs.version }}
+  #   steps:
+  #     - name: Extract semver from tag
+  #       id: extract_semver
+  #       run: |
+  #         full_semver=$(echo ${{ github.event.inputs.tag }} | sed 's/ampd-//')
+  #         version_number=$(echo $full_semver | sed 's/^v//')
+  #         echo "semver=$full_semver" >> $GITHUB_OUTPUT
+  #         echo "version=$version_number" >> $GITHUB_OUTPUT
 
-      - name: Upload binaries to S3
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
-        run: |
-          aws s3 cp ./ampdbin ${S3_PATH}/ --recursive
+  #     - name: Validate tag
+  #       env:
+  #         TAG: ${{ github.event.inputs.tag }}
+  #         SEMVER: ${{ steps.extract_semver.outputs.semver }}
+  #       run: |
+  #         if [[ $TAG =~ ampd-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
+  #         aws s3 ls s3://axelar-releases/ampd/"$SEMVER" && echo "tag already exists, use a new one" && exit 1
 
-      - name: Prepare source directory structure for r2 upload
-        id: prepare-r2-release
-        run: |
-          version="${{ needs.extract-semver.outputs.version }}"
-          mkdir -p "./${version}"
-          cp -R ./ampdbin/. "./${version}/"
-          echo "release-dir=./${version}" >> $GITHUB_OUTPUT
-          echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
 
-      - name: Upload to R2
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        uses: ryand56/r2-upload-action@v1.3.2
-        with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
-          r2-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CF }}
-          r2-bucket: ${{ secrets.R2_BUCKET }}
-          source-dir: ${{ steps.prepare-r2-release.outputs.release-dir }}
-          destination-dir: ${{ steps.prepare-r2-release.outputs.r2-destination-dir }}
 
-  release-docker:
-    runs-on: ubuntu-22.04
-    needs: extract-semver
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-    if: ${{ github.event.inputs.dry-run == 'false' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-          ref: ${{ github.event.inputs.tag }}
-          submodules: recursive
-          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
+  # release-binaries:
+  #   runs-on: ${{ matrix.os }}
+  #   needs: extract-semver
+  #   strategy:
+  #     matrix:
+  #       os: [ ubuntu-22.04, macos-14 ]
+  #       arch: [ amd64, arm64 ]
+  #       exclude:
+  #         - os: macos-14
+  #           arch: amd64
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  #   permissions:
+  #     contents: write
+  #     packages: write
+  #     id-token: write
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
+  #   steps:
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-region: us-east-2
+  #         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: '0'
+  #         ref: ${{ github.event.inputs.tag }}
+  #         submodules: recursive
+  #         token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
-      - name: Build and push docker images
-        env:
-          PLATFORM: linux/amd64
-          SEMVER: ${{ needs.extract-semver.outputs.semver }}
-        run: |
-          make build-push-docker-images
+  #     - name: Set up Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: 1.81.0
+  #         override: true
 
-  combine-sign:
-    needs: [ release-docker, extract-semver ]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-    if: ${{ github.event.inputs.dry-run == 'false' }}
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
-        with:
-          cosign-release: 'v2.2.2'
+  #     - name: Import GPG key
+  #       id: import_gpg
+  #       uses: crazy-max/ghaction-import-gpg@v6
+  #       with:
+  #         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+  #         passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+  #     - name: build and sign darwin binaries
+  #       env:
+  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
+  #       if: matrix.os == 'macos-14'
+  #       run: |
+  #         OS="darwin"
+  #         ARCH="${{ matrix.arch }}"
+          
+  #         brew install protobuf
+          
+  #         if [ "$ARCH" == "arm64" ]
+  #         then
+  #           rustup target add aarch64-apple-darwin
+  #           cargo build --release --target aarch64-apple-darwin
+  #           mkdir ampdbin
+  #           mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-apple-darwin/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+  #         else
+  #           cargo build --release
+  #           mkdir ampdbin
+  #           mv "/Users/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+  #         fi
+          
+  #         gpg --armor --detach-sign "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
 
-      - name: Create multiarch manifest
-        env:
-          SEMVER: ${{ needs.extract-semver.outputs.semver }}
-        run: |
-          docker buildx imagetools create -t axelarnet/axelar-ampd:${SEMVER} \
-            axelarnet/axelar-ampd-linux-amd64:${SEMVER}
+  #     - name: build and sign linux binaries
+  #       env:
+  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
+  #       if: matrix.os == 'ubuntu-22.04'
+  #       run: |
+  #         OS="linux"
+  #         ARCH="${{ matrix.arch }}"
+  #         sudo apt-get install protobuf-compiler
+          
+  #         if [ "$ARCH" == "arm64" ]
+  #         then
+  #           sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+  #           rustup target add aarch64-unknown-linux-gnu
+  #           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+  #           cargo build --release --target aarch64-unknown-linux-gnu
+  #           mkdir ampdbin
+  #           mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/aarch64-unknown-linux-gnu/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"            
+  #         else
+  #           cargo build --release
+  #           mkdir ampdbin
+  #           mv "/home/runner/work/axelar-amplifier/axelar-amplifier/target/release/ampd" "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
+  #         fi     
+          
+  #          gpg --armor --detach-sign  "./ampdbin/ampd-$OS-$ARCH-$SEMVER"
 
-      - name: Sign the images with GitHub OIDC
-        run: cosign sign -y --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
-        env:
-          TAGS: axelarnet/axelar-ampd:${{ needs.extract-semver.outputs.semver }}
-          COSIGN_EXPERIMENTAL: 1
+
+  #     - name: Test Binary Format
+  #       working-directory: ./ampdbin
+  #       run: |
+  #         for binary in ./ampd-*; do
+  #         if [[ "$binary" != *.asc ]]; then
+  #           echo "Testing binary: $binary"
+  #           OUTPUT=$(file "$binary" | cut -d: -f2- | awk -F, '{print $1"," $2}')
+  #           if [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
+  #             if [[ "${{ matrix.arch }}" == "amd64" ]]; then
+  #               EXPECTED="ELF 64-bit LSB pie executable, x86-64"
+  #             elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+  #               EXPECTED="ELF 64-bit LSB pie executable, ARM aarch64"
+  #             fi
+  #           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+  #             OUTPUT=$(file "$binary" | cut -d: -f2-)
+  #             if [[ "${{ matrix.arch }}" == "amd64" ]]; then
+  #               EXPECTED="Mach-O 64-bit executable x86_64"
+  #             elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+  #               EXPECTED="Mach-O 64-bit executable arm64"
+  #             fi
+  #           fi
+
+  #           echo "Output: $OUTPUT"
+  #           echo "Expected: $EXPECTED"
+
+  #           if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+  #             echo "The binary format is correct."
+  #           else
+  #             echo "Error: The binary format does not match the expected format."
+  #             exit 1
+  #           fi
+  #         fi
+  #         done
+
+  #     - name: Create zip and sha256 files
+  #       working-directory: ./ampdbin
+  #       run: |
+  #         for i in `ls | grep -v .asc`
+  #         do
+  #           shasum -a 256 $i | awk '{print $1}' > $i.sha256
+  #           zip $i.zip $i
+  #           shasum -a 256 $i.zip | awk '{print $1}' > $i.zip.sha256
+  #         done
+
+  #     - name: Upload binaries to release
+  #       if: ${{ github.event.inputs.dry-run == 'false' }}
+  #       uses: svenstaro/upload-release-action@v2
+  #       with:
+  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #         file: ./ampdbin/*
+  #         tag: ${{ github.event.inputs.tag }}
+  #         overwrite: true
+  #         file_glob: true
+
+  #     - name: Upload binaries to S3
+  #       if: ${{ github.event.inputs.dry-run == 'false' }}
+  #       env:
+  #         S3_PATH: s3://axelar-releases/ampd/${{ needs.extract-semver.outputs.semver }}
+  #       run: |
+  #         aws s3 cp ./ampdbin ${S3_PATH}/ --recursive
+
+  #     - name: Prepare source directory structure for r2 upload
+  #       id: prepare-r2-release
+  #       run: |
+  #         version="${{ needs.extract-semver.outputs.version }}"
+  #         mkdir -p "./${version}"
+  #         cp -R ./ampdbin/. "./${version}/"
+  #         echo "release-dir=./${version}" >> $GITHUB_OUTPUT
+  #         echo "r2-destination-dir=./releases/ampd/" >> $GITHUB_OUTPUT
+
+  #     - name: Upload to R2
+  #       if: ${{ github.event.inputs.dry-run == 'false' }}
+  #       uses: ryand56/r2-upload-action@v1.3.2
+  #       with:
+  #         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+  #         r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
+  #         r2-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CF }}
+  #         r2-bucket: ${{ secrets.R2_BUCKET }}
+  #         source-dir: ${{ steps.prepare-r2-release.outputs.release-dir }}
+  #         destination-dir: ${{ steps.prepare-r2-release.outputs.r2-destination-dir }}
+
+  # release-docker:
+  #   runs-on: ubuntu-22.04
+  #   needs: extract-semver
+  #   permissions:
+  #     contents: write
+  #     packages: write
+  #     id-token: write
+  #   if: ${{ github.event.inputs.dry-run == 'false' }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: '0'
+  #         ref: ${{ github.event.inputs.tag }}
+  #         submodules: recursive
+  #         token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
+
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@v3
+
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+  #     - name: Build and push docker images
+  #       env:
+  #         PLATFORM: linux/amd64
+  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
+  #       run: |
+  #         make build-push-docker-images
+
+  # combine-sign:
+  #   needs: [ release-docker, extract-semver ]
+  #   runs-on: ubuntu-22.04
+  #   permissions:
+  #     contents: write
+  #     packages: write
+  #     id-token: write
+  #   if: ${{ github.event.inputs.dry-run == 'false' }}
+  #   steps:
+  #     - name: Install Cosign
+  #       uses: sigstore/cosign-installer@v3.3.0
+  #       with:
+  #         cosign-release: 'v2.2.2'
+
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+  #     - name: Create multiarch manifest
+  #       env:
+  #         SEMVER: ${{ needs.extract-semver.outputs.semver }}
+  #       run: |
+  #         docker buildx imagetools create -t axelarnet/axelar-ampd:${SEMVER} \
+  #           axelarnet/axelar-ampd-linux-amd64:${SEMVER}
+
+  #     - name: Sign the images with GitHub OIDC
+  #       run: cosign sign -y --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
+  #       env:
+  #         TAGS: axelarnet/axelar-ampd:${{ needs.extract-semver.outputs.semver }}
+  #         COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
