### PR TITLE
feat(minor-ampd): create the gRPC server with todo's in services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
 name = "ampd"
 version = "1.7.0"
 dependencies = [
+ "ampd-proto",
  "assert_ok",
  "async-trait",
  "axelar-solana-encoding",
@@ -322,6 +323,7 @@ dependencies = [
  "toml 0.5.11",
  "tonic 0.13.0",
  "tonic-build",
+ "tower 0.5.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ampd-proto = { workspace = true }
 async-trait = { workspace = true }
 axelar-solana-encoding = { workspace = true }
 axelar-solana-gateway = { workspace = true }
@@ -80,6 +81,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 toml = "0.5.9"
 tonic = "0.13.0"
+tower = "0.5.2"
 tracing = { version = "0.1.37", features = ["valuable", "log"] }
 tracing-core = { version = "0.1.30", features = ["valuable"] }
 tracing-subscriber = { version = "0.3.16", features = [

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -82,16 +82,9 @@ mod tests {
             concurrency_limit_per_connection = {concurrency_limit_per_connection}
             ",
         );
-
         let cfg: Config = toml::from_str(config_str.as_str()).unwrap();
 
-        assert_eq!(cfg.grpc.ip_addr.to_string(), ip_addr);
-        assert_eq!(cfg.grpc.port, port);
-        assert_eq!(cfg.grpc.concurrency_limit, concurrency_limit);
-        assert_eq!(
-            cfg.grpc.concurrency_limit_per_connection,
-            concurrency_limit_per_connection
-        );
+        goldie::assert_json!(cfg);
     }
 
     #[test]

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -8,7 +8,7 @@ use crate::handlers::config::deserialize_handler_configs;
 use crate::handlers::{self};
 use crate::tofnd::Config as TofndConfig;
 use crate::url::Url;
-use crate::{broadcaster, event_processor};
+use crate::{broadcaster, event_processor, grpc};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(default)]
@@ -24,6 +24,8 @@ pub struct Config {
     pub tofnd_config: TofndConfig,
     pub service_registry: ServiceRegistryConfig,
     pub rewards: RewardsConfig,
+    #[serde(deserialize_with = "grpc::deserialize_config")]
+    pub grpc: grpc::Config,
 }
 
 impl Default for Config {
@@ -39,6 +41,7 @@ impl Default for Config {
             service_registry: ServiceRegistryConfig::default(),
             rewards: RewardsConfig::default(),
             health_check_bind_addr: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3000),
+            grpc: grpc::Config::default(),
         }
     }
 }
@@ -62,6 +65,122 @@ mod tests {
     use crate::url::Url;
 
     const PREFIX: &str = "axelar";
+
+    #[test]
+    fn deserialize_valid_grpc_config() {
+        let ip_addr = "0.0.0.0";
+        let port = 9091;
+        let concurrency_limit = 2048;
+        let concurrency_limit_per_connection = 256;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+
+        let cfg: Config = toml::from_str(config_str.as_str()).unwrap();
+
+        assert_eq!(cfg.grpc.ip_addr.to_string(), ip_addr);
+        assert_eq!(cfg.grpc.port, port);
+        assert_eq!(cfg.grpc.concurrency_limit, concurrency_limit);
+        assert_eq!(
+            cfg.grpc.concurrency_limit_per_connection,
+            concurrency_limit_per_connection
+        );
+    }
+
+    #[test]
+    fn deserialize_invalid_grpc_config() {
+        let ip_addr = "invalid_ip";
+        let port = 9091;
+        let concurrency_limit = 2048;
+        let concurrency_limit_per_connection = 256;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+        let cfg: Result<Config, _> = toml::from_str(config_str.as_str());
+        assert!(cfg.is_err());
+
+        let ip_addr = "0.0.0.0";
+        let port = "invalid_port";
+        let concurrency_limit = 2048;
+        let concurrency_limit_per_connection = 256;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+        let cfg: Result<Config, _> = toml::from_str(config_str.as_str());
+        assert!(cfg.is_err());
+
+        let ip_addr = "0.0.0.0";
+        let port = 9090;
+        let concurrency_limit = 0;
+        let concurrency_limit_per_connection = 256;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+        let cfg: Result<Config, _> = toml::from_str(config_str.as_str());
+        assert!(cfg.is_err());
+
+        let ip_addr = "0.0.0.0";
+        let port = 9090;
+        let concurrency_limit = 2048;
+        let concurrency_limit_per_connection = 0;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+        let cfg: Result<Config, _> = toml::from_str(config_str.as_str());
+        assert!(cfg.is_err());
+
+        let ip_addr = "0.0.0.0";
+        let port = 9090;
+        let concurrency_limit = 100;
+        let concurrency_limit_per_connection = 200;
+
+        let config_str = format!(
+            "
+            [grpc]
+            ip_addr = '{ip_addr}'
+            port = {port}
+            concurrency_limit = {concurrency_limit}
+            concurrency_limit_per_connection = {concurrency_limit_per_connection}
+            ",
+        );
+        let cfg: Result<Config, _> = toml::from_str(config_str.as_str());
+        assert!(cfg.is_err());
+    }
 
     #[test]
     fn deserialize_handlers() {

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -40,18 +40,22 @@ impl BlockchainService for Service {
             let mut interval = time::interval(duration);
 
             loop {
-                let _ = tx.send(ampd_proto::subscribe_response::Event::BlockBegin(
-                    ampd_proto::EventBlockBegin {
-                        height: height.value(),
-                    },
-                ));
+                let _ = tx
+                    .send(ampd_proto::subscribe_response::Event::BlockBegin(
+                        ampd_proto::EventBlockBegin {
+                            height: height.value(),
+                        },
+                    ))
+                    .await;
                 interval.tick().await;
 
-                let _ = tx.send(ampd_proto::subscribe_response::Event::BlockEnd(
-                    ampd_proto::EventBlockEnd {
-                        height: height.value(),
-                    },
-                ));
+                let _ = tx
+                    .send(ampd_proto::subscribe_response::Event::BlockEnd(
+                        ampd_proto::EventBlockEnd {
+                            height: height.value(),
+                        },
+                    ))
+                    .await;
                 interval.tick().await;
 
                 height = height.increment();

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -1,0 +1,56 @@
+use std::pin::Pin;
+
+use ampd_proto::blockchain_service_server::BlockchainService;
+use ampd_proto::{
+    AddressRequest, AddressResponse, BroadcastRequest, BroadcastResponse, ContractsRequest,
+    ContractsResponse, QueryRequest, QueryResponse, SubscribeRequest, SubscribeResponse,
+};
+use async_trait::async_trait;
+use futures::Stream;
+use tonic::{Request, Response, Status};
+
+pub struct Service {}
+
+impl Service {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl BlockchainService for Service {
+    type SubscribeStream =
+        Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send + 'static>>;
+
+    async fn subscribe(
+        &self,
+        _req: Request<SubscribeRequest>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        todo!("implement subscribe method")
+    }
+
+    async fn broadcast(
+        &self,
+        _req: Request<BroadcastRequest>,
+    ) -> Result<Response<BroadcastResponse>, Status> {
+        todo!("implement broadcast method")
+    }
+
+    async fn query(&self, _req: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        todo!("implement query method")
+    }
+
+    async fn address(
+        &self,
+        _req: Request<AddressRequest>,
+    ) -> Result<Response<AddressResponse>, Status> {
+        todo!("implement address method")
+    }
+
+    async fn contracts(
+        &self,
+        _req: Request<ContractsRequest>,
+    ) -> Result<Response<ContractsResponse>, Status> {
+        todo!("implement contracts method")
+    }
+}

--- a/ampd/src/grpc/crypto_service.rs
+++ b/ampd/src/grpc/crypto_service.rs
@@ -1,0 +1,23 @@
+use ampd_proto::crypto_service_server::CryptoService;
+use ampd_proto::{KeyRequest, KeyResponse, SignRequest, SignResponse};
+use async_trait::async_trait;
+use tonic::{Request, Response, Status};
+
+pub struct Service {}
+
+impl Service {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl CryptoService for Service {
+    async fn sign(&self, _req: Request<SignRequest>) -> Result<Response<SignResponse>, Status> {
+        todo!("implement sign method")
+    }
+
+    async fn key(&self, _req: Request<KeyRequest>) -> Result<Response<KeyResponse>, Status> {
+        todo!("implement key method")
+    }
+}

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -1,0 +1,93 @@
+use std::net::{IpAddr, SocketAddr};
+
+use ampd_proto::blockchain_service_server::BlockchainServiceServer;
+use ampd_proto::crypto_service_server::CryptoServiceServer;
+use error_stack::Result;
+use report::ErrorExt;
+use serde::de::{self, Deserializer};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use tonic::transport;
+use tower::layer::util::{Identity, Stack};
+use tower::limit::ConcurrencyLimitLayer;
+
+mod blockchain_service;
+mod crypto_service;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to start the gRPC server")]
+    Transport(#[from] transport::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Config {
+    pub ip_addr: IpAddr,
+    pub port: u16,
+    pub concurrency_limit: usize,
+    pub concurrency_limit_per_connection: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ip_addr: "127.0.0.1".parse().expect("default IP must be valid"),
+            port: 9090,
+            concurrency_limit: 1024,
+            concurrency_limit_per_connection: 32,
+        }
+    }
+}
+
+pub fn deserialize_config<'de, D>(deserializer: D) -> std::result::Result<Config, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let config: Config = Deserialize::deserialize(deserializer)?;
+
+    if config.concurrency_limit == 0 {
+        return Err(de::Error::custom("concurrency_limit must be > 0"));
+    }
+
+    if config.concurrency_limit_per_connection == 0 {
+        return Err(de::Error::custom(
+            "concurrency_limit_per_connection must be > 0",
+        ));
+    }
+
+    if config.concurrency_limit < config.concurrency_limit_per_connection {
+        return Err(de::Error::custom(
+            "concurrency_limit must be >= concurrency_limit_per_connection",
+        ));
+    }
+
+    Ok(config)
+}
+
+pub struct Server {
+    addr: SocketAddr,
+    router: transport::server::Router<Stack<ConcurrencyLimitLayer, Identity>>,
+}
+
+impl Server {
+    pub fn new(config: &Config) -> Self {
+        Self {
+            addr: SocketAddr::new(config.ip_addr, config.port),
+            router: transport::Server::builder()
+                .layer(ConcurrencyLimitLayer::new(config.concurrency_limit))
+                .concurrency_limit_per_connection(config.concurrency_limit_per_connection)
+                .add_service(BlockchainServiceServer::new(
+                    blockchain_service::Service::new(),
+                ))
+                .add_service(CryptoServiceServer::new(crypto_service::Service::new())),
+        }
+    }
+
+    pub async fn run(self, token: CancellationToken) -> Result<(), Error> {
+        self.router
+            .serve_with_shutdown(self.addr, token.cancelled_owned())
+            .await
+            .map_err(ErrorExt::into_report)
+    }
+}

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -35,6 +35,7 @@ mod cosmos;
 mod event_processor;
 mod event_sub;
 mod evm;
+mod grpc;
 mod handlers;
 mod health_check;
 mod json_rpc;
@@ -72,8 +73,10 @@ async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
         service_registry: _service_registry,
         rewards: _rewards,
         health_check_bind_addr,
+        grpc: grpc_config,
     } = cfg;
 
+    let grpc_server = grpc::Server::new(&grpc_config);
     let tm_client = tendermint_rpc::HttpClient::new(tm_jsonrpc.to_string().as_str())
         .change_context(Error::Connection)
         .attach_printable(tm_jsonrpc.clone())?;
@@ -142,6 +145,7 @@ async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
         event_processor.stream_buffer_size,
         block_height_monitor,
         health_check_server,
+        grpc_server,
     )
     .configure_handlers(verifier, handlers, event_processor)
     .await
@@ -175,6 +179,7 @@ where
     multisig_client: MultisigClient,
     block_height_monitor: BlockHeightMonitor<tendermint_rpc::HttpClient>,
     health_check_server: health_check::Server,
+    grpc_server: grpc::Server,
 }
 
 impl<T> App<T>
@@ -190,6 +195,7 @@ where
         event_buffer_cap: usize,
         block_height_monitor: BlockHeightMonitor<tendermint_rpc::HttpClient>,
         health_check_server: health_check::Server,
+        grpc_server: grpc::Server,
     ) -> Self {
         let (event_publisher, event_subscriber) =
             event_sub::EventPublisher::new(tm_client, event_buffer_cap);
@@ -205,6 +211,7 @@ where
             multisig_client,
             block_height_monitor,
             health_check_server,
+            grpc_server,
         }
     }
 
@@ -564,6 +571,7 @@ where
             tx_confirmer,
             block_height_monitor,
             health_check_server,
+            grpc_server,
             ..
         } = self;
 
@@ -607,6 +615,9 @@ where
             .add_task(CancellableTask::create(|token| {
                 App::create_broadcaster_task(broadcaster, tx_confirmer).run(token)
             }))
+            .add_task(CancellableTask::create(|token| {
+                grpc_server.run(token).change_context(Error::GrpcServer)
+            }))
             .run(main_token)
             .await
     }
@@ -640,4 +651,6 @@ pub enum Error {
     InvalidFinalizerType(ChainName),
     #[error("health check is not working")]
     HealthCheck,
+    #[error("gRPC server failed")]
+    GrpcServer,
 }

--- a/ampd/src/testdata/deserialize_valid_grpc_config.golden
+++ b/ampd/src/testdata/deserialize_valid_grpc_config.golden
@@ -1,0 +1,47 @@
+{
+  "health_check_bind_addr": "0.0.0.0:3000",
+  "tm_jsonrpc": "http://localhost:26657/",
+  "tm_grpc": "tcp://localhost:9090",
+  "tm_grpc_timeout": {
+    "secs": 5,
+    "nanos": 0
+  },
+  "event_processor": {
+    "retry_delay": "1s",
+    "retry_max_attempts": 3,
+    "stream_timeout": "15s",
+    "stream_buffer_size": 100000
+  },
+  "broadcast": {
+    "chain_id": "axelar-dojo-1",
+    "tx_fetch_interval": "500ms",
+    "tx_fetch_max_retries": 10,
+    "gas_adjustment": 1.2,
+    "gas_price": "0.00005uaxl",
+    "batch_gas_limit": 1000000,
+    "queue_cap": 1000,
+    "broadcast_interval": "5s"
+  },
+  "handlers": [],
+  "tofnd_config": {
+    "url": "http://localhost:50051/",
+    "party_uid": "ampd",
+    "key_uid": "axelar",
+    "timeout": {
+      "secs": 3,
+      "nanos": 0
+    }
+  },
+  "service_registry": {
+    "cosmwasm_contract": "axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6"
+  },
+  "rewards": {
+    "cosmwasm_contract": "axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6"
+  },
+  "grpc": {
+    "ip_addr": "0.0.0.0",
+    "port": 9091,
+    "concurrency_limit": 2048,
+    "concurrency_limit_per_connection": 256
+  }
+}

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -131,3 +131,9 @@ cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
 
 [rewards]
 cosmwasm_contract = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'
+
+[grpc]
+ip_addr = '127.0.0.1'
+port = 9090
+concurrency_limit = 1024
+concurrency_limit_per_connection = 32

--- a/packages/ampd-proto/build.rs
+++ b/packages/ampd-proto/build.rs
@@ -1,6 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
-        .build_server(false)
+        .build_server(true)
         .build_client(true)
         .compile_protos(
             &["proto-files/ampd/v1/ampd.proto"],

--- a/packages/axelar-wasm-std/src/nonempty/mod.rs
+++ b/packages/axelar-wasm-std/src/nonempty/mod.rs
@@ -9,5 +9,5 @@ pub use error::Error;
 pub use hexbinary::HexBinary;
 pub use string::String;
 pub use timestamp::Timestamp;
-pub use uint::{Uint128, Uint256, Uint64};
+pub use uint::{Uint128, Uint256, Uint64, Usize};
 pub use vec::Vec;


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
