### PR TITLE
feat(minor-ampd): create new tx broadcaster with todo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "multiversx-sdk",
  "num-traits",
  "openssl",
+ "pin-project-lite",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "rand 0.8.5",

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -45,6 +45,7 @@ num-traits = { workspace = true }
 openssl = { version = "0.10.35", features = [
   "vendored",
 ] } # Needed to make arm compilation work by forcing vendoring
+pin-project-lite = "0.2.16"
 prost = "0.11.9"
 prost-types = "0.11.9"
 report = { workspace = true }

--- a/ampd/src/broadcaster/mod.rs
+++ b/ampd/src/broadcaster/mod.rs
@@ -35,7 +35,7 @@ use crate::{cosmos, tofnd};
 
 pub mod confirm_tx;
 mod dec_coin;
-mod tx;
+pub mod tx;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/ampd/src/cosmos.rs
+++ b/ampd/src/cosmos.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use cosmrs::proto::cosmos::auth::v1beta1::query_client::QueryClient as AuthQueryClient;
-use cosmrs::proto::cosmos::auth::v1beta1::{QueryAccountRequest, QueryAccountResponse};
+use cosmrs::proto::cosmos::auth::v1beta1::{
+    BaseAccount, QueryAccountRequest, QueryAccountResponse,
+};
 use cosmrs::proto::cosmos::bank::v1beta1::query_client::QueryClient as BankQueryClient;
 use cosmrs::proto::cosmos::bank::v1beta1::{QueryBalanceRequest, QueryBalanceResponse};
 use cosmrs::proto::cosmos::tx::v1beta1::service_client::ServiceClient;
@@ -8,11 +10,18 @@ use cosmrs::proto::cosmos::tx::v1beta1::{
     BroadcastTxRequest, BroadcastTxResponse, GetTxRequest, GetTxResponse, SimulateRequest,
     SimulateResponse,
 };
-use mockall::automock;
+use cosmrs::tx::MessageExt;
+use cosmrs::Any;
+use error_stack::{report, ResultExt};
+use mockall::mock;
+use prost::Message;
 use report::ErrorExt;
 use thiserror::Error;
 use tonic::transport::Channel;
 use tonic::Response;
+
+use crate::broadcaster::tx::Tx;
+use crate::types::{CosmosPublicKey, TMAddress};
 
 type Result<T> = error_stack::Result<T, Error>;
 
@@ -22,9 +31,37 @@ pub enum Error {
     GrpcConnection(#[from] tonic::transport::Error),
     #[error("failed to make the grpc request")]
     GrpcRequest(#[from] tonic::Status),
+    #[error("failed building tx")]
+    TxBuilding,
+    #[error("gas info is missing in the query response")]
+    GasInfoMissing,
+    #[error("account is missing in the query response")]
+    AccountMissing,
+    #[error("failed to decode the query response")]
+    MalformedResponse,
 }
 
-#[automock]
+mock! {
+    #[derive(Debug)]
+    pub CosmosClient{}
+
+    impl Clone for CosmosClient {
+        fn clone(&self) -> Self;
+    }
+
+
+    #[async_trait]
+    impl CosmosClient for CosmosClient {
+        async fn broadcast_tx(&mut self, req: BroadcastTxRequest) -> Result<BroadcastTxResponse>;
+        async fn simulate(&mut self, req: SimulateRequest) -> Result<SimulateResponse>;
+        async fn tx(&mut self, req: GetTxRequest) -> Result<GetTxResponse>;
+
+        async fn account(&mut self, address: QueryAccountRequest) -> Result<QueryAccountResponse>;
+
+        async fn balance(&mut self, request: QueryBalanceRequest) -> Result<QueryBalanceResponse>;
+    }
+}
+
 #[async_trait]
 pub trait CosmosClient {
     async fn broadcast_tx(&mut self, req: BroadcastTxRequest) -> Result<BroadcastTxResponse>;
@@ -96,5 +133,180 @@ impl CosmosClient for CosmosGRpcClient {
             .await
             .map(Response::into_inner)
             .map_err(ErrorExt::into_report)
+    }
+}
+
+pub async fn estimate_gas<T>(
+    client: &mut T,
+    msgs: Vec<Any>,
+    pub_key: CosmosPublicKey,
+    acc_sequence: u64,
+) -> Result<u64>
+where
+    T: CosmosClient,
+{
+    let tx_bytes = Tx::builder()
+        .msgs(msgs)
+        .pub_key(pub_key)
+        .acc_sequence(acc_sequence)
+        .build()
+        .with_dummy_sig()
+        .await
+        .expect("dummy signature must be valid")
+        .to_bytes()
+        .change_context(Error::TxBuilding)?;
+
+    #[allow(deprecated)]
+    client
+        .simulate(SimulateRequest { tx: None, tx_bytes })
+        .await
+        .and_then(|res| {
+            res.gas_info
+                .map(|info| info.gas_used)
+                .ok_or(report!(Error::GasInfoMissing))
+        })
+}
+
+pub async fn account<T>(client: &mut T, address: &TMAddress) -> Result<BaseAccount>
+where
+    T: CosmosClient,
+{
+    client
+        .account(QueryAccountRequest {
+            address: address.to_string(),
+        })
+        .await
+        .and_then(|res| res.account.ok_or(report!(Error::AccountMissing)))
+        .and_then(decode_base_account)
+}
+
+fn decode_base_account(account: Any) -> Result<BaseAccount> {
+    BaseAccount::decode(&account.value[..]).change_context(Error::MalformedResponse)
+}
+
+#[cfg(test)]
+mod tests {
+    use axelar_wasm_std::assert_err_contains;
+    use mockall::predicate;
+
+    use super::*;
+    use crate::types::random_cosmos_public_key;
+    use crate::PREFIX;
+
+    #[tokio::test]
+    async fn estimate_gas_success() {
+        let pub_key = random_cosmos_public_key();
+        let acc_sequence = 5u64;
+        let msgs = vec![Any {
+            type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
+            value: vec![1, 2, 3],
+        }];
+        let gas_used = 150000u64;
+
+        let mut mock_client = MockCosmosClient::new();
+        mock_client.expect_simulate().return_once(move |_| {
+            Ok(SimulateResponse {
+                gas_info: Some(cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo {
+                    gas_wanted: 200000,
+                    gas_used,
+                }),
+                result: None,
+            })
+        });
+
+        let actual = estimate_gas(&mut mock_client, msgs, pub_key, acc_sequence).await;
+
+        assert_eq!(actual.unwrap(), gas_used);
+    }
+
+    #[tokio::test]
+    async fn estimate_gas_missing_gas_info() {
+        let pub_key = random_cosmos_public_key();
+        let acc_sequence = 5u64;
+        let msgs = vec![Any {
+            type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
+            value: vec![1, 2, 3],
+        }];
+
+        let mut mock_client = MockCosmosClient::new();
+        mock_client.expect_simulate().return_once(|_| {
+            Ok(SimulateResponse {
+                gas_info: None,
+                result: None,
+            })
+        });
+
+        let actual = estimate_gas(&mut mock_client, msgs, pub_key, acc_sequence).await;
+
+        assert_err_contains!(actual, Error, Error::GasInfoMissing);
+    }
+
+    #[tokio::test]
+    async fn account_success() {
+        let address = TMAddress::random(PREFIX);
+        let base_account = BaseAccount {
+            address: address.to_string(),
+            pub_key: None,
+            account_number: 42,
+            sequence: 10,
+        };
+        let base_account_any = base_account.to_any().unwrap();
+
+        let mut mock_client = MockCosmosClient::new();
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .return_once(move |_| {
+                Ok(QueryAccountResponse {
+                    account: Some(base_account_any),
+                })
+            });
+
+        let actual = account(&mut mock_client, &address).await;
+
+        assert_eq!(actual.unwrap(), base_account);
+    }
+
+    #[tokio::test]
+    async fn account_account_missing() {
+        let address = TMAddress::random(PREFIX);
+
+        let mut mock_client = MockCosmosClient::new();
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .return_once(move |_| Ok(QueryAccountResponse { account: None }));
+
+        let actual = account(&mut mock_client, &address).await;
+
+        assert_err_contains!(actual, Error, Error::AccountMissing);
+    }
+
+    #[tokio::test]
+    async fn account_malformed_response() {
+        let address = TMAddress::random(PREFIX);
+
+        let mut mock_client = MockCosmosClient::new();
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .return_once(move |_| {
+                Ok(QueryAccountResponse {
+                    account: Some(Any {
+                        type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
+                        value: vec![1, 2, 3],
+                    }),
+                })
+            });
+
+        let actual = account(&mut mock_client, &address).await;
+
+        assert_err_contains!(actual, Error, Error::MalformedResponse);
     }
 }

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -46,6 +46,8 @@ mod stellar;
 mod sui;
 mod tm_client;
 mod tofnd;
+#[allow(dead_code)]
+mod tx_broadcaster;
 mod types;
 mod url;
 mod xrpl;

--- a/ampd/src/tx_broadcaster/account.rs
+++ b/ampd/src/tx_broadcaster/account.rs
@@ -1,0 +1,301 @@
+use std::cmp;
+use std::sync::Arc;
+
+use error_stack::{report, ResultExt};
+use mockall::automock;
+use report::ResultCompatExt;
+use tokio::sync::{Mutex, MutexGuard};
+
+use super::{Error, Result};
+use crate::types::{CosmosPublicKey, TMAddress};
+use crate::{cosmos, PREFIX};
+
+#[automock]
+pub trait AccountManager {
+    fn pub_key(&self) -> CosmosPublicKey;
+    fn address(&self) -> TMAddress;
+    fn account_number(&self) -> u64;
+    async fn curr_sequence(&mut self) -> Result<u64>;
+    async fn curr_sequence_and_incr(&mut self) -> Result<u64>;
+}
+
+#[derive(Clone)]
+pub struct CosmosAccountManager<T>
+where
+    T: cosmos::CosmosClient + Clone,
+{
+    client: T,
+    pub_key: CosmosPublicKey,
+    address: TMAddress,
+    account_number: u64,
+    curr_sequence: Arc<Mutex<u64>>,
+}
+
+impl<T> CosmosAccountManager<T>
+where
+    T: cosmos::CosmosClient + Clone,
+{
+    pub async fn new(mut client: T, pub_key: CosmosPublicKey) -> Result<Self> {
+        let address = pub_key
+            .account_id(PREFIX)
+            .change_context(Error::InvalidPubKey)?
+            .into();
+        cosmos::account(&mut client, &address)
+            .await
+            .map(|account| Self {
+                client,
+                pub_key,
+                address,
+                account_number: account.account_number,
+                curr_sequence: Arc::new(Mutex::new(account.sequence)),
+            })
+            .change_context(Error::QueryAccount)
+    }
+
+    async fn set_curr_sequence(&mut self) -> Result<MutexGuard<u64>> {
+        let mut curr_sequence = self.curr_sequence.lock().await;
+        *curr_sequence = cosmos::account(&mut self.client, &self.address)
+            .await
+            .map(|account| cmp::max(account.sequence, *curr_sequence))
+            .change_context(Error::QueryAccount)?;
+
+        Ok(curr_sequence)
+    }
+}
+
+impl<T> AccountManager for CosmosAccountManager<T>
+where
+    T: cosmos::CosmosClient + Clone,
+{
+    fn pub_key(&self) -> CosmosPublicKey {
+        self.pub_key.clone()
+    }
+
+    fn address(&self) -> TMAddress {
+        self.address.clone()
+    }
+
+    fn account_number(&self) -> u64 {
+        self.account_number
+    }
+
+    async fn curr_sequence(&mut self) -> Result<u64> {
+        let curr_sequence = self.set_curr_sequence().await?;
+
+        Ok(*curr_sequence)
+    }
+
+    async fn curr_sequence_and_incr(&mut self) -> Result<u64> {
+        let mut curr_sequence = self.set_curr_sequence().await?;
+        let result = *curr_sequence;
+
+        *curr_sequence = curr_sequence
+            .checked_add(1)
+            .ok_or(report!(Error::IntegerOverflow))?;
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmrs::proto::cosmos::auth::v1beta1::{
+        BaseAccount, QueryAccountRequest, QueryAccountResponse,
+    };
+    use cosmrs::tx::MessageExt;
+    use mockall::predicate;
+    use tokio::task::JoinSet;
+
+    use super::*;
+    use crate::cosmos::MockCosmosClient;
+    use crate::types::random_cosmos_public_key;
+    use crate::PREFIX;
+
+    #[tokio::test]
+    async fn new_cosmos_account_manager() {
+        let mut mock_client = MockCosmosClient::new();
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .return_once(|req| {
+                Ok(QueryAccountResponse {
+                    account: Some(
+                        BaseAccount {
+                            account_number: 42,
+                            sequence: 10,
+                            address: req.address,
+                            pub_key: None,
+                        }
+                        .to_any()
+                        .unwrap(),
+                    ),
+                })
+            });
+
+        let manager = CosmosAccountManager::new(mock_client, pub_key.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(manager.account_number(), 42);
+        assert_eq!(*manager.curr_sequence.lock().await, 10);
+        assert_eq!(manager.address(), address);
+        assert_eq!(manager.pub_key(), pub_key);
+    }
+
+    #[tokio::test]
+    async fn curr_sequence() {
+        let mut mock_client = MockCosmosClient::new();
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .times(4)
+            .returning(|req| {
+                Ok(QueryAccountResponse {
+                    account: Some(
+                        BaseAccount {
+                            account_number: 42,
+                            sequence: 15,
+                            address: req.address,
+                            pub_key: None,
+                        }
+                        .to_any()
+                        .unwrap(),
+                    ),
+                })
+            });
+
+        let mut manager = CosmosAccountManager::new(mock_client, pub_key)
+            .await
+            .unwrap();
+
+        assert_eq!(manager.curr_sequence().await.unwrap(), 15);
+        assert_eq!(manager.curr_sequence().await.unwrap(), 15);
+        assert_eq!(manager.curr_sequence().await.unwrap(), 15);
+    }
+
+    #[tokio::test]
+    async fn curr_sequence_and_incr() {
+        let mut mock_client = MockCosmosClient::new();
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .times(4)
+            .returning(|req| {
+                Ok(QueryAccountResponse {
+                    account: Some(
+                        BaseAccount {
+                            account_number: 42,
+                            sequence: 15,
+                            address: req.address,
+                            pub_key: None,
+                        }
+                        .to_any()
+                        .unwrap(),
+                    ),
+                })
+            });
+
+        let mut manager = CosmosAccountManager::new(mock_client, pub_key)
+            .await
+            .unwrap();
+
+        assert_eq!(manager.curr_sequence_and_incr().await.unwrap(), 15);
+        assert_eq!(manager.curr_sequence_and_incr().await.unwrap(), 16);
+        assert_eq!(manager.curr_sequence_and_incr().await.unwrap(), 17);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_curr_sequence_and_incr() {
+        let mut mock_client = MockCosmosClient::new();
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+        let address_clone = address.clone();
+
+        mock_client
+            .expect_account()
+            .with(predicate::eq(QueryAccountRequest {
+                address: address.to_string(),
+            }))
+            .returning(|req| {
+                Ok(QueryAccountResponse {
+                    account: Some(
+                        BaseAccount {
+                            account_number: 42,
+                            sequence: 10,
+                            address: req.address,
+                            pub_key: None,
+                        }
+                        .to_any()
+                        .unwrap(),
+                    ),
+                })
+            });
+        mock_client.expect_clone().returning(move || {
+            let mut mock_client = MockCosmosClient::new();
+            mock_client
+                .expect_account()
+                .with(predicate::eq(QueryAccountRequest {
+                    address: address_clone.to_string(),
+                }))
+                .returning(|req| {
+                    Ok(QueryAccountResponse {
+                        account: Some(
+                            BaseAccount {
+                                account_number: 42,
+                                sequence: 10,
+                                address: req.address,
+                                pub_key: None,
+                            }
+                            .to_any()
+                            .unwrap(),
+                        ),
+                    })
+                });
+
+            mock_client
+        });
+
+        let mut manager = CosmosAccountManager::new(mock_client, pub_key)
+            .await
+            .unwrap();
+
+        let num_tasks = 50;
+        let mut join_set = JoinSet::new();
+        for _ in 0..num_tasks {
+            let mut manager_clone = manager.clone();
+            join_set.spawn(async move { manager_clone.curr_sequence_and_incr().await });
+        }
+
+        let mut results: Vec<_> = join_set
+            .join_all()
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+        results.sort();
+
+        for (i, seq) in results.iter().enumerate() {
+            assert_eq!(*seq, 10 + i as u64);
+        }
+
+        assert_eq!(
+            manager.curr_sequence().await.unwrap(),
+            10 + num_tasks as u64,
+        );
+    }
+}

--- a/ampd/src/tx_broadcaster/mod.rs
+++ b/ampd/src/tx_broadcaster/mod.rs
@@ -1,0 +1,52 @@
+use futures::Stream;
+use thiserror::Error;
+use tokio::sync::mpsc;
+use typed_builder::TypedBuilder;
+
+use crate::cosmos;
+use crate::tofnd::grpc::Multisig;
+
+mod account;
+mod msg_queue;
+
+type Result<T> = error_stack::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to enqueue message")]
+    EnqueueMsg(#[from] mpsc::error::SendError<msg_queue::Msg>),
+    #[error("failed to estimate gas")]
+    EstimateGas,
+    #[error("failed to query account")]
+    QueryAccount,
+    #[error("invalid public key")]
+    InvalidPubKey,
+    #[error("integer overflow")]
+    IntegerOverflow,
+}
+
+#[derive(TypedBuilder)]
+pub struct TxBroadcaster<T, A, Q, S>
+where
+    T: cosmos::CosmosClient,
+    A: account::AccountManager,
+    Q: Stream<Item = Vec<msg_queue::Msg>>,
+    S: Multisig,
+{
+    cosmos_client: T,
+    account_manager: A,
+    msg_queue: Q,
+    signer: S,
+}
+
+impl<T, A, Q, S> TxBroadcaster<T, A, Q, S>
+where
+    T: cosmos::CosmosClient,
+    A: account::AccountManager,
+    Q: Stream<Item = Vec<msg_queue::Msg>>,
+    S: Multisig,
+{
+    pub async fn run(self) -> Result<()> {
+        todo!()
+    }
+}

--- a/ampd/src/tx_broadcaster/msg_queue.rs
+++ b/ampd/src/tx_broadcaster/msg_queue.rs
@@ -1,0 +1,512 @@
+use core::pin::Pin;
+use core::task::{ready, Context, Poll};
+use std::future::Future;
+
+use cosmrs::{Any, Gas};
+use error_stack::{report, ResultExt};
+use futures::Stream;
+use pin_project_lite::pin_project;
+use report::ErrorExt;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time;
+use tokio_stream::adapters::Fuse;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+
+use super::{Error, Result};
+use crate::cosmos;
+use crate::tx_broadcaster::account;
+
+#[derive(Debug)]
+pub struct Msg {
+    pub msg: Any,
+    pub gas: Gas,
+    pub tx_res_callback: Option<oneshot::Sender<Result<(String, u64)>>>,
+}
+
+#[derive(Clone)]
+pub struct MsgQueueClient<T, A>
+where
+    T: cosmos::CosmosClient,
+    A: account::AccountManager,
+{
+    tx: mpsc::Sender<Msg>,
+    cosmos_client: T,
+    account_manager: A,
+}
+
+impl<T, A> MsgQueueClient<T, A>
+where
+    T: cosmos::CosmosClient,
+    A: account::AccountManager,
+{
+    pub async fn enqueue_with_res(
+        &mut self,
+        msg: Any,
+    ) -> Result<oneshot::Receiver<Result<(String, u64)>>> {
+        let (tx, rx) = oneshot::channel();
+        let msg = self.new_msg(msg, Some(tx)).await?;
+
+        self.tx.send(msg).await.map_err(ErrorExt::into_report)?;
+
+        Ok(rx)
+    }
+
+    pub async fn enqueue(&mut self, msg: Any) -> Result<()> {
+        let msg = self.new_msg(msg, None).await?;
+
+        self.tx.send(msg).await.map_err(ErrorExt::into_report)?;
+
+        Ok(())
+    }
+
+    async fn new_msg(
+        &mut self,
+        msg: Any,
+        tx_res_callback: Option<oneshot::Sender<Result<(String, u64)>>>,
+    ) -> Result<Msg> {
+        let sequence = self.account_manager.curr_sequence().await?;
+        let gas = cosmos::estimate_gas(
+            &mut self.cosmos_client,
+            vec![msg.clone()],
+            self.account_manager.pub_key(),
+            sequence,
+        )
+        .await
+        .change_context(Error::EstimateGas)?;
+        let msg = Msg {
+            msg,
+            gas,
+            tx_res_callback,
+        };
+
+        Ok(msg)
+    }
+}
+
+pin_project! {
+    pub struct MsgQueue {
+        #[pin]
+        stream: Fuse<ReceiverStream<Msg>>,
+        #[pin]
+        deadline: Option<time::Sleep>,
+        queue: Queue,
+        gas_capacity: Gas,
+        duration: time::Duration,
+    }
+}
+
+impl MsgQueue {
+    pub fn new_msg_queue_and_client<T, A>(
+        cosmos_client: T,
+        account_manager: A,
+        msg_cap: usize,
+        gas_cap: Gas,
+        duration: time::Duration,
+    ) -> Result<(impl Stream<Item = Vec<Msg>>, MsgQueueClient<T, A>)>
+    where
+        T: cosmos::CosmosClient,
+        A: account::AccountManager,
+    {
+        let (tx, rx) = mpsc::channel(msg_cap);
+
+        Ok((
+            Box::pin(MsgQueue {
+                stream: ReceiverStream::new(rx).fuse(),
+                deadline: None,
+                queue: Queue::default(),
+                gas_capacity: gas_cap,
+                duration,
+            }),
+            MsgQueueClient {
+                tx,
+                cosmos_client,
+                account_manager,
+            },
+        ))
+    }
+}
+
+impl Stream for MsgQueue {
+    type Item = Vec<Msg>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.as_mut().project();
+
+        loop {
+            match me.stream.as_mut().poll_next(cx) {
+                Poll::Pending => break,
+                Poll::Ready(Some(msg)) => {
+                    if me.queue.is_empty() {
+                        me.deadline.set(Some(time::sleep(*me.duration)));
+                    }
+
+                    // gas overflow
+                    if me.queue.gas_cost().checked_add(msg.gas).is_none() {
+                        let msgs = me.queue.pop_all();
+                        me.queue.push(msg).expect("gas must not overflow");
+
+                        return Poll::Ready(Some(msgs));
+                    } else {
+                        me.queue.push(msg).expect("gas must not overflow");
+                    };
+
+                    if me.queue.gas_cost() >= *me.gas_capacity {
+                        return Poll::Ready(Some(me.queue.pop_all()));
+                    }
+                }
+                Poll::Ready(None) => {
+                    // Returning Some here is only correct because we fuse the inner stream.
+                    let last = if me.queue.is_empty() {
+                        None
+                    } else {
+                        Some(me.queue.pop_all())
+                    };
+
+                    return Poll::Ready(last);
+                }
+            }
+        }
+
+        if me.queue.is_empty() {
+            return Poll::Pending;
+        }
+
+        if let Some(deadline) = me.deadline.as_pin_mut() {
+            ready!(deadline.poll(cx));
+        }
+
+        Poll::Ready(Some(me.queue.pop_all()))
+    }
+}
+
+#[derive(Default)]
+struct Queue {
+    msgs: Vec<Msg>,
+    gas_cost: Gas,
+}
+
+impl Queue {
+    pub fn push(&mut self, msg: Msg) -> Result<()> {
+        self.gas_cost = self
+            .gas_cost
+            .checked_add(msg.gas)
+            .ok_or(report!(Error::IntegerOverflow))?;
+        self.msgs.push(msg);
+
+        Ok(())
+    }
+
+    pub fn pop_all(&mut self) -> Vec<Msg> {
+        self.gas_cost = 0;
+
+        std::mem::take(&mut self.msgs)
+    }
+
+    pub fn gas_cost(&self) -> Gas {
+        self.gas_cost
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.msgs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axelar_wasm_std::assert_err_contains;
+    use cosmrs::proto::cosmos::bank::v1beta1::MsgSend;
+    use cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo;
+    use cosmrs::proto::cosmos::tx::v1beta1::SimulateResponse;
+    use cosmrs::tx::MessageExt;
+
+    use super::*;
+    use crate::{
+        types::{random_cosmos_public_key, TMAddress},
+        PREFIX,
+    };
+
+    #[tokio::test]
+    async fn msg_queue_client_enqueue() {
+        let gas_cap = 1000u64;
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager.expect_curr_sequence().return_once(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .once()
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client.expect_simulate().return_once(move |_| {
+            Ok(SimulateResponse {
+                gas_info: Some(GasInfo {
+                    gas_wanted: gas_cap,
+                    gas_used: gas_cap,
+                }),
+                result: None,
+            })
+        });
+
+        let (mut msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            gas_cap,
+            time::Duration::from_secs(1),
+        )
+        .unwrap();
+
+        msg_queue_client.enqueue(dummy_msg()).await.unwrap();
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].gas, gas_cap);
+        assert_eq!(actual[0].msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+        assert!(actual[0].tx_res_callback.is_none());
+    }
+
+    #[tokio::test]
+    async fn msg_queue_client_enqueue_with_res() {
+        let gas_cap = 1000u64;
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager.expect_curr_sequence().return_once(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .once()
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client.expect_simulate().return_once(move |_| {
+            Ok(SimulateResponse {
+                gas_info: Some(GasInfo {
+                    gas_wanted: gas_cap,
+                    gas_used: gas_cap,
+                }),
+                result: None,
+            })
+        });
+
+        let (mut msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            gas_cap,
+            time::Duration::from_secs(1),
+        )
+        .unwrap();
+
+        msg_queue_client
+            .enqueue_with_res(dummy_msg())
+            .await
+            .unwrap();
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].gas, gas_cap);
+        assert_eq!(actual[0].msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+        assert!(actual[0].tx_res_callback.is_some());
+    }
+
+    #[tokio::test]
+    async fn msg_queue_client_error_handling() {
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager
+            .expect_curr_sequence()
+            .return_once(|| Err(report!(Error::QueryAccount)));
+        let cosmos_client = cosmos::MockCosmosClient::new();
+        let (_msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            1000u64,
+            time::Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert_err_contains!(
+            msg_queue_client.enqueue(dummy_msg()).await,
+            Error,
+            Error::QueryAccount
+        );
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager.expect_curr_sequence().return_once(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .once()
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client.expect_simulate().return_once(move |_| {
+            Ok(SimulateResponse {
+                gas_info: None,
+                result: None,
+            })
+        });
+        let (_msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            1000u64,
+            time::Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert_err_contains!(
+            msg_queue_client.enqueue(dummy_msg()).await,
+            Error,
+            Error::EstimateGas
+        );
+    }
+
+    #[tokio::test]
+    async fn msg_queue_stream_timeout() {
+        let gas_cap = 1000u64;
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager.expect_curr_sequence().return_once(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .once()
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client.expect_simulate().return_once(move |_| {
+            Ok(SimulateResponse {
+                gas_info: Some(GasInfo {
+                    gas_wanted: gas_cap / 10,
+                    gas_used: gas_cap / 10,
+                }),
+                result: None,
+            })
+        });
+
+        let (mut msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            gas_cap,
+            time::Duration::from_secs(3),
+        )
+        .unwrap();
+
+        msg_queue_client.enqueue(dummy_msg()).await.unwrap();
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].gas, gas_cap / 10);
+        assert_eq!(actual[0].msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+        assert!(actual[0].tx_res_callback.is_none());
+    }
+
+    #[tokio::test]
+    async fn msg_queue_gas_capacity() {
+        let gas_cap = 1000u64;
+        let msg_count = 10;
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager
+            .expect_curr_sequence()
+            .times(msg_count)
+            .returning(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .times(msg_count)
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client
+            .expect_simulate()
+            .times(msg_count)
+            .returning(move |_| {
+                Ok(SimulateResponse {
+                    gas_info: Some(GasInfo {
+                        gas_wanted: gas_cap / msg_count as u64,
+                        gas_used: gas_cap / msg_count as u64,
+                    }),
+                    result: None,
+                })
+            });
+
+        let (mut msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            gas_cap,
+            time::Duration::from_secs(3),
+        )
+        .unwrap();
+
+        for _ in 0..msg_count {
+            msg_queue_client.enqueue(dummy_msg()).await.unwrap();
+        }
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), msg_count);
+        for msg in actual {
+            assert_eq!(msg.gas, gas_cap / 10);
+            assert_eq!(msg.msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+            assert!(msg.tx_res_callback.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn msg_queue_gas_overflow() {
+        let gas_cap = u64::MAX;
+
+        let mut account_manager = account::MockAccountManager::new();
+        account_manager
+            .expect_curr_sequence()
+            .times(2)
+            .returning(|| Ok(0));
+        account_manager
+            .expect_pub_key()
+            .times(2)
+            .return_const(random_cosmos_public_key());
+        let mut cosmos_client = cosmos::MockCosmosClient::new();
+        cosmos_client
+            .expect_simulate()
+            .times(2)
+            .returning(move |_| {
+                Ok(SimulateResponse {
+                    gas_info: Some(GasInfo {
+                        gas_wanted: gas_cap,
+                        gas_used: gas_cap,
+                    }),
+                    result: None,
+                })
+            });
+
+        let (mut msg_queue, mut msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            cosmos_client,
+            account_manager,
+            10,
+            gas_cap,
+            time::Duration::from_secs(1),
+        )
+        .unwrap();
+
+        msg_queue_client.enqueue(dummy_msg()).await.unwrap();
+        msg_queue_client.enqueue(dummy_msg()).await.unwrap();
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].gas, gas_cap);
+        assert_eq!(actual[0].msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+        assert!(actual[0].tx_res_callback.is_none());
+
+        let actual = msg_queue.next().await.unwrap();
+
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].gas, gas_cap);
+        assert_eq!(actual[0].msg.type_url, "/cosmos.bank.v1beta1.MsgSend");
+        assert!(actual[0].tx_res_callback.is_none());
+    }
+
+    fn dummy_msg() -> Any {
+        MsgSend {
+            from_address: TMAddress::random(PREFIX).to_string(),
+            to_address: TMAddress::random(PREFIX).to_string(),
+            amount: vec![],
+        }
+        .to_any()
+        .unwrap()
+    }
+}

--- a/ampd/src/types/key.rs
+++ b/ampd/src/types/key.rs
@@ -126,6 +126,17 @@ impl From<CosmosPublicKey> for PublicKey {
 }
 
 #[cfg(test)]
+pub mod test_utils {
+    use rand::rngs::OsRng;
+
+    use super::CosmosPublicKey;
+
+    pub fn random_cosmos_public_key() -> CosmosPublicKey {
+        CosmosPublicKey::from(k256::ecdsa::SigningKey::random(&mut OsRng).verifying_key())
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use axelar_wasm_std::assert_err_contains;
     use rand::random;

--- a/ampd/src/types/mod.rs
+++ b/ampd/src/types/mod.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 
 mod key;
 pub(crate) mod starknet;
+#[cfg(test)]
+pub use key::test_utils::random_cosmos_public_key;
 pub use key::{CosmosPublicKey, PublicKey};
 
 pub type EVMAddress = Address;
@@ -41,15 +43,13 @@ impl fmt::Display for TMAddress {
 
 #[cfg(test)]
 pub mod test_utils {
-    use rand::rngs::OsRng;
-
-    use super::CosmosPublicKey;
+    use super::key::test_utils::random_cosmos_public_key;
     use crate::types::TMAddress;
 
     impl TMAddress {
         pub fn random(prefix: &str) -> Self {
             Self(
-                CosmosPublicKey::from(k256::ecdsa::SigningKey::random(&mut OsRng).verifying_key())
+                random_cosmos_public_key()
                     .account_id(prefix)
                     .expect("failed to convert to account identifier"),
             )


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
