### PR TITLE
feat(minor-ampd): implement gRPC method subscribe for the blockchain service

### DIFF
--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -56,6 +56,7 @@ pub trait EventSub {
     fn subscribe(&self) -> impl Stream<Item = Result<Event, Error>> + Send + 'static;
 }
 
+#[derive(Clone)]
 pub struct EventSubscriber {
     tx: Sender<std::result::Result<Event, Error>>,
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -1,5 +1,5 @@
 use std::pin::Pin;
-use std::time::Duration;
+use std::str::FromStr;
 
 use ampd_proto::blockchain_service_server::BlockchainService;
 use ampd_proto::{
@@ -7,64 +7,77 @@ use ampd_proto::{
     ContractsResponse, QueryRequest, QueryResponse, SubscribeRequest, SubscribeResponse,
 };
 use async_trait::async_trait;
-use cosmrs::tendermint::block;
-use futures::{Stream, StreamExt};
-use tokio::sync::mpsc;
-use tokio::time;
-use tokio_stream::wrappers::ReceiverStream;
+use cosmrs::AccountId;
+use futures::{Stream, TryStreamExt};
+use report::LoggableError;
+use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
+use tracing::error;
+use valuable::Valuable;
 
-pub struct Service {}
+use crate::{event_sub, PREFIX};
 
-impl Service {
-    pub fn new() -> Self {
-        Self {}
+pub struct Service<E>
+where
+    E: event_sub::EventSub,
+{
+    event_sub: E,
+}
+
+impl<E> Service<E>
+where
+    E: event_sub::EventSub,
+{
+    pub fn new(event_sub: E) -> Self {
+        Self { event_sub }
     }
 }
 
 #[async_trait]
-impl BlockchainService for Service {
+impl<E> BlockchainService for Service<E>
+where
+    E: event_sub::EventSub + Send + Sync + 'static,
+{
     type SubscribeStream =
         Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send + 'static>>;
 
     async fn subscribe(
         &self,
-        _req: Request<SubscribeRequest>,
+        req: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        // TODO: replace the dummy implementation
-        let (tx, rx) = mpsc::channel(10000);
+        let SubscribeRequest {
+            filters,
+            include_block_begin_end,
+        } = req.into_inner();
 
-        tokio::spawn(async move {
-            let mut height: block::Height = 10u32.into();
-            let duration = Duration::from_secs(3);
-            let mut interval = time::interval(duration);
+        filters.iter().try_for_each(validate_filter)?;
 
-            loop {
-                let _ = tx
-                    .send(ampd_proto::subscribe_response::Event::BlockBegin(
-                        ampd_proto::EventBlockBegin {
-                            height: height.value(),
-                        },
-                    ))
-                    .await;
-                interval.tick().await;
+        Ok(Response::new(Box::pin(
+            self.event_sub
+                .subscribe()
+                .filter(filter_event_with(filters, include_block_begin_end))
+                .map_ok(Into::into)
+                .map_ok(|event| ampd_proto::SubscribeResponse { event: Some(event) })
+                .map_err(|err| {
+                    error!(
+                        err = LoggableError::from(&err).as_value(),
+                        "event subscription error"
+                    );
 
-                let _ = tx
-                    .send(ampd_proto::subscribe_response::Event::BlockEnd(
-                        ampd_proto::EventBlockEnd {
-                            height: height.value(),
-                        },
-                    ))
-                    .await;
-                interval.tick().await;
-
-                height = height.increment();
-            }
-        });
-
-        Ok(Response::new(Box::pin(ReceiverStream::new(rx).map(
-            |event| Ok(SubscribeResponse { event: Some(event) }),
-        ))))
+                    match err.current_context() {
+                        event_sub::Error::LatestBlockQuery
+                        | event_sub::Error::BlockResultsQuery { .. } => {
+                            Status::unavailable("blockchain service is temporarily unavailable")
+                        }
+                        event_sub::Error::EventDecoding { .. } => Status::internal(
+                            "server encountered an error processing blockchain events",
+                        ),
+                        event_sub::Error::BroadcastStreamRecv(_) => {
+                            Status::data_loss("events have been missed due to client lag")
+                        }
+                    }
+                }),
+        )))
     }
 
     async fn broadcast(
@@ -90,5 +103,411 @@ impl BlockchainService for Service {
         _req: Request<ContractsRequest>,
     ) -> Result<Response<ContractsResponse>, Status> {
         todo!("implement contracts method")
+    }
+}
+
+fn validate_filter(filter: &ampd_proto::EventFilter) -> Result<(), Status> {
+    if filter.r#type.is_empty() && filter.contract.is_empty() {
+        return Err(Status::invalid_argument("empty filter received"));
+    }
+
+    if !is_valid_contract_address(&filter.contract) {
+        return Err(Status::invalid_argument(format!(
+            "invalid contract address {} received in the filters",
+            filter.contract
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_valid_contract_address(contract: &str) -> bool {
+    contract.is_empty()
+        || AccountId::from_str(contract).is_ok_and(|contract| contract.prefix() == PREFIX)
+}
+
+fn filter_event_with(
+    filters: Vec<ampd_proto::EventFilter>,
+    include_block_begin_end: bool,
+) -> impl FnMut(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
+    move |event| match event {
+        Ok(event) => {
+            let contract = event.contract_address();
+
+            match event {
+                events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
+                    include_block_begin_end
+                }
+                events::Event::Abci { event_type, .. } => {
+                    filter_abci_event(&filters, event_type, contract)
+                }
+            }
+        }
+        Err(_) => true,
+    }
+}
+
+fn filter_abci_event(
+    filters: &[ampd_proto::EventFilter],
+    event_type: &str,
+    contract: Option<AccountId>,
+) -> bool {
+    if filters.is_empty() {
+        return true;
+    }
+
+    filters.iter().any(|filter| {
+        if !filter.r#type.is_empty() && filter.r#type != event_type {
+            return false;
+        }
+
+        if !filter.contract.is_empty()
+            && filter.contract
+                != contract
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default()
+        {
+            return false;
+        }
+
+        true
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use error_stack::report;
+    use events::{self, Event};
+    use futures::{stream, StreamExt};
+    use report::ErrorExt;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    use tonic::{Code, Request};
+
+    use super::*;
+    use crate::event_sub::{self, MockEventSub};
+    use crate::types::TMAddress;
+
+    #[tokio::test]
+    async fn subscribe_should_stream_events_successfully() {
+        let expected = vec![
+            block_begin_event(100),
+            abci_event("test_event", vec![("key1", "value1")], None),
+            block_end_event(100),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        let events = expected.clone();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        for expected in expected {
+            let actual = event_stream.next().await.unwrap().unwrap();
+            assert_eq!(actual.event, Some(expected.into()))
+        }
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_return_error_if_any_filter_is_invalid() {
+        let mock_event_sub = MockEventSub::new();
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(
+                vec![ampd_proto::EventFilter::default()],
+                true,
+            ))
+            .await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+        let res = service
+            .subscribe(subscribe_req(
+                vec![ampd_proto::EventFilter {
+                    contract: "invalid_contract".to_string(),
+                    ..Default::default()
+                }],
+                true,
+            ))
+            .await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_latest_block_query_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(|| {
+            tokio_stream::once(Err(report!(event_sub::Error::LatestBlockQuery))).boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Unavailable);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_block_results_query_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(report!(event_sub::Error::BlockResultsQuery {
+                block: 100u32.into()
+            })))
+            .boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Unavailable);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_event_decoding_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(report!(event_sub::Error::EventDecoding {
+                block: 100u32.into()
+            })))
+            .boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Internal);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_broadcast_stream_recv_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(BroadcastStreamRecvError::Lagged(10).into_report())).boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::DataLoss);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_event_type() {
+        let expected = abci_event("event_type_2", vec![("key2", "\"value2\"")], None);
+        let events = vec![
+            abci_event("event_type_1", vec![("key1", "\"value1\"")], None),
+            expected.clone(),
+            abci_event("event_type_3", vec![("key3", "\"value3\"")], None),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter = ampd_proto::EventFilter {
+            r#type: "event_type_2".to_string(),
+            ..Default::default()
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_contract() {
+        let expected = abci_event(
+            "test_event",
+            vec![],
+            Some(TMAddress::random(PREFIX).to_string().as_str()),
+        );
+        let events = vec![
+            abci_event("test_event", vec![], None),
+            expected.clone(),
+            abci_event(
+                "test_event",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: expected.contract_address().unwrap().to_string(),
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_block_events_filter() {
+        let expected = abci_event("test_event", vec![("key1", "\"value1\"")], None);
+        let events = vec![
+            block_begin_event(100),
+            expected.clone(),
+            block_end_event(100),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_multiple_filters() {
+        let expected = vec![
+            abci_event(
+                "event_1",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+            abci_event(
+                "event_2",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+        ];
+        let events = vec![
+            abci_event("test_event", vec![], None),
+            expected[0].clone(),
+            abci_event(
+                "test_event",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+            expected[1].clone(),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter_1 = ampd_proto::EventFilter {
+            r#type: "event_1".to_string(),
+            ..Default::default()
+        };
+        let filter_2 = ampd_proto::EventFilter {
+            contract: expected[1].contract_address().unwrap().to_string(),
+            ..Default::default()
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter_1, filter_2], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        for expected in expected {
+            let actual = event_stream.next().await.unwrap().unwrap();
+            assert_eq!(actual.event, Some(expected.into()))
+        }
+        assert!(event_stream.next().await.is_none());
+    }
+
+    fn subscribe_req(
+        filters: Vec<ampd_proto::EventFilter>,
+        include_block_begin_end: bool,
+    ) -> Request<SubscribeRequest> {
+        Request::new(SubscribeRequest {
+            filters,
+            include_block_begin_end,
+        })
+    }
+
+    fn block_begin_event(height: u64) -> Event {
+        Event::BlockBegin(height.try_into().unwrap())
+    }
+
+    fn block_end_event(height: u64) -> Event {
+        Event::BlockEnd(height.try_into().unwrap())
+    }
+
+    fn abci_event(
+        event_type: &str,
+        attributes: Vec<(&str, &str)>,
+        contract: Option<&str>,
+    ) -> Event {
+        Event::Abci {
+            event_type: event_type.to_string(),
+            attributes: attributes
+                .into_iter()
+                .chain(
+                    contract
+                        .into_iter()
+                        .map(|contract| ("_contract_address", contract)),
+                )
+                .map(|(key, value)| {
+                    (
+                        key.to_string(),
+                        serde_json::from_str(value)
+                            .unwrap_or_else(|_| serde_json::Value::String(value.to_string())),
+                    )
+                })
+                .collect(),
+        }
     }
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -128,7 +128,7 @@ fn is_valid_contract_address(contract: &str) -> bool {
 fn filter_event_with(
     filters: Vec<ampd_proto::EventFilter>,
     include_block_begin_end: bool,
-) -> impl FnMut(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
+) -> impl Fn(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
     move |event| match event {
         Ok(event) => {
             let contract = event.contract_address();

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -38,8 +38,7 @@ impl<E> BlockchainService for Service<E>
 where
     E: event_sub::EventSub + Send + Sync + 'static,
 {
-    type SubscribeStream =
-        Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send + 'static>>;
+    type SubscribeStream = Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send>>;
 
     async fn subscribe(
         &self,

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -77,6 +77,7 @@ impl From<&event_sub::Error> for Error {
 
 #[cfg(test)]
 mod tests {
+    use error_stack::report;
     use tendermint::block::Height;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::Code;
@@ -104,19 +105,19 @@ mod tests {
             Code::Unavailable
         );
         assert_eq!(
-            event_sub::Error::BlockResultsQuery {
+            report!(event_sub::Error::BlockResultsQuery {
                 block: Height::default()
-            }
+            })
             .into_status()
             .code(),
             Code::Unavailable
         );
         assert_eq!(
-            event_sub::Error::EventDecoding {
+            (&report!(event_sub::Error::EventDecoding {
                 block: Height::default()
-            }
-            .into_status()
-            .code(),
+            }))
+                .into_status()
+                .code(),
             Code::Internal
         );
         assert_eq!(

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -1,0 +1,129 @@
+use error_stack::Report;
+use tonic::Status;
+
+use super::event_filters;
+use crate::event_sub;
+
+pub trait ErrorExt {
+    fn into_status(self) -> Status;
+}
+
+struct Error(Status);
+
+impl<Err> ErrorExt for Err
+where
+    Err: Into<Error>,
+{
+    fn into_status(self) -> Status {
+        self.into().0
+    }
+}
+
+impl<'a, Err> ErrorExt for &Report<Err>
+where
+    Error: From<&'a Err>,
+    Err: Send + Sync + 'static,
+    Self: 'a,
+{
+    fn into_status(self) -> Status {
+        self.current_context().into_status()
+    }
+}
+
+impl<Err> ErrorExt for Report<Err>
+where
+    for<'a> Error: From<&'a Err>,
+    Err: Send + Sync + 'static,
+{
+    fn into_status(self) -> Status {
+        (&self).into_status()
+    }
+}
+
+impl From<Status> for Error {
+    fn from(status: Status) -> Self {
+        Self(status)
+    }
+}
+
+impl From<&event_filters::Error> for Error {
+    fn from(err: &event_filters::Error) -> Self {
+        match err {
+            event_filters::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            event_filters::Error::InvalidContractAddress(contract) => Status::invalid_argument(
+                format!("invalid contract address {} provided in filters", contract),
+            ),
+        }
+        .into()
+    }
+}
+
+impl From<&event_sub::Error> for Error {
+    fn from(err: &event_sub::Error) -> Self {
+        match err {
+            event_sub::Error::LatestBlockQuery | event_sub::Error::BlockResultsQuery { .. } => {
+                Status::unavailable("blockchain service is temporarily unavailable")
+            }
+            event_sub::Error::EventDecoding { .. } => {
+                Status::internal("server encountered an error processing blockchain events")
+            }
+            event_sub::Error::BroadcastStreamRecv(_) => {
+                Status::data_loss("events have been missed due to client lag")
+            }
+        }
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tendermint::block::Height;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    use tonic::Code;
+
+    use super::*;
+
+    #[test]
+    fn event_filters_errors_to_status() {
+        assert_eq!(
+            event_filters::Error::EmptyFilter.into_status().code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            event_filters::Error::InvalidContractAddress("invalid_contract_address".to_string())
+                .into_status()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn event_sub_errors_to_status() {
+        assert_eq!(
+            event_sub::Error::LatestBlockQuery.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            event_sub::Error::BlockResultsQuery {
+                block: Height::default()
+            }
+            .into_status()
+            .code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            event_sub::Error::EventDecoding {
+                block: Height::default()
+            }
+            .into_status()
+            .code(),
+            Code::Internal
+        );
+        assert_eq!(
+            event_sub::Error::BroadcastStreamRecv(BroadcastStreamRecvError::Lagged(10))
+                .into_status()
+                .code(),
+            Code::DataLoss
+        );
+    }
+}

--- a/ampd/src/grpc/event_filters.rs
+++ b/ampd/src/grpc/event_filters.rs
@@ -1,0 +1,380 @@
+use std::str::FromStr;
+
+use axelar_wasm_std::nonempty;
+use cosmrs::AccountId;
+use error_stack::{report, Report, Result};
+use report::ResultCompatExt;
+use thiserror::Error;
+use tonic::Status;
+
+use crate::types::TMAddress;
+use crate::{event_sub, PREFIX};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("empty filter")]
+    EmptyFilter,
+    #[error("invalid contract address in filter")]
+    InvalidContractAddress(String),
+}
+
+impl From<&Error> for Status {
+    fn from(error: &Error) -> Self {
+        match error {
+            Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            Error::InvalidContractAddress(contract) => Status::invalid_argument(format!(
+                "invalid contract address {} provided in filters",
+                contract
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EventFilter {
+    event_type: Option<nonempty::String>,
+    contract: Option<TMAddress>,
+}
+
+impl TryFrom<ampd_proto::EventFilter> for EventFilter {
+    type Error = Report<Error>;
+
+    fn try_from(event_filter: ampd_proto::EventFilter) -> Result<Self, Error> {
+        let event_type = event_filter.r#type.try_into().ok();
+        let contract = if event_filter.contract.is_empty() {
+            None
+        } else {
+            let contract = AccountId::from_str(&event_filter.contract)
+                .change_context(Error::InvalidContractAddress(event_filter.contract.clone()))
+                .and_then(|contract| {
+                    if contract.prefix() != PREFIX {
+                        return Err(report!(Error::InvalidContractAddress(
+                            event_filter.contract
+                        )));
+                    }
+
+                    Ok(contract)
+                })
+                .map(Into::into)?;
+
+            Some(contract)
+        };
+
+        if event_type.is_none() && contract.is_none() {
+            return Err(report!(Error::EmptyFilter));
+        }
+
+        Ok(EventFilter {
+            event_type,
+            contract,
+        })
+    }
+}
+
+impl EventFilter {
+    pub fn filter(&self, event_type: &str, contract: &Option<TMAddress>) -> bool {
+        if self
+            .event_type
+            .as_ref()
+            .is_some_and(|filter| *filter != event_type)
+        {
+            return false;
+        }
+
+        if self.contract.is_some() && self.contract != *contract {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct EventFilters {
+    filters: Vec<EventFilter>,
+    include_block_begin_end: bool,
+}
+
+impl EventFilters {
+    pub fn filter(&self, event: &Result<events::Event, event_sub::Error>) -> bool {
+        match event {
+            Ok(event) => {
+                let contract = event.contract_address();
+
+                match event {
+                    events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
+                        self.include_block_begin_end
+                    }
+                    events::Event::Abci { event_type, .. } => {
+                        self.filter_abci_event(event_type, contract)
+                    }
+                }
+            }
+            Err(_) => true,
+        }
+    }
+
+    fn filter_abci_event<T>(&self, event_type: &str, contract: Option<T>) -> bool
+    where
+        T: Into<TMAddress>,
+    {
+        if self.filters.is_empty() {
+            return true;
+        }
+
+        let contract = contract.map(Into::into);
+
+        self.filters
+            .iter()
+            .any(|filter| filter.filter(event_type, &contract))
+    }
+}
+
+impl TryFrom<(Vec<ampd_proto::EventFilter>, bool)> for EventFilters {
+    type Error = Report<Error>;
+
+    fn try_from(
+        (event_filters, include_block_begin_end): (Vec<ampd_proto::EventFilter>, bool),
+    ) -> Result<Self, Error> {
+        Ok(EventFilters {
+            filters: event_filters
+                .into_iter()
+                .map(EventFilter::try_from)
+                .collect::<Result<_, _>>()?,
+            include_block_begin_end,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use axelar_wasm_std::assert_err_contains;
+    use error_stack::report;
+    use events::Event;
+    use serde_json::{Map, Value};
+
+    use super::*;
+    use crate::types::TMAddress;
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_event_filter() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.event_type.is_some());
+        assert!(filter.contract.is_none());
+    }
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_contract_address() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.event_type.is_none());
+        assert_eq!(filter.contract.as_ref(), Some(&address));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_empty_filter() {
+        let proto_filter = ampd_proto::EventFilter::default();
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::EmptyFilter);
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_invalid_contract_address() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: "invalid_address".to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_contract_with_wrong_prefix() {
+        let address = TMAddress::random("wrong");
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_event_type() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.filter("test_event", &None));
+        assert!(!filter.filter("other_event", &None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("any_event", &Some(address.clone())));
+        assert!(!filter.filter("any_event", &Some(TMAddress::random(PREFIX))));
+        assert!(!filter.filter("any_event", &None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_both_event_type_and_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("test_event", &Some(address.clone())));
+        assert!(!filter.filter("other_event", &Some(address.clone())));
+        assert!(!filter.filter("test_event", &Some(TMAddress::random(PREFIX))));
+    }
+
+    #[test]
+    fn event_filters_should_be_created_from_valid_proto_filters() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, true)).unwrap();
+        assert_eq!(filters.filters.len(), 1);
+        assert!(filters.include_block_begin_end);
+    }
+
+    #[test]
+    fn event_filters_should_fail_if_any_filter_is_invalid() {
+        let proto_filters = vec![
+            ampd_proto::EventFilter {
+                r#type: "test_event".to_string(),
+                contract: "".to_string(),
+            },
+            ampd_proto::EventFilter::default(),
+        ];
+
+        let result = EventFilters::try_from((proto_filters, true));
+        assert_err_contains!(result, Error, Error::EmptyFilter);
+    }
+
+    #[test]
+    fn event_filters_should_include_block_events_when_configured() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, true)).unwrap();
+        assert!(filters.filter(&Ok(Event::BlockBegin(100u32.into()))));
+        assert!(filters.filter(&Ok(Event::BlockEnd(100u32.into()))));
+    }
+
+    #[test]
+    fn event_filters_should_exclude_block_events_when_configured() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(!filters.filter(&Ok(Event::BlockBegin(100u32.into()))));
+        assert!(!filters.filter(&Ok(Event::BlockEnd(100u32.into()))));
+    }
+
+    #[test]
+    fn event_filters_should_match_abci_events_with_matching_filters() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "test_event".to_string(),
+            attributes: Map::new(),
+        })));
+        assert!(!filters.filter(&Ok(Event::Abci {
+            event_type: "other_event".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_match_any_filter_in_multiple_filters() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filters = vec![
+            ampd_proto::EventFilter {
+                r#type: "event_1".to_string(),
+                contract: "".to_string(),
+            },
+            ampd_proto::EventFilter {
+                r#type: "".to_string(),
+                contract: address.to_string(),
+            },
+        ];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "event_1".to_string(),
+            attributes: Map::new(),
+        })));
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "any_event".to_string(),
+            attributes: iter::once((
+                "_contract_address".to_string(),
+                Value::String(address.to_string()),
+            ))
+            .collect(),
+        })));
+        assert!(!filters.filter(&Ok(Event::Abci {
+            event_type: "event_2".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_allow_all_events_when_no_filters_provided() {
+        let filters = EventFilters::try_from((vec![], true)).unwrap();
+
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "any_event".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_always_allow_error_events() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Err(report!(event_sub::Error::LatestBlockQuery))));
+    }
+}

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -17,6 +17,7 @@ use crate::event_sub::EventSub;
 
 mod blockchain_service;
 mod crypto_service;
+mod event_filters;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -17,6 +17,7 @@ use crate::event_sub::EventSub;
 
 mod blockchain_service;
 mod crypto_service;
+mod error;
 mod event_filters;
 
 #[derive(Error, Debug)]

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -13,6 +13,8 @@ use tonic::transport;
 use tower::layer::util::{Identity, Stack};
 use tower::limit::ConcurrencyLimitLayer;
 
+use crate::event_sub::EventSub;
+
 mod blockchain_service;
 mod crypto_service;
 
@@ -66,7 +68,10 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(config: &Config) -> Self {
+    pub fn new<E>(config: &Config, event_sub: E) -> Self
+    where
+        E: EventSub + Send + Sync + 'static,
+    {
         Self {
             addr: SocketAddr::new(config.ip_addr, config.port),
             // TODO: add TLS and optional public key pinning
@@ -74,7 +79,7 @@ impl Server {
                 .layer(ConcurrencyLimitLayer::new(config.concurrency_limit.into()))
                 .concurrency_limit_per_connection(config.concurrency_limit_per_connection.into())
                 .add_service(BlockchainServiceServer::new(
-                    blockchain_service::Service::new(),
+                    blockchain_service::Service::new(event_sub),
                 ))
                 .add_service(CryptoServiceServer::new(crypto_service::Service::new())),
         }

--- a/ampd/src/types/mod.rs
+++ b/ampd/src/types/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::hash::{Hash as StdHash, Hasher};
+use std::str::FromStr;
 
 use cosmrs::AccountId;
 use ethers_core::types::{Address, H256};
@@ -16,6 +17,14 @@ pub type Hash = H256;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TMAddress(AccountId);
+
+impl FromStr for TMAddress {
+    type Err = <AccountId as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        AccountId::from_str(s).map(Self)
+    }
+}
 
 impl StdHash for TMAddress {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -470,7 +470,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
+        assert_eq!(event.message_id, msg_id.to_string().as_str());
         assert_eq!(event.verifier_set, verifier_set);
     }
 
@@ -492,7 +492,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
+        assert_eq!(event.message_id, msg_id.to_string().as_str());
         assert_eq!(event.verifier_set, verifier_set);
     }
 

--- a/packages/ampd-sdk/src/grpc/client.rs
+++ b/packages/ampd-sdk/src/grpc/client.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::pin::Pin;
 use std::vec;
 
@@ -81,10 +80,9 @@ impl Client for GrpcClient {
         let request = SubscribeRequest {
             filters: filters
                 .into_iter()
-                .map(|filter| ampd_proto::Event {
+                .map(|filter| ampd_proto::EventFilter {
                     r#type: filter.event_type,
-                    contract: String::new(),
-                    attributes: HashMap::new(),
+                    contract: Default::default(),
                 })
                 .collect(),
             include_block_begin_end,

--- a/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
@@ -116,7 +116,7 @@ mod tests {
             let res = Base58TxDigestAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_digest_as_base58(), tx_digest.try_into().unwrap(),);
+            assert_eq!(parsed.tx_digest_as_base58(), tx_digest.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
@@ -123,7 +123,7 @@ mod tests {
             let res = Base58SolanaTxSignatureAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.signature_as_base58(), tx_digest.try_into().unwrap());
+            assert_eq!(parsed.signature_as_base58(), tx_digest.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/starknet_field_element_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/starknet_field_element_event_index.rs
@@ -134,7 +134,7 @@ mod tests {
             let res = FieldElementAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.try_into().unwrap(),);
+            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.as_str(),);
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
@@ -111,7 +111,7 @@ mod tests {
 
             let res = HexTxHash::from_str(&msg_id);
             let parsed = res.unwrap();
-            assert_eq!(parsed.tx_hash_as_hex(), msg_id.clone().try_into().unwrap());
+            assert_eq!(parsed.tx_hash_as_hex(), msg_id.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -127,7 +127,7 @@ mod tests {
             let res = HexTxHashAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.try_into().unwrap(),);
+            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/nonempty/string.rs
+++ b/packages/axelar-wasm-std/src/nonempty/string.rs
@@ -13,6 +13,12 @@ use crate::nonempty::Error;
 #[derive(Eq, Hash, Valuable, IntoInner)]
 pub struct String(std::string::String);
 
+impl PartialEq<&str> for String {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
 impl TryFrom<std::string::String> for String {
     type Error = Error;
 

--- a/packages/axelar-wasm-std/src/nonempty/string.rs
+++ b/packages/axelar-wasm-std/src/nonempty/string.rs
@@ -13,6 +13,12 @@ use crate::nonempty::Error;
 #[derive(Eq, Hash, Valuable, IntoInner)]
 pub struct String(std::string::String);
 
+impl PartialEq<&str> for &String {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
 impl PartialEq<&str> for String {
     fn eq(&self, other: &&str) -> bool {
         self.0 == *other

--- a/packages/events/src/event.rs
+++ b/packages/events/src/event.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::Display;
 
 use axelar_wasm_std::FnExt;
@@ -11,6 +11,8 @@ use tendermint::{abci, block};
 
 use crate::errors::DecodingError;
 use crate::Error;
+
+const KEY_CONTRACT_ADDRESS: &str = "_contract_address";
 
 pub struct AbciEventTypeFilter {
     pub event_type: String,
@@ -70,7 +72,7 @@ impl Event {
                 event_type: _,
                 attributes,
             } => attributes
-                .get("_contract_address")
+                .get(KEY_CONTRACT_ADDRESS)
                 .and_then(|address| serde_json::from_value::<AccountId>(address.clone()).ok()),
             _ => None,
         }
@@ -120,6 +122,39 @@ fn base64_to_utf8(base64_str: &str) -> std::result::Result<String, DecodingError
     Ok(STANDARD.decode(base64_str)?.then(String::from_utf8)?)
 }
 
+impl From<Event> for ampd_proto::subscribe_response::Event {
+    fn from(event: Event) -> Self {
+        let contract = event.contract_address();
+
+        match event {
+            Event::BlockBegin(height) => {
+                ampd_proto::subscribe_response::Event::BlockBegin(ampd_proto::EventBlockBegin {
+                    height: height.value(),
+                })
+            }
+            Event::BlockEnd(height) => {
+                ampd_proto::subscribe_response::Event::BlockEnd(ampd_proto::EventBlockEnd {
+                    height: height.value(),
+                })
+            }
+            Event::Abci {
+                event_type,
+                attributes,
+            } => ampd_proto::subscribe_response::Event::Abci(ampd_proto::Event {
+                r#type: event_type,
+                contract: contract
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(key, value)| (key, value.to_string()))
+                    .collect(),
+            }),
+        }
+    }
+}
+
 impl TryFrom<ampd_proto::subscribe_response::Event> for Event {
     type Error = Report<Error>;
 
@@ -141,25 +176,20 @@ impl TryFrom<ampd_proto::subscribe_response::Event> for Event {
             }
             ampd_proto::subscribe_response::Event::Abci(abci) => Ok(Self::Abci {
                 event_type: abci.r#type,
-                attributes: convert_attributes(&abci.attributes),
+                attributes: abci
+                    .attributes
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            serde_json::from_str(&value)
+                                .unwrap_or(serde_json::Value::String(value)),
+                        )
+                    })
+                    .collect(),
             }),
         }
     }
-}
-
-fn convert_attributes(
-    proto_attrs: &HashMap<String, String>,
-) -> serde_json::Map<String, serde_json::Value> {
-    let mut result = serde_json::Map::new();
-
-    for (key, value) in proto_attrs {
-        let json_value = serde_json::from_str(value)
-            .unwrap_or_else(|_| serde_json::Value::String(value.clone()));
-
-        result.insert(key.clone(), json_value);
-    }
-
-    result
 }
 
 #[cfg(test)]
@@ -170,12 +200,13 @@ mod test {
     use cosmrs::AccountId;
     use tendermint::block;
 
+    use super::KEY_CONTRACT_ADDRESS;
     use crate::Event;
 
     fn make_event_with_contract_address(contract_address: &AccountId) -> Event {
         let mut attributes = serde_json::Map::new();
         attributes.insert(
-            "_contract_address".to_string(),
+            KEY_CONTRACT_ADDRESS.to_string(),
             contract_address.to_string().into(),
         );
         Event::Abci {
@@ -271,7 +302,7 @@ mod test {
         attrs.insert("key1".to_string(), "value1".to_string());
         attrs.insert("key2".to_string(), "42".to_string());
         attrs.insert(
-            "_contract_address".to_string(),
+            KEY_CONTRACT_ADDRESS.to_string(),
             contract_address_string.clone(),
         );
 


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
