### PR TITLE
fix(interchain-token-service): fix migration to handle all values

### DIFF
--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -5,16 +5,17 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{DepsMut, Env, Response};
 
-pub mod v1_1_0;
+pub mod v1_1_1;
 
 #[cw_serde]
 pub struct MigrateMsg {
     operator_address: String,
 }
 
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 #[migrate_from_version("1.1")]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-    v1_1_0::migrate(deps, msg)?;
+    v1_1_1::migrate(deps, msg)?;
     Ok(Response::default())
 }

--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -12,7 +12,6 @@ pub struct MigrateMsg {
     operator_address: String,
 }
 
-
 #[cfg_attr(not(feature = "library"), entry_point)]
 #[migrate_from_version("1.1")]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {

--- a/contracts/interchain-token-service/src/contract/migrations/v1_1_0.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/v1_1_0.rs
@@ -51,23 +51,23 @@ pub fn migrate(deps: DepsMut, msg: MigrateMsg) -> Result<(), ContractError> {
     let transformed_configs: Vec<(ChainNameRaw, state::ChainConfig)> = old_configs
         .into_iter()
         .map(|(chain_name, old_config)| {
-            convert_max_uint_to_max_bits(old_config.truncation.max_uint).map(|max_uint_bits| {
-                (
-                    chain_name,
-                    state::ChainConfig {
-                        truncation: state::TruncationConfig {
-                            max_decimals_when_truncating: old_config
-                                .truncation
-                                .max_decimals_when_truncating,
-                            max_uint_bits,
-                        },
-                        its_address: old_config.its_address,
-                        frozen: old_config.frozen,
+            (
+                chain_name,
+                state::ChainConfig {
+                    truncation: state::TruncationConfig {
+                        max_decimals_when_truncating: old_config
+                            .truncation
+                            .max_decimals_when_truncating,
+                        max_uint_bits: convert_max_uint_to_max_bits(
+                            *old_config.truncation.max_uint,
+                        ),
                     },
-                )
-            })
+                    its_address: old_config.its_address,
+                    frozen: old_config.frozen,
+                },
+            )
         })
-        .try_collect()?;
+        .collect();
 
     for (chain, config) in transformed_configs {
         NEW_CHAIN_CONFIGS.save(deps.storage, &chain, &config)?;
@@ -76,17 +76,14 @@ pub fn migrate(deps: DepsMut, msg: MigrateMsg) -> Result<(), ContractError> {
     Ok(())
 }
 
-fn convert_max_uint_to_max_bits(max_uint: nonempty::Uint256) -> Result<NumBits, ContractError> {
-    let fixed_cases = [256, 128, 64, 32];
-    for case in fixed_cases {
-        // some chains were incorrectly registered with the max number of bits as the max uint
-        if *max_uint == Uint256::from_u128(case as u128) {
-            return NumBits::try_from(case).map_err(|err| err.into());
-        }
+fn convert_max_uint_to_max_bits(max_uint: Uint256) -> NumBits {
+    if max_uint <= Uint256::from_u128(256) {
+        return NumBits::round_to_nearest(max_uint);
     }
+
     // Need to add one to correctly get the number of bits. This will round down if the result is not a power of two
     #[allow(clippy::arithmetic_side_effects)] // can't possibly overflow
-    NumBits::try_from((Uint512::from(*max_uint) + Uint512::one()).ilog2()).map_err(|err| err.into())
+    NumBits::round_to_nearest((Uint512::from(max_uint) + Uint512::one()).ilog2())
 }
 
 #[cfg(test)]
@@ -97,10 +94,86 @@ mod test {
     use router_api::{Address, ChainNameRaw};
 
     use super::{migrate, ChainConfig, OLD_CHAIN_CONFIGS};
-    use crate::contract::migrations::v1_1_0::{OldConfig, NEW_CHAIN_CONFIGS, OLD_CONFIG};
+    use crate::contract::migrations::v1_1_0::{
+        convert_max_uint_to_max_bits, OldConfig, NEW_CHAIN_CONFIGS, OLD_CONFIG,
+    };
     use crate::contract::migrations::MigrateMsg;
     use crate::shared::NumBits;
     use crate::state;
+
+    #[test]
+    fn convert_max_uint_to_max_bits_should_round_correctly() {
+        let bits32 = NumBits::try_from(32).unwrap();
+        let bits64 = NumBits::try_from(64).unwrap();
+        let bits128 = NumBits::try_from(128).unwrap();
+        let bits256 = NumBits::try_from(256).unwrap();
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::one()), bits32);
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::from_u128(31)), bits32);
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::from_u128(32)), bits32);
+
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::from_u128(50)), bits64);
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::from_u128(63)), bits64);
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::from_u128(64)), bits64);
+
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(100)),
+            bits128
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(127)),
+            bits128
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(128)),
+            bits128
+        );
+
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(200)),
+            bits256
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(255)),
+            bits256
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(256)),
+            bits256
+        );
+
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from_u128(512)),
+            bits32
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u32::MAX / 2)),
+            bits32
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u32::MAX)),
+            bits32
+        );
+
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u64::MAX / 2)),
+            bits64
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u64::MAX)),
+            bits64
+        );
+
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u128::MAX / 2)),
+            bits128
+        );
+        assert_eq!(
+            convert_max_uint_to_max_bits(Uint256::from(u128::MAX)),
+            bits128
+        );
+
+        assert_eq!(convert_max_uint_to_max_bits(Uint256::MAX), bits256);
+    }
 
     #[test]
     fn should_migrate_max_uints() {
@@ -126,10 +199,32 @@ mod test {
                 },
             ),
             (
+                ChainNameRaw::try_from("avalanche").unwrap(),
+                ChainConfig {
+                    truncation: super::TruncationConfig {
+                        max_uint: Uint256::one().checked_shl(200).unwrap().try_into().unwrap(),
+                        max_decimals_when_truncating: 18,
+                    },
+                    its_address: Address::try_from("0x00".to_string()).unwrap(),
+                    frozen: false,
+                },
+            ),
+            (
                 ChainNameRaw::try_from("solana").unwrap(),
                 ChainConfig {
                     truncation: super::TruncationConfig {
                         max_uint: Uint256::from_u128(256u128).try_into().unwrap(),
+                        max_decimals_when_truncating: 18,
+                    },
+                    its_address: Address::try_from("0x00".to_string()).unwrap(),
+                    frozen: false,
+                },
+            ),
+            (
+                ChainNameRaw::try_from("xrpl").unwrap(),
+                ChainConfig {
+                    truncation: super::TruncationConfig {
+                        max_uint: Uint256::from_u128(255u128).try_into().unwrap(),
                         max_decimals_when_truncating: 18,
                     },
                     its_address: Address::try_from("0x00".to_string()).unwrap(),

--- a/contracts/interchain-token-service/src/contract/migrations/v1_1_1.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/v1_1_1.rs
@@ -285,11 +285,13 @@ mod test {
         let expected_num_bits = [256, 128, 127, 64, 32, 9, 7, 7];
         for ((chain, old_config), expected_num_bits) in old_configs.iter().zip(expected_num_bits) {
             let new_config = NEW_CHAIN_CONFIGS.load(&deps.storage, chain).unwrap();
+
             assert_eq!(new_config.its_address, old_config.its_address);
             assert_eq!(
                 new_config.truncation.max_decimals_when_truncating,
                 old_config.truncation.max_decimals_when_truncating
             );
+
             assert_eq!(new_config.frozen, old_config.frozen);
             assert_eq!(
                 new_config.truncation.max_uint_bits,

--- a/contracts/interchain-token-service/src/contract/migrations/v1_1_1.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/v1_1_1.rs
@@ -284,7 +284,7 @@ mod test {
 
         let expected_num_bits = [256, 128, 127, 64, 32, 9, 7, 7];
         for ((chain, old_config), expected_num_bits) in old_configs.iter().zip(expected_num_bits) {
-            let new_config = NEW_CHAIN_CONFIGS.load(&deps.storage, &chain).unwrap();
+            let new_config = NEW_CHAIN_CONFIGS.load(&deps.storage, chain).unwrap();
             assert_eq!(new_config.its_address, old_config.its_address);
             assert_eq!(
                 new_config.truncation.max_decimals_when_truncating,

--- a/contracts/interchain-token-service/src/shared.rs
+++ b/contracts/interchain-token-service/src/shared.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 
 use axelar_wasm_std::IntoContractError;
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint256;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq, IntoContractError)]
@@ -21,6 +22,22 @@ impl TryFrom<u32> for NumBits {
         match value {
             32 | 64 | 128 | 256 => Ok(Self(value)),
             _ => Err(Error::InvalidNumberOfBits(value)),
+        }
+    }
+}
+
+impl NumBits {
+    // rounds up to the nearest supported number of bits.
+    // Anything greater than 256 is rounded to 256
+    pub fn round_to_nearest<T>(value: T) -> Self
+    where
+        T: Into<Uint256>,
+    {
+        match value.into() {
+            v if v <= Uint256::from(32u32) => NumBits(32),
+            v if v <= Uint256::from(64u32) => NumBits(64),
+            v if v <= Uint256::from(128u32) => NumBits(128),
+            _ => NumBits(256),
         }
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
