### PR TITLE
feat(minor-ampd): add timeout to tofnd and cosmos grpc clients

### DIFF
--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -53,10 +53,14 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
 
     let tofnd_config = config.tofnd_config.clone();
 
-    let multisig_client = MultisigClient::new(tofnd_config.party_uid, tofnd_config.url.clone())
-        .await
-        .change_context(Error::Connection)
-        .attach_printable(tofnd_config.url)?;
+    let multisig_client = MultisigClient::new(
+        tofnd_config.party_uid,
+        tofnd_config.url.as_str(),
+        tofnd_config.timeout,
+    )
+    .await
+    .change_context(Error::Connection)
+    .attach_printable(tofnd_config.url)?;
     let multisig_key = multisig_client
         .keygen(&multisig_address.to_string(), args.key_type.into())
         .await

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -1,4 +1,5 @@
 use std::net::{Ipv4Addr, SocketAddrV4};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +16,7 @@ pub struct Config {
     pub health_check_bind_addr: SocketAddrV4,
     pub tm_jsonrpc: Url,
     pub tm_grpc: Url,
+    pub tm_grpc_timeout: Duration,
     pub event_processor: event_processor::Config,
     pub broadcast: broadcaster::Config,
     #[serde(deserialize_with = "deserialize_handler_configs")]
@@ -29,6 +31,7 @@ impl Default for Config {
         Self {
             tm_jsonrpc: "http://localhost:26657".parse().unwrap(),
             tm_grpc: "tcp://localhost:9090".parse().unwrap(),
+            tm_grpc_timeout: Duration::from_secs(3),
             broadcast: broadcaster::Config::default(),
             handlers: vec![],
             tofnd_config: TofndConfig::default(),
@@ -279,6 +282,10 @@ mod tests {
             url = '{url}'
             party_uid = '{party_uid}'
             key_uid = '{key_uid}'
+
+            [tofnd_config.timeout]
+            secs = 3
+            nanos = 0
             ",
         );
 

--- a/ampd/src/cosmos.rs
+++ b/ampd/src/cosmos.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use cosmrs::proto::cosmos::auth::v1beta1::query_client::QueryClient as AuthQueryClient;
 use cosmrs::proto::cosmos::auth::v1beta1::{QueryAccountRequest, QueryAccountResponse};
@@ -59,9 +61,14 @@ pub struct CosmosGrpcClient {
 }
 
 impl CosmosGrpcClient {
-    pub async fn new(url: &str) -> Result<Self> {
+    pub async fn new(url: &str, timeout: Duration) -> Result<Self> {
         let endpoint: tonic::transport::Endpoint = url.parse().map_err(ErrorExt::into_report)?;
-        let conn = endpoint.connect().await.map_err(ErrorExt::into_report)?;
+        let conn = endpoint
+            .timeout(timeout)
+            .connect_timeout(timeout)
+            .connect()
+            .await
+            .map_err(ErrorExt::into_report)?;
 
         Ok(Self {
             auth: AuthQueryClient::new(conn.clone()),

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -2,6 +2,10 @@ health_check_bind_addr = '0.0.0.0:3000'
 tm_jsonrpc = 'http://localhost:26657/'
 tm_grpc = 'tcp://localhost:9090'
 
+[tm_grpc_timeout]
+secs = 3
+nanos = 0
+
 [event_processor]
 retry_delay = '1s'
 retry_max_attempts = 3
@@ -117,6 +121,10 @@ nanos = 0
 url = 'http://localhost:50051/'
 party_uid = 'ampd'
 key_uid = 'axelar'
+
+[tofnd_config.timeout]
+secs = 3
+nanos = 0
 
 [service_registry]
 cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'

--- a/ampd/src/tofnd/error.rs
+++ b/ampd/src/tofnd/error.rs
@@ -2,8 +2,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("grpc failed")]
-    Grpc,
+    #[error("failed to connect to the grpc endpoint")]
+    GrpcConnection(#[from] tonic::transport::Error),
+    #[error("failed to make the grpc request")]
+    GrpcRequest(#[from] tonic::Status),
     #[error("keygen failed")]
     KeygenFailed,
     #[error("sign failed")]

--- a/ampd/src/tofnd/mod.rs
+++ b/ampd/src/tofnd/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use hex::{self, FromHex};
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +20,7 @@ pub struct Config {
     pub url: Url,
     pub party_uid: String,
     pub key_uid: String,
+    pub timeout: Duration,
 }
 
 impl Default for Config {
@@ -26,6 +29,7 @@ impl Default for Config {
             url: "http://localhost:50051/".parse().unwrap(),
             party_uid: "ampd".into(),
             key_uid: "axelar".into(),
+            timeout: Duration::from_secs(3),
         }
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
