### PR TITLE
AXE 8227 Implement Blockchain.Subscribe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/ampd-proto/proto-files"]
 	path = packages/ampd-proto/proto-files
 	url = https://github.com/axelarnetwork/ampd-proto.git
-	branch = main
+	branch = docs/update-subscribe-status-code-comments

--- a/ampd/src/broadcaster_v2/broadcaster.rs
+++ b/ampd/src/broadcaster_v2/broadcaster.rs
@@ -99,7 +99,7 @@ where
             .into();
         let account = cosmos::account(&mut client, &address)
             .await
-            .change_context(Error::QueryAccount)?;
+            .change_context(Error::AccountQuery)?;
 
         Ok(Self {
             client,
@@ -184,7 +184,7 @@ where
             .build()
             .sign_with(&self.chain_id, self.acc_number, sign_fn)
             .await
-            .change_context(Error::TxSigning)?;
+            .change_context(Error::SignTx)?;
 
         match cosmos::broadcast(&mut self.client, tx).await {
             Ok(tx_response) => {
@@ -215,7 +215,7 @@ where
 {
     let account = cosmos::account(client, address)
         .await
-        .change_context(Error::QueryAccount)?;
+        .change_context(Error::AccountQuery)?;
     *acc_sequence = account.sequence;
 
     Ok(())
@@ -322,7 +322,7 @@ mod tests {
 
         let result = Broadcaster::new(mock_client, chain_id, pub_key).await;
 
-        assert_err_contains!(result, Error, Error::QueryAccount);
+        assert_err_contains!(result, Error, Error::AccountQuery);
     }
 
     #[tokio::test]
@@ -502,7 +502,7 @@ mod tests {
 
         let result = broadcaster.broadcast(vec![dummy_msg()], fee, sign_fn).await;
 
-        assert_err_contains!(result, Error, Error::TxSigning);
+        assert_err_contains!(result, Error, Error::SignTx);
         assert_eq!(*broadcaster.acc_sequence.read().await, sequence);
     }
 

--- a/ampd/src/broadcaster_v2/msg_queue.rs
+++ b/ampd/src/broadcaster_v2/msg_queue.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use axelar_wasm_std::nonempty;
 use cosmrs::{Any, Gas};
 use error_stack::{report, Report, ResultExt};
-use futures::{FutureExt, Stream};
+use futures::{FutureExt, Stream, TryFutureExt};
 use pin_project_lite::pin_project;
 use report::{ErrorExt, LoggableError};
 use serde_json::json;
@@ -100,13 +100,19 @@ where
         &mut self,
         msg: Any,
     ) -> Result<impl Future<Output = Result<(String, u64)>> + Send> {
-        let rx = self.enqueue_with_channel(msg).await?;
+        let attachment = json!({ "msg": msg });
+        let rx = self
+            .enqueue_with_channel(msg.clone())
+            .await
+            .map_err(|err| err.attach_printable(attachment.clone()))?;
 
-        Ok(rx.map(|result| match result {
-            Ok(Ok(result)) => Ok(result),
-            Ok(Err(err)) => Err(err),
-            Err(err) => Err(err.into_report()),
-        }))
+        Ok(rx
+            .map(|result| match result {
+                Ok(Ok(result)) => Ok(result),
+                Ok(Err(err)) => Err(err),
+                Err(err) => Err(err.into_report()),
+            })
+            .map_err(move |err| err.attach_printable(attachment)))
     }
 
     /// Enqueues a message without waiting for its result
@@ -225,16 +231,13 @@ impl MsgQueue {
         msg_cap: usize,
         gas_cap: Gas,
         duration: time::Duration,
-    ) -> Result<(
-        impl Stream<Item = nonempty::Vec<QueueMsg>>,
-        MsgQueueClient<T>,
-    )>
+    ) -> (Pin<Box<MsgQueue>>, MsgQueueClient<T>)
     where
         T: cosmos::CosmosClient,
     {
         let (tx, rx) = mpsc::channel(msg_cap);
 
-        Ok((
+        (
             Box::pin(MsgQueue {
                 stream: ReceiverStream::new(rx).fuse(),
                 deadline: time::sleep(duration),
@@ -242,7 +245,7 @@ impl MsgQueue {
                 duration,
             }),
             MsgQueueClient { broadcaster, tx },
-        ))
+        )
     }
 }
 
@@ -297,12 +300,10 @@ impl Stream for MsgQueue {
 
 fn handle_queue_error(msg: QueueMsg, err: Error) {
     let QueueMsg {
-        msg,
-        tx_res_callback,
-        ..
+        tx_res_callback, ..
     } = msg;
 
-    let err = report!(err).attach_printable(json!({ "msg": msg }));
+    let err = report!(err);
     warn!(
         error = LoggableError::from(&err).as_value(),
         "message dropped"
@@ -434,8 +435,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())
@@ -492,8 +492,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let actual = msg_queue.next().await.unwrap();
@@ -566,8 +565,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
 
         let handles: Vec<_> = (0..client_count)
             .map(|_| {
@@ -627,8 +625,7 @@ mod tests {
             10,
             1000u64,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         assert_err_contains!(
             msg_queue_client.enqueue_and_forget(dummy_msg()).await,
@@ -675,8 +672,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let _ = msg_queue.next().await;
@@ -722,8 +718,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())
@@ -782,8 +777,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
         let handle = tokio::spawn(async move {
             let actual = msg_queue.next().await.unwrap();
             assert_eq!(actual.as_ref().len(), 10);
@@ -849,8 +843,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let handle = tokio::spawn(async move {
@@ -904,8 +897,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -56,6 +56,7 @@ pub trait EventSub {
     fn subscribe(&self) -> impl Stream<Item = Result<Event, Error>> + Send + 'static;
 }
 
+#[derive(Clone)]
 pub struct EventSubscriber {
     tx: Sender<std::result::Result<Event, Error>>,
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -1,5 +1,5 @@
 use std::pin::Pin;
-use std::time::Duration;
+use std::str::FromStr;
 
 use ampd_proto::blockchain_service_server::BlockchainService;
 use ampd_proto::{
@@ -7,64 +7,77 @@ use ampd_proto::{
     ContractsResponse, QueryRequest, QueryResponse, SubscribeRequest, SubscribeResponse,
 };
 use async_trait::async_trait;
-use cosmrs::tendermint::block;
-use futures::{Stream, StreamExt};
-use tokio::sync::mpsc;
-use tokio::time;
-use tokio_stream::wrappers::ReceiverStream;
+use cosmrs::AccountId;
+use futures::{Stream, TryStreamExt};
+use report::LoggableError;
+use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
+use tracing::error;
+use valuable::Valuable;
 
-pub struct Service {}
+use crate::{event_sub, PREFIX};
 
-impl Service {
-    pub fn new() -> Self {
-        Self {}
+pub struct Service<E>
+where
+    E: event_sub::EventSub,
+{
+    event_sub: E,
+}
+
+impl<E> Service<E>
+where
+    E: event_sub::EventSub,
+{
+    pub fn new(event_sub: E) -> Self {
+        Self { event_sub }
     }
 }
 
 #[async_trait]
-impl BlockchainService for Service {
+impl<E> BlockchainService for Service<E>
+where
+    E: event_sub::EventSub + Send + Sync + 'static,
+{
     type SubscribeStream =
         Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send + 'static>>;
 
     async fn subscribe(
         &self,
-        _req: Request<SubscribeRequest>,
+        req: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        // TODO: replace the dummy implementation
-        let (tx, rx) = mpsc::channel(10000);
+        let SubscribeRequest {
+            filters,
+            include_block_begin_end,
+        } = req.into_inner();
 
-        tokio::spawn(async move {
-            let mut height: block::Height = 10u32.into();
-            let duration = Duration::from_secs(3);
-            let mut interval = time::interval(duration);
+        filters.iter().try_for_each(validate_filter)?;
 
-            loop {
-                let _ = tx
-                    .send(ampd_proto::subscribe_response::Event::BlockBegin(
-                        ampd_proto::EventBlockBegin {
-                            height: height.value(),
-                        },
-                    ))
-                    .await;
-                interval.tick().await;
+        Ok(Response::new(Box::pin(
+            self.event_sub
+                .subscribe()
+                .filter(filter_event_with(filters, include_block_begin_end))
+                .map_ok(Into::into)
+                .map_ok(|event| ampd_proto::SubscribeResponse { event: Some(event) })
+                .map_err(|err| {
+                    error!(
+                        err = LoggableError::from(&err).as_value(),
+                        "event subscription error"
+                    );
 
-                let _ = tx
-                    .send(ampd_proto::subscribe_response::Event::BlockEnd(
-                        ampd_proto::EventBlockEnd {
-                            height: height.value(),
-                        },
-                    ))
-                    .await;
-                interval.tick().await;
-
-                height = height.increment();
-            }
-        });
-
-        Ok(Response::new(Box::pin(ReceiverStream::new(rx).map(
-            |event| Ok(SubscribeResponse { event: Some(event) }),
-        ))))
+                    match err.current_context() {
+                        event_sub::Error::LatestBlockQuery
+                        | event_sub::Error::BlockResultsQuery { .. } => {
+                            Status::unavailable("blockchain service is temporarily unavailable")
+                        }
+                        event_sub::Error::EventDecoding { .. } => Status::internal(
+                            "server encountered an error processing blockchain events",
+                        ),
+                        event_sub::Error::BroadcastStreamRecv(_) => {
+                            Status::data_loss("events have been missed due to client lag")
+                        }
+                    }
+                }),
+        )))
     }
 
     async fn broadcast(
@@ -90,5 +103,411 @@ impl BlockchainService for Service {
         _req: Request<ContractsRequest>,
     ) -> Result<Response<ContractsResponse>, Status> {
         todo!("implement contracts method")
+    }
+}
+
+fn validate_filter(filter: &ampd_proto::EventFilter) -> Result<(), Status> {
+    if filter.r#type.is_empty() && filter.contract.is_empty() {
+        return Err(Status::invalid_argument("empty filter received"));
+    }
+
+    if !is_valid_contract_address(&filter.contract) {
+        return Err(Status::invalid_argument(format!(
+            "invalid contract address {} received in the filters",
+            filter.contract
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_valid_contract_address(contract: &str) -> bool {
+    contract.is_empty()
+        || AccountId::from_str(contract).is_ok_and(|contract| contract.prefix() == PREFIX)
+}
+
+fn filter_event_with(
+    filters: Vec<ampd_proto::EventFilter>,
+    include_block_begin_end: bool,
+) -> impl FnMut(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
+    move |event| match event {
+        Ok(event) => {
+            let contract = event.contract_address();
+
+            match event {
+                events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
+                    include_block_begin_end
+                }
+                events::Event::Abci { event_type, .. } => {
+                    filter_abci_event(&filters, event_type, contract)
+                }
+            }
+        }
+        Err(_) => true,
+    }
+}
+
+fn filter_abci_event(
+    filters: &[ampd_proto::EventFilter],
+    event_type: &str,
+    contract: Option<AccountId>,
+) -> bool {
+    if filters.is_empty() {
+        return true;
+    }
+
+    filters.iter().any(|filter| {
+        if !filter.r#type.is_empty() && filter.r#type != event_type {
+            return false;
+        }
+
+        if !filter.contract.is_empty()
+            && filter.contract
+                != contract
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default()
+        {
+            return false;
+        }
+
+        true
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use error_stack::report;
+    use events::{self, Event};
+    use futures::{stream, StreamExt};
+    use report::ErrorExt;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    use tonic::{Code, Request};
+
+    use super::*;
+    use crate::event_sub::{self, MockEventSub};
+    use crate::types::TMAddress;
+
+    #[tokio::test]
+    async fn subscribe_should_stream_events_successfully() {
+        let expected = vec![
+            block_begin_event(100),
+            abci_event("test_event", vec![("key1", "value1")], None),
+            block_end_event(100),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        let events = expected.clone();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        for expected in expected {
+            let actual = event_stream.next().await.unwrap().unwrap();
+            assert_eq!(actual.event, Some(expected.into()))
+        }
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_return_error_if_any_filter_is_invalid() {
+        let mock_event_sub = MockEventSub::new();
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(
+                vec![ampd_proto::EventFilter::default()],
+                true,
+            ))
+            .await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+        let res = service
+            .subscribe(subscribe_req(
+                vec![ampd_proto::EventFilter {
+                    contract: "invalid_contract".to_string(),
+                    ..Default::default()
+                }],
+                true,
+            ))
+            .await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_latest_block_query_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(|| {
+            tokio_stream::once(Err(report!(event_sub::Error::LatestBlockQuery))).boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Unavailable);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_block_results_query_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(report!(event_sub::Error::BlockResultsQuery {
+                block: 100u32.into()
+            })))
+            .boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Unavailable);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_event_decoding_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(report!(event_sub::Error::EventDecoding {
+                block: 100u32.into()
+            })))
+            .boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::Internal);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_broadcast_stream_recv_error() {
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub.expect_subscribe().return_once(move || {
+            tokio_stream::once(Err(BroadcastStreamRecvError::Lagged(10).into_report())).boxed()
+        });
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], true))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let error = event_stream.next().await.unwrap().unwrap_err();
+        assert_eq!(error.code(), Code::DataLoss);
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_event_type() {
+        let expected = abci_event("event_type_2", vec![("key2", "\"value2\"")], None);
+        let events = vec![
+            abci_event("event_type_1", vec![("key1", "\"value1\"")], None),
+            expected.clone(),
+            abci_event("event_type_3", vec![("key3", "\"value3\"")], None),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter = ampd_proto::EventFilter {
+            r#type: "event_type_2".to_string(),
+            ..Default::default()
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_contract() {
+        let expected = abci_event(
+            "test_event",
+            vec![],
+            Some(TMAddress::random(PREFIX).to_string().as_str()),
+        );
+        let events = vec![
+            abci_event("test_event", vec![], None),
+            expected.clone(),
+            abci_event(
+                "test_event",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: expected.contract_address().unwrap().to_string(),
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_handle_block_events_filter() {
+        let expected = abci_event("test_event", vec![("key1", "\"value1\"")], None);
+        let events = vec![
+            block_begin_event(100),
+            expected.clone(),
+            block_end_event(100),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        let actual = event_stream.next().await.unwrap().unwrap();
+        assert_eq!(actual.event, Some(expected.into()));
+        assert!(event_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_should_filter_events_by_multiple_filters() {
+        let expected = vec![
+            abci_event(
+                "event_1",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+            abci_event(
+                "event_2",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+        ];
+        let events = vec![
+            abci_event("test_event", vec![], None),
+            expected[0].clone(),
+            abci_event(
+                "test_event",
+                vec![],
+                Some(TMAddress::random(PREFIX).to_string().as_str()),
+            ),
+            expected[1].clone(),
+        ];
+
+        let mut mock_event_sub = MockEventSub::new();
+        mock_event_sub
+            .expect_subscribe()
+            .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
+
+        let filter_1 = ampd_proto::EventFilter {
+            r#type: "event_1".to_string(),
+            ..Default::default()
+        };
+        let filter_2 = ampd_proto::EventFilter {
+            contract: expected[1].contract_address().unwrap().to_string(),
+            ..Default::default()
+        };
+        let service = Service::new(mock_event_sub);
+        let res = service
+            .subscribe(subscribe_req(vec![filter_1, filter_2], false))
+            .await
+            .unwrap();
+        let mut event_stream = res.into_inner();
+
+        for expected in expected {
+            let actual = event_stream.next().await.unwrap().unwrap();
+            assert_eq!(actual.event, Some(expected.into()))
+        }
+        assert!(event_stream.next().await.is_none());
+    }
+
+    fn subscribe_req(
+        filters: Vec<ampd_proto::EventFilter>,
+        include_block_begin_end: bool,
+    ) -> Request<SubscribeRequest> {
+        Request::new(SubscribeRequest {
+            filters,
+            include_block_begin_end,
+        })
+    }
+
+    fn block_begin_event(height: u64) -> Event {
+        Event::BlockBegin(height.try_into().unwrap())
+    }
+
+    fn block_end_event(height: u64) -> Event {
+        Event::BlockEnd(height.try_into().unwrap())
+    }
+
+    fn abci_event(
+        event_type: &str,
+        attributes: Vec<(&str, &str)>,
+        contract: Option<&str>,
+    ) -> Event {
+        Event::Abci {
+            event_type: event_type.to_string(),
+            attributes: attributes
+                .into_iter()
+                .chain(
+                    contract
+                        .into_iter()
+                        .map(|contract| ("_contract_address", contract)),
+                )
+                .map(|(key, value)| {
+                    (
+                        key.to_string(),
+                        serde_json::from_str(value)
+                            .unwrap_or_else(|_| serde_json::Value::String(value.to_string())),
+                    )
+                })
+                .collect(),
+        }
     }
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -128,7 +128,7 @@ fn is_valid_contract_address(contract: &str) -> bool {
 fn filter_event_with(
     filters: Vec<ampd_proto::EventFilter>,
     include_block_begin_end: bool,
-) -> impl FnMut(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
+) -> impl Fn(&error_stack::Result<events::Event, event_sub::Error>) -> bool {
     move |event| match event {
         Ok(event) => {
             let contract = event.contract_address();

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -6,37 +6,33 @@ use ampd_proto::{
     ContractsResponse, QueryRequest, QueryResponse, SubscribeRequest, SubscribeResponse,
 };
 use async_trait::async_trait;
-use futures::{Stream, TryStreamExt};
+use futures::{FutureExt, Stream, TryStreamExt};
 use report::LoggableError;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
 use tracing::error;
+use typed_builder::TypedBuilder;
 use valuable::Valuable;
 
 use super::error::ErrorExt;
-use crate::event_sub;
-use crate::grpc::event_filters;
+use super::reqs;
+use crate::{broadcaster_v2, cosmos, event_sub};
 
-pub struct Service<E>
+#[derive(TypedBuilder)]
+pub struct Service<E, C>
 where
     E: event_sub::EventSub,
+    C: cosmos::CosmosClient,
 {
     event_sub: E,
-}
-
-impl<E> Service<E>
-where
-    E: event_sub::EventSub,
-{
-    pub fn new(event_sub: E) -> Self {
-        Self { event_sub }
-    }
+    msg_queue_client: broadcaster_v2::MsgQueueClient<C>,
 }
 
 #[async_trait]
-impl<E> BlockchainService for Service<E>
+impl<E, C> BlockchainService for Service<E, C>
 where
     E: event_sub::EventSub + Send + Sync + 'static,
+    C: cosmos::CosmosClient + Clone + Send + Sync + 'static,
 {
     type SubscribeStream = Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send>>;
 
@@ -44,17 +40,11 @@ where
         &self,
         req: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        let SubscribeRequest {
-            filters,
-            include_block_begin_end,
-        } = req.into_inner();
-
-        let filters: event_filters::EventFilters = (filters, include_block_begin_end)
-            .try_into()
+        let filters = reqs::validate_subscribe(req)
             .inspect_err(|err| {
                 error!(
                     err = LoggableError::from(err).as_value(),
-                    "invalid event filters provided for event subscription"
+                    "invalid subscribe request"
                 );
             })
             .map_err(ErrorExt::into_status)?;
@@ -67,7 +57,7 @@ where
                     Err(_) => true,
                 })
                 .map_ok(Into::into)
-                .map_ok(|event| ampd_proto::SubscribeResponse { event: Some(event) })
+                .map_ok(|event| SubscribeResponse { event: Some(event) })
                 .inspect_err(|err| {
                     error!(
                         err = LoggableError::from(err).as_value(),
@@ -80,9 +70,37 @@ where
 
     async fn broadcast(
         &self,
-        _req: Request<BroadcastRequest>,
+        req: Request<BroadcastRequest>,
     ) -> Result<Response<BroadcastResponse>, Status> {
-        todo!("implement broadcast method")
+        let msg = reqs::validate_broadcast(req)
+            .inspect_err(|err| {
+                error!(
+                    err = LoggableError::from(err).as_value(),
+                    "invalid broadcast request"
+                );
+            })
+            .map_err(ErrorExt::into_status)?;
+
+        self.msg_queue_client
+            .clone()
+            .enqueue(msg)
+            .map(|rx| async {
+                match rx {
+                    Ok(rx) => rx.await,
+                    Err(err) => Err(err),
+                }
+            })
+            .await
+            .await
+            .map(|(tx_hash, index)| BroadcastResponse { tx_hash, index })
+            .map(Response::new)
+            .inspect_err(|err| {
+                error!(
+                    err = LoggableError::from(err).as_value(),
+                    "message broadcast error"
+                );
+            })
+            .map_err(ErrorExt::into_status)
     }
 
     async fn query(&self, _req: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
@@ -106,17 +124,73 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axelar_wasm_std::nonempty;
+    use cosmrs::bank::MsgSend;
+    use cosmrs::proto::cosmos::auth::v1beta1::{BaseAccount, QueryAccountResponse};
+    use cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo;
+    use cosmrs::proto::cosmos::tx::v1beta1::SimulateResponse;
+    use cosmrs::tx::Msg;
+    use cosmrs::{AccountId, Any, Gas};
     use error_stack::report;
     use events::{self, Event};
+    use futures::future::join_all;
     use futures::{stream, StreamExt};
     use report::ErrorExt;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::{Code, Request};
 
     use super::*;
+    use crate::cosmos::MockCosmosClient;
     use crate::event_sub::{self, MockEventSub};
-    use crate::types::TMAddress;
+    use crate::types::{random_cosmos_public_key, TMAddress};
     use crate::PREFIX;
+
+    const GAS_CAP: Gas = 10000;
+
+    async fn setup(
+        mock_event_sub: MockEventSub,
+        mut mock_cosmos_client: MockCosmosClient,
+    ) -> (
+        Service<MockEventSub, MockCosmosClient>,
+        impl Stream<Item = nonempty::Vec<broadcaster_v2::QueueMsg>>,
+    ) {
+        mock_cosmos_client.expect_account().return_once(|_| {
+            Ok(QueryAccountResponse {
+                account: Some(
+                    Any::from_msg(&BaseAccount {
+                        address: TMAddress::random(PREFIX).to_string(),
+                        pub_key: None,
+                        account_number: 42,
+                        sequence: 10,
+                    })
+                    .unwrap(),
+                ),
+            })
+        });
+
+        let broadcaster = broadcaster_v2::Broadcaster::new(
+            mock_cosmos_client,
+            "chain_id".try_into().unwrap(),
+            random_cosmos_public_key(),
+        )
+        .await
+        .unwrap();
+        let (msg_queue, msg_queue_client) = broadcaster_v2::MsgQueue::new_msg_queue_and_client(
+            broadcaster,
+            100,
+            GAS_CAP,
+            Duration::from_secs(1),
+        );
+        let service = Service::builder()
+            .event_sub(mock_event_sub)
+            .msg_queue_client(msg_queue_client)
+            .build();
+
+        (service, msg_queue)
+    }
 
     #[tokio::test]
     async fn subscribe_should_stream_events_successfully() {
@@ -132,7 +206,7 @@ mod tests {
             .expect_subscribe()
             .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![], true))
             .await
@@ -148,9 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_should_return_error_if_any_filter_is_invalid() {
-        let mock_event_sub = MockEventSub::new();
-
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(MockEventSub::new(), MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter::default()],
@@ -158,6 +230,7 @@ mod tests {
             ))
             .await;
         assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -177,7 +250,7 @@ mod tests {
             tokio_stream::once(Err(report!(event_sub::Error::LatestBlockQuery))).boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -205,7 +278,7 @@ mod tests {
             .boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -233,7 +306,7 @@ mod tests {
             .boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -258,7 +331,7 @@ mod tests {
             tokio_stream::once(Err(BroadcastStreamRecvError::Lagged(10).into_report())).boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -294,7 +367,7 @@ mod tests {
             r#type: "event_type_2".to_string(),
             ..Default::default()
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter], false))
             .await
@@ -332,7 +405,7 @@ mod tests {
             r#type: "test_event".to_string(),
             contract: expected.contract_address().unwrap().to_string(),
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter], false))
             .await
@@ -358,7 +431,7 @@ mod tests {
             .expect_subscribe()
             .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![], false))
             .await
@@ -408,7 +481,7 @@ mod tests {
             contract: expected[1].contract_address().unwrap().to_string(),
             ..Default::default()
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter_1, filter_2], false))
             .await
@@ -422,6 +495,120 @@ mod tests {
         assert!(event_stream.next().await.is_none());
     }
 
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_req_is_invalid() {
+        let (service, _) = setup(MockEventSub::new(), MockCosmosClient::new()).await;
+        let res = service.broadcast(broadcast_req(None)).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_enqueue_failed() {
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client.expect_clone().return_once(|| {
+            let mut mock_cosmos_client = MockCosmosClient::new();
+            mock_cosmos_client
+                .expect_simulate()
+                .return_once(|_| Err(Status::internal("simulate error").into_report()));
+
+            mock_cosmos_client
+        });
+
+        let (service, _) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        let res = service.broadcast(broadcast_req(Some(dummy_msg()))).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_broadcast_failed() {
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client.expect_clone().return_once(|| {
+            let mut mock_cosmos_client = MockCosmosClient::new();
+            mock_cosmos_client.expect_simulate().return_once(|_| {
+                Ok(SimulateResponse {
+                    gas_info: Some(GasInfo {
+                        gas_wanted: GAS_CAP + 1,
+                        gas_used: GAS_CAP + 1,
+                    }),
+                    result: None,
+                })
+            });
+
+            mock_cosmos_client
+        });
+
+        let (service, mut msg_queue) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        tokio::spawn(async move { while msg_queue.next().await.is_some() {} });
+        let res = service.broadcast(broadcast_req(Some(dummy_msg()))).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_tx_hash_and_index() {
+        let tx_hash = "0x7cedbb3799cd99636045c84c5c55aef8a138f107ac8ba53a08cad1070ba4385b";
+        let msg_count = 10;
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client
+            .expect_clone()
+            .times(msg_count)
+            .returning(move || {
+                let mut mock_cosmos_client = MockCosmosClient::new();
+                mock_cosmos_client.expect_simulate().return_once(move |_| {
+                    Ok(SimulateResponse {
+                        gas_info: Some(GasInfo {
+                            gas_wanted: GAS_CAP / msg_count as u64,
+                            gas_used: GAS_CAP / msg_count as u64,
+                        }),
+                        result: None,
+                    })
+                });
+
+                mock_cosmos_client
+            });
+
+        let (service, mut msg_queue) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        let service = Arc::new(service);
+        let handles = join_all(
+            (0..msg_count)
+                .map(|_| {
+                    let service = service.clone();
+
+                    tokio::spawn(async move {
+                        let res = service
+                            .broadcast(broadcast_req(Some(dummy_msg())))
+                            .await
+                            .unwrap()
+                            .into_inner();
+
+                        (res.tx_hash, res.index)
+                    })
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let msgs: Vec<_> = msg_queue.next().await.unwrap().into();
+        assert_eq!(msgs.len(), msg_count);
+        for (i, msg) in msgs.into_iter().enumerate() {
+            assert_eq!(msg.gas, GAS_CAP / msg_count as u64);
+            msg.tx_res_callback
+                .send(Ok((tx_hash.to_string(), i as u64)))
+                .unwrap();
+        }
+
+        let mut results = handles.await;
+        results.sort_by(|result_a, result_b| {
+            let result_a = result_a.as_ref().unwrap();
+            let result_b = result_b.as_ref().unwrap();
+
+            result_a.1.cmp(&result_b.1)
+        });
+        for (i, result) in results.into_iter().enumerate() {
+            let (tx_hash, index) = result.unwrap();
+            assert_eq!(tx_hash, tx_hash.to_string());
+            assert_eq!(index, i as u64);
+        }
+    }
+
     fn subscribe_req(
         filters: Vec<ampd_proto::EventFilter>,
         include_block_begin_end: bool,
@@ -430,6 +617,10 @@ mod tests {
             filters,
             include_block_begin_end,
         })
+    }
+
+    fn broadcast_req(msg: Option<Any>) -> Request<BroadcastRequest> {
+        Request::new(BroadcastRequest { msg })
     }
 
     fn block_begin_event(height: u64) -> Event {
@@ -463,5 +654,15 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    fn dummy_msg() -> Any {
+        MsgSend {
+            from_address: AccountId::new("", &[1, 2, 3]).unwrap(),
+            to_address: AccountId::new("", &[4, 5, 6]).unwrap(),
+            amount: vec![],
+        }
+        .to_any()
+        .unwrap()
     }
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -38,8 +38,7 @@ impl<E> BlockchainService for Service<E>
 where
     E: event_sub::EventSub + Send + Sync + 'static,
 {
-    type SubscribeStream =
-        Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send + 'static>>;
+    type SubscribeStream = Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send>>;
 
     async fn subscribe(
         &self,

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -77,6 +77,7 @@ impl From<&event_sub::Error> for Error {
 
 #[cfg(test)]
 mod tests {
+    use error_stack::report;
     use tendermint::block::Height;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::Code;
@@ -104,19 +105,19 @@ mod tests {
             Code::Unavailable
         );
         assert_eq!(
-            event_sub::Error::BlockResultsQuery {
+            report!(event_sub::Error::BlockResultsQuery {
                 block: Height::default()
-            }
+            })
             .into_status()
             .code(),
             Code::Unavailable
         );
         assert_eq!(
-            event_sub::Error::EventDecoding {
+            (&report!(event_sub::Error::EventDecoding {
                 block: Height::default()
-            }
-            .into_status()
-            .code(),
+            }))
+                .into_status()
+                .code(),
             Code::Internal
         );
         assert_eq!(

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -1,0 +1,129 @@
+use error_stack::Report;
+use tonic::Status;
+
+use super::event_filters;
+use crate::event_sub;
+
+pub trait ErrorExt {
+    fn into_status(self) -> Status;
+}
+
+struct Error(Status);
+
+impl<Err> ErrorExt for Err
+where
+    Err: Into<Error>,
+{
+    fn into_status(self) -> Status {
+        self.into().0
+    }
+}
+
+impl<'a, Err> ErrorExt for &Report<Err>
+where
+    Error: From<&'a Err>,
+    Err: Send + Sync + 'static,
+    Self: 'a,
+{
+    fn into_status(self) -> Status {
+        self.current_context().into_status()
+    }
+}
+
+impl<Err> ErrorExt for Report<Err>
+where
+    for<'a> Error: From<&'a Err>,
+    Err: Send + Sync + 'static,
+{
+    fn into_status(self) -> Status {
+        (&self).into_status()
+    }
+}
+
+impl From<Status> for Error {
+    fn from(status: Status) -> Self {
+        Self(status)
+    }
+}
+
+impl From<&event_filters::Error> for Error {
+    fn from(err: &event_filters::Error) -> Self {
+        match err {
+            event_filters::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            event_filters::Error::InvalidContractAddress(contract) => Status::invalid_argument(
+                format!("invalid contract address {} provided in filters", contract),
+            ),
+        }
+        .into()
+    }
+}
+
+impl From<&event_sub::Error> for Error {
+    fn from(err: &event_sub::Error) -> Self {
+        match err {
+            event_sub::Error::LatestBlockQuery | event_sub::Error::BlockResultsQuery { .. } => {
+                Status::unavailable("blockchain service is temporarily unavailable")
+            }
+            event_sub::Error::EventDecoding { .. } => {
+                Status::internal("server encountered an error processing blockchain events")
+            }
+            event_sub::Error::BroadcastStreamRecv(_) => {
+                Status::data_loss("events have been missed due to client lag")
+            }
+        }
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tendermint::block::Height;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    use tonic::Code;
+
+    use super::*;
+
+    #[test]
+    fn event_filters_errors_to_status() {
+        assert_eq!(
+            event_filters::Error::EmptyFilter.into_status().code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            event_filters::Error::InvalidContractAddress("invalid_contract_address".to_string())
+                .into_status()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn event_sub_errors_to_status() {
+        assert_eq!(
+            event_sub::Error::LatestBlockQuery.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            event_sub::Error::BlockResultsQuery {
+                block: Height::default()
+            }
+            .into_status()
+            .code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            event_sub::Error::EventDecoding {
+                block: Height::default()
+            }
+            .into_status()
+            .code(),
+            Code::Internal
+        );
+        assert_eq!(
+            event_sub::Error::BroadcastStreamRecv(BroadcastStreamRecvError::Lagged(10))
+                .into_status()
+                .code(),
+            Code::DataLoss
+        );
+    }
+}

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -1,8 +1,8 @@
 use error_stack::Report;
 use tonic::Status;
 
-use super::event_filters;
-use crate::event_sub;
+use super::reqs;
+use crate::{broadcaster_v2, event_sub};
 
 pub trait ErrorExt {
     fn into_status(self) -> Status;
@@ -46,13 +46,17 @@ impl From<Status> for Error {
     }
 }
 
-impl From<&event_filters::Error> for Error {
-    fn from(err: &event_filters::Error) -> Self {
+impl From<&reqs::Error> for Error {
+    fn from(err: &reqs::Error) -> Self {
         match err {
-            event_filters::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
-            event_filters::Error::InvalidContractAddress(contract) => Status::invalid_argument(
-                format!("invalid contract address {} provided in filters", contract),
-            ),
+            reqs::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            reqs::Error::InvalidContractAddress(contract) => Status::invalid_argument(format!(
+                "invalid contract address {} provided in filters",
+                contract
+            )),
+            reqs::Error::EmptyBroadcastMsg => {
+                Status::invalid_argument("empty broadcast message provided")
+            }
         }
         .into()
     }
@@ -75,10 +79,34 @@ impl From<&event_sub::Error> for Error {
     }
 }
 
+impl From<&broadcaster_v2::Error> for Error {
+    fn from(err: &broadcaster_v2::Error) -> Self {
+        match err {
+            broadcaster_v2::Error::EstimateGas | broadcaster_v2::Error::GasExceedsGasCap { .. } => {
+                Status::invalid_argument("failed to estimate gas or gas exceeds gas cap")
+            }
+            broadcaster_v2::Error::AccountQuery | broadcaster_v2::Error::BroadcastTx => {
+                Status::unavailable("blockchain service is temporarily unavailable")
+            }
+            broadcaster_v2::Error::SignTx => {
+                Status::unavailable("signing service is temporarily unavailable")
+            }
+            broadcaster_v2::Error::EnqueueMsg
+            | broadcaster_v2::Error::FeeAdjustment
+            | broadcaster_v2::Error::InvalidPubKey
+            | broadcaster_v2::Error::ReceiveTxResult(_) => {
+                Status::internal("server encountered an error processing request")
+            }
+        }
+        .into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use error_stack::report;
     use tendermint::block::Height;
+    use tokio::sync::oneshot;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::Code;
 
@@ -87,11 +115,11 @@ mod tests {
     #[test]
     fn event_filters_errors_to_status() {
         assert_eq!(
-            event_filters::Error::EmptyFilter.into_status().code(),
+            reqs::Error::EmptyFilter.into_status().code(),
             Code::InvalidArgument
         );
         assert_eq!(
-            event_filters::Error::InvalidContractAddress("invalid_contract_address".to_string())
+            reqs::Error::InvalidContractAddress("invalid_contract_address".to_string())
                 .into_status()
                 .code(),
             Code::InvalidArgument
@@ -125,6 +153,55 @@ mod tests {
                 .into_status()
                 .code(),
             Code::DataLoss
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcaster_v2_errors_to_status() {
+        assert_eq!(
+            broadcaster_v2::Error::EstimateGas.into_status().code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            broadcaster_v2::Error::GasExceedsGasCap {
+                msg_type: "test_message".to_string(),
+                gas: 1000000,
+                gas_cap: 500000
+            }
+            .into_status()
+            .code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            broadcaster_v2::Error::AccountQuery.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::BroadcastTx.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::SignTx.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::EnqueueMsg.into_status().code(),
+            Code::Internal
+        );
+        assert_eq!(
+            broadcaster_v2::Error::FeeAdjustment.into_status().code(),
+            Code::Internal
+        );
+        assert_eq!(
+            broadcaster_v2::Error::InvalidPubKey.into_status().code(),
+            Code::Internal
+        );
+        let (_, rx) = oneshot::channel::<u32>();
+        assert_eq!(
+            broadcaster_v2::Error::ReceiveTxResult(rx.await.unwrap_err())
+                .into_status()
+                .code(),
+            Code::Internal
         );
     }
 }

--- a/ampd/src/grpc/event_filters.rs
+++ b/ampd/src/grpc/event_filters.rs
@@ -1,0 +1,380 @@
+use std::str::FromStr;
+
+use axelar_wasm_std::nonempty;
+use cosmrs::AccountId;
+use error_stack::{report, Report, Result};
+use report::ResultCompatExt;
+use thiserror::Error;
+use tonic::Status;
+
+use crate::types::TMAddress;
+use crate::{event_sub, PREFIX};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("empty filter")]
+    EmptyFilter,
+    #[error("invalid contract address in filter")]
+    InvalidContractAddress(String),
+}
+
+impl From<&Error> for Status {
+    fn from(error: &Error) -> Self {
+        match error {
+            Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            Error::InvalidContractAddress(contract) => Status::invalid_argument(format!(
+                "invalid contract address {} provided in filters",
+                contract
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EventFilter {
+    event_type: Option<nonempty::String>,
+    contract: Option<TMAddress>,
+}
+
+impl TryFrom<ampd_proto::EventFilter> for EventFilter {
+    type Error = Report<Error>;
+
+    fn try_from(event_filter: ampd_proto::EventFilter) -> Result<Self, Error> {
+        let event_type = event_filter.r#type.try_into().ok();
+        let contract = if event_filter.contract.is_empty() {
+            None
+        } else {
+            let contract = AccountId::from_str(&event_filter.contract)
+                .change_context(Error::InvalidContractAddress(event_filter.contract.clone()))
+                .and_then(|contract| {
+                    if contract.prefix() != PREFIX {
+                        return Err(report!(Error::InvalidContractAddress(
+                            event_filter.contract
+                        )));
+                    }
+
+                    Ok(contract)
+                })
+                .map(Into::into)?;
+
+            Some(contract)
+        };
+
+        if event_type.is_none() && contract.is_none() {
+            return Err(report!(Error::EmptyFilter));
+        }
+
+        Ok(EventFilter {
+            event_type,
+            contract,
+        })
+    }
+}
+
+impl EventFilter {
+    pub fn filter(&self, event_type: &str, contract: &Option<TMAddress>) -> bool {
+        if self
+            .event_type
+            .as_ref()
+            .is_some_and(|filter| *filter != event_type)
+        {
+            return false;
+        }
+
+        if self.contract.is_some() && self.contract != *contract {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct EventFilters {
+    filters: Vec<EventFilter>,
+    include_block_begin_end: bool,
+}
+
+impl EventFilters {
+    pub fn filter(&self, event: &Result<events::Event, event_sub::Error>) -> bool {
+        match event {
+            Ok(event) => {
+                let contract = event.contract_address();
+
+                match event {
+                    events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
+                        self.include_block_begin_end
+                    }
+                    events::Event::Abci { event_type, .. } => {
+                        self.filter_abci_event(event_type, contract)
+                    }
+                }
+            }
+            Err(_) => true,
+        }
+    }
+
+    fn filter_abci_event<T>(&self, event_type: &str, contract: Option<T>) -> bool
+    where
+        T: Into<TMAddress>,
+    {
+        if self.filters.is_empty() {
+            return true;
+        }
+
+        let contract = contract.map(Into::into);
+
+        self.filters
+            .iter()
+            .any(|filter| filter.filter(event_type, &contract))
+    }
+}
+
+impl TryFrom<(Vec<ampd_proto::EventFilter>, bool)> for EventFilters {
+    type Error = Report<Error>;
+
+    fn try_from(
+        (event_filters, include_block_begin_end): (Vec<ampd_proto::EventFilter>, bool),
+    ) -> Result<Self, Error> {
+        Ok(EventFilters {
+            filters: event_filters
+                .into_iter()
+                .map(EventFilter::try_from)
+                .collect::<Result<_, _>>()?,
+            include_block_begin_end,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use axelar_wasm_std::assert_err_contains;
+    use error_stack::report;
+    use events::Event;
+    use serde_json::{Map, Value};
+
+    use super::*;
+    use crate::types::TMAddress;
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_event_filter() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.event_type.is_some());
+        assert!(filter.contract.is_none());
+    }
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_contract_address() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.event_type.is_none());
+        assert_eq!(filter.contract.as_ref(), Some(&address));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_empty_filter() {
+        let proto_filter = ampd_proto::EventFilter::default();
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::EmptyFilter);
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_invalid_contract_address() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: "invalid_address".to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_contract_with_wrong_prefix() {
+        let address = TMAddress::random("wrong");
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_event_type() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.filter("test_event", &None));
+        assert!(!filter.filter("other_event", &None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("any_event", &Some(address.clone())));
+        assert!(!filter.filter("any_event", &Some(TMAddress::random(PREFIX))));
+        assert!(!filter.filter("any_event", &None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_both_event_type_and_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("test_event", &Some(address.clone())));
+        assert!(!filter.filter("other_event", &Some(address.clone())));
+        assert!(!filter.filter("test_event", &Some(TMAddress::random(PREFIX))));
+    }
+
+    #[test]
+    fn event_filters_should_be_created_from_valid_proto_filters() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, true)).unwrap();
+        assert_eq!(filters.filters.len(), 1);
+        assert!(filters.include_block_begin_end);
+    }
+
+    #[test]
+    fn event_filters_should_fail_if_any_filter_is_invalid() {
+        let proto_filters = vec![
+            ampd_proto::EventFilter {
+                r#type: "test_event".to_string(),
+                contract: "".to_string(),
+            },
+            ampd_proto::EventFilter::default(),
+        ];
+
+        let result = EventFilters::try_from((proto_filters, true));
+        assert_err_contains!(result, Error, Error::EmptyFilter);
+    }
+
+    #[test]
+    fn event_filters_should_include_block_events_when_configured() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, true)).unwrap();
+        assert!(filters.filter(&Ok(Event::BlockBegin(100u32.into()))));
+        assert!(filters.filter(&Ok(Event::BlockEnd(100u32.into()))));
+    }
+
+    #[test]
+    fn event_filters_should_exclude_block_events_when_configured() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(!filters.filter(&Ok(Event::BlockBegin(100u32.into()))));
+        assert!(!filters.filter(&Ok(Event::BlockEnd(100u32.into()))));
+    }
+
+    #[test]
+    fn event_filters_should_match_abci_events_with_matching_filters() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "test_event".to_string(),
+            attributes: Map::new(),
+        })));
+        assert!(!filters.filter(&Ok(Event::Abci {
+            event_type: "other_event".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_match_any_filter_in_multiple_filters() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filters = vec![
+            ampd_proto::EventFilter {
+                r#type: "event_1".to_string(),
+                contract: "".to_string(),
+            },
+            ampd_proto::EventFilter {
+                r#type: "".to_string(),
+                contract: address.to_string(),
+            },
+        ];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "event_1".to_string(),
+            attributes: Map::new(),
+        })));
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "any_event".to_string(),
+            attributes: iter::once((
+                "_contract_address".to_string(),
+                Value::String(address.to_string()),
+            ))
+            .collect(),
+        })));
+        assert!(!filters.filter(&Ok(Event::Abci {
+            event_type: "event_2".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_allow_all_events_when_no_filters_provided() {
+        let filters = EventFilters::try_from((vec![], true)).unwrap();
+
+        assert!(filters.filter(&Ok(Event::Abci {
+            event_type: "any_event".to_string(),
+            attributes: Map::new(),
+        })));
+    }
+
+    #[test]
+    fn event_filters_should_always_allow_error_events() {
+        let proto_filters = vec![ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        }];
+
+        let filters = EventFilters::try_from((proto_filters, false)).unwrap();
+        assert!(filters.filter(&Err(report!(event_sub::Error::LatestBlockQuery))));
+    }
+}

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -17,6 +17,7 @@ use crate::event_sub::EventSub;
 
 mod blockchain_service;
 mod crypto_service;
+mod event_filters;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -17,6 +17,7 @@ use crate::event_sub::EventSub;
 
 mod blockchain_service;
 mod crypto_service;
+mod error;
 mod event_filters;
 
 #[derive(Error, Debug)]

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -13,6 +13,8 @@ use tonic::transport;
 use tower::layer::util::{Identity, Stack};
 use tower::limit::ConcurrencyLimitLayer;
 
+use crate::event_sub::EventSub;
+
 mod blockchain_service;
 mod crypto_service;
 
@@ -66,7 +68,10 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(config: &Config) -> Self {
+    pub fn new<E>(config: &Config, event_sub: E) -> Self
+    where
+        E: EventSub + Send + Sync + 'static,
+    {
         Self {
             addr: SocketAddr::new(config.ip_addr, config.port),
             // TODO: add TLS and optional public key pinning
@@ -74,7 +79,7 @@ impl Server {
                 .layer(ConcurrencyLimitLayer::new(config.concurrency_limit.into()))
                 .concurrency_limit_per_connection(config.concurrency_limit_per_connection.into())
                 .add_service(BlockchainServiceServer::new(
-                    blockchain_service::Service::new(),
+                    blockchain_service::Service::new(event_sub),
                 ))
                 .add_service(CryptoServiceServer::new(crypto_service::Service::new())),
         }

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -1,8 +1,10 @@
+use std::pin::Pin;
 use std::time::Duration;
 
 use asyncutil::task::{CancellableTask, TaskError, TaskGroup};
 use block_height_monitor::BlockHeightMonitor;
 use broadcaster::Broadcaster;
+use broadcaster_v2::MsgQueue;
 use cosmos::CosmosGrpcClient;
 use error_stack::{FutureExt, Result, ResultExt};
 use event_processor::EventHandler;
@@ -81,13 +83,6 @@ async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
     let tm_client = tendermint_rpc::HttpClient::new(tm_jsonrpc.to_string().as_str())
         .change_context(Error::Connection)
         .attach_printable(tm_jsonrpc.clone())?;
-    let (event_publisher, event_subscriber) =
-        event_sub::EventPublisher::new(tm_client.clone(), event_processor.stream_buffer_size);
-    let grpc_server = grpc::Server::new(&grpc_config, event_subscriber.clone());
-    let cosmos_client = cosmos::CosmosGrpcClient::new(tm_grpc.as_str(), tm_grpc_timeout)
-        .await
-        .change_context(Error::Connection)
-        .attach_printable(tm_grpc.clone())?;
     let multisig_client = MultisigClient::new(
         tofnd_config.party_uid,
         tofnd_config.url.as_str(),
@@ -96,18 +91,43 @@ async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
     .await
     .change_context(Error::Connection)
     .attach_printable(tofnd_config.url)?;
-
     let block_height_monitor = BlockHeightMonitor::connect(tm_client.clone())
         .await
         .change_context(Error::Connection)
         .attach_printable(tm_jsonrpc)?;
-
     let pub_key = multisig_client
         .keygen(&tofnd_config.key_uid, tofnd::Algorithm::Ecdsa)
         .await
         .change_context(Error::Tofnd)?;
     let pub_key = CosmosPublicKey::try_from(pub_key).change_context(Error::Tofnd)?;
-
+    let (event_publisher, event_subscriber) =
+        event_sub::EventPublisher::new(tm_client.clone(), event_processor.stream_buffer_size);
+    let cosmos_client = cosmos::CosmosGrpcClient::new(tm_grpc.as_str(), tm_grpc_timeout)
+        .await
+        .change_context(Error::Connection)
+        .attach_printable(tm_grpc.clone())?;
+    let broadcaster = broadcaster_v2::Broadcaster::new(
+        cosmos_client.clone(),
+        broadcast.chain_id.clone(),
+        pub_key,
+    )
+    .await
+    .unwrap();
+    let (msg_queue, msg_queue_client) = broadcaster_v2::MsgQueue::new_msg_queue_and_client(
+        broadcaster.clone(),
+        broadcast.queue_cap,
+        broadcast.batch_gas_limit,
+        broadcast.broadcast_interval,
+    );
+    let grpc_server = grpc::Server::new(&grpc_config, event_subscriber.clone(), msg_queue_client);
+    let broadcaster_task = broadcaster_v2::BroadcasterTask::builder()
+        .broadcaster(broadcaster)
+        .msg_queue(msg_queue)
+        .signer(multisig_client.clone())
+        .key_id(tofnd_config.key_uid.clone())
+        .gas_adjustment(broadcast.gas_adjustment)
+        .gas_price(broadcast.gas_price.clone())
+        .build();
     let broadcaster = broadcaster::UnvalidatedBasicBroadcaster::builder()
         .address_prefix(PREFIX.to_string())
         .client(cosmos_client.clone())
@@ -150,6 +170,7 @@ async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
         block_height_monitor,
         health_check_server,
         grpc_server,
+        broadcaster_task,
     )
     .configure_handlers(verifier, handlers, event_processor)
     .await
@@ -184,6 +205,11 @@ where
     block_height_monitor: BlockHeightMonitor<tendermint_rpc::HttpClient>,
     health_check_server: health_check::Server,
     grpc_server: grpc::Server,
+    broadcaster_task: broadcaster_v2::BroadcasterTask<
+        cosmos::CosmosGrpcClient,
+        Pin<Box<MsgQueue>>,
+        MultisigClient,
+    >,
 }
 
 impl<T> App<T>
@@ -200,6 +226,11 @@ where
         block_height_monitor: BlockHeightMonitor<tendermint_rpc::HttpClient>,
         health_check_server: health_check::Server,
         grpc_server: grpc::Server,
+        broadcaster_task: broadcaster_v2::BroadcasterTask<
+            cosmos::CosmosGrpcClient,
+            Pin<Box<MsgQueue>>,
+            MultisigClient,
+        >,
     ) -> Self {
         let event_processor = TaskGroup::new("event handler");
 
@@ -213,6 +244,7 @@ where
             block_height_monitor,
             health_check_server,
             grpc_server,
+            broadcaster_task,
         }
     }
 
@@ -573,6 +605,7 @@ where
             block_height_monitor,
             health_check_server,
             grpc_server,
+            broadcaster_task,
             ..
         } = self;
 
@@ -618,6 +651,9 @@ where
             }))
             .add_task(CancellableTask::create(|token| {
                 grpc_server.run(token).change_context(Error::GrpcServer)
+            }))
+            .add_task(CancellableTask::create(|_| {
+                broadcaster_task.run().change_context(Error::Broadcaster)
             }))
             .run(main_token)
             .await

--- a/ampd/src/types/mod.rs
+++ b/ampd/src/types/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::hash::{Hash as StdHash, Hasher};
+use std::str::FromStr;
 
 use cosmrs::AccountId;
 use ethers_core::types::{Address, H256};
@@ -16,6 +17,14 @@ pub type Hash = H256;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TMAddress(AccountId);
+
+impl FromStr for TMAddress {
+    type Err = <AccountId as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        AccountId::from_str(s).map(Self)
+    }
+}
 
 impl StdHash for TMAddress {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -470,7 +470,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
+        assert_eq!(event.message_id, msg_id.to_string().as_str());
         assert_eq!(event.verifier_set, verifier_set);
     }
 
@@ -492,7 +492,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(event.message_id, msg_id.to_string().try_into().unwrap());
+        assert_eq!(event.message_id, msg_id.to_string().as_str());
         assert_eq!(event.verifier_set, verifier_set);
     }
 

--- a/packages/ampd-sdk/src/grpc/client.rs
+++ b/packages/ampd-sdk/src/grpc/client.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::pin::Pin;
 use std::vec;
 
@@ -81,10 +80,9 @@ impl Client for GrpcClient {
         let request = SubscribeRequest {
             filters: filters
                 .into_iter()
-                .map(|filter| ampd_proto::Event {
+                .map(|filter| ampd_proto::EventFilter {
                     r#type: filter.event_type,
-                    contract: String::new(),
-                    attributes: HashMap::new(),
+                    contract: Default::default(),
                 })
                 .collect(),
             include_block_begin_end,

--- a/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_event_index.rs
@@ -116,7 +116,7 @@ mod tests {
             let res = Base58TxDigestAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_digest_as_base58(), tx_digest.try_into().unwrap(),);
+            assert_eq!(parsed.tx_digest_as_base58(), tx_digest.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/base_58_solana_event_index.rs
@@ -123,7 +123,7 @@ mod tests {
             let res = Base58SolanaTxSignatureAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.signature_as_base58(), tx_digest.try_into().unwrap());
+            assert_eq!(parsed.signature_as_base58(), tx_digest.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/starknet_field_element_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/starknet_field_element_event_index.rs
@@ -134,7 +134,7 @@ mod tests {
             let res = FieldElementAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.try_into().unwrap(),);
+            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.as_str(),);
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
@@ -111,7 +111,7 @@ mod tests {
 
             let res = HexTxHash::from_str(&msg_id);
             let parsed = res.unwrap();
-            assert_eq!(parsed.tx_hash_as_hex(), msg_id.clone().try_into().unwrap());
+            assert_eq!(parsed.tx_hash_as_hex(), msg_id.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash_event_index.rs
@@ -127,7 +127,7 @@ mod tests {
             let res = HexTxHashAndEventIndex::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(parsed.event_index, event_index);
-            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.try_into().unwrap(),);
+            assert_eq!(parsed.tx_hash_as_hex(), tx_hash.as_str());
             assert_eq!(parsed.to_string(), msg_id);
         }
     }

--- a/packages/axelar-wasm-std/src/nonempty/string.rs
+++ b/packages/axelar-wasm-std/src/nonempty/string.rs
@@ -13,6 +13,12 @@ use crate::nonempty::Error;
 #[derive(Eq, Hash, Valuable, IntoInner)]
 pub struct String(std::string::String);
 
+impl PartialEq<&str> for String {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
 impl TryFrom<std::string::String> for String {
     type Error = Error;
 

--- a/packages/axelar-wasm-std/src/nonempty/string.rs
+++ b/packages/axelar-wasm-std/src/nonempty/string.rs
@@ -13,6 +13,12 @@ use crate::nonempty::Error;
 #[derive(Eq, Hash, Valuable, IntoInner)]
 pub struct String(std::string::String);
 
+impl PartialEq<&str> for &String {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
 impl PartialEq<&str> for String {
     fn eq(&self, other: &&str) -> bool {
         self.0 == *other

--- a/packages/events/src/event.rs
+++ b/packages/events/src/event.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::Display;
 
 use axelar_wasm_std::FnExt;
@@ -11,6 +11,8 @@ use tendermint::{abci, block};
 
 use crate::errors::DecodingError;
 use crate::Error;
+
+const KEY_CONTRACT_ADDRESS: &str = "_contract_address";
 
 pub struct AbciEventTypeFilter {
     pub event_type: String,
@@ -70,7 +72,7 @@ impl Event {
                 event_type: _,
                 attributes,
             } => attributes
-                .get("_contract_address")
+                .get(KEY_CONTRACT_ADDRESS)
                 .and_then(|address| serde_json::from_value::<AccountId>(address.clone()).ok()),
             _ => None,
         }
@@ -120,6 +122,39 @@ fn base64_to_utf8(base64_str: &str) -> std::result::Result<String, DecodingError
     Ok(STANDARD.decode(base64_str)?.then(String::from_utf8)?)
 }
 
+impl From<Event> for ampd_proto::subscribe_response::Event {
+    fn from(event: Event) -> Self {
+        let contract = event.contract_address();
+
+        match event {
+            Event::BlockBegin(height) => {
+                ampd_proto::subscribe_response::Event::BlockBegin(ampd_proto::EventBlockBegin {
+                    height: height.value(),
+                })
+            }
+            Event::BlockEnd(height) => {
+                ampd_proto::subscribe_response::Event::BlockEnd(ampd_proto::EventBlockEnd {
+                    height: height.value(),
+                })
+            }
+            Event::Abci {
+                event_type,
+                attributes,
+            } => ampd_proto::subscribe_response::Event::Abci(ampd_proto::Event {
+                r#type: event_type,
+                contract: contract
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(key, value)| (key, value.to_string()))
+                    .collect(),
+            }),
+        }
+    }
+}
+
 impl TryFrom<ampd_proto::subscribe_response::Event> for Event {
     type Error = Report<Error>;
 
@@ -141,25 +176,20 @@ impl TryFrom<ampd_proto::subscribe_response::Event> for Event {
             }
             ampd_proto::subscribe_response::Event::Abci(abci) => Ok(Self::Abci {
                 event_type: abci.r#type,
-                attributes: convert_attributes(&abci.attributes),
+                attributes: abci
+                    .attributes
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            serde_json::from_str(&value)
+                                .unwrap_or(serde_json::Value::String(value)),
+                        )
+                    })
+                    .collect(),
             }),
         }
     }
-}
-
-fn convert_attributes(
-    proto_attrs: &HashMap<String, String>,
-) -> serde_json::Map<String, serde_json::Value> {
-    let mut result = serde_json::Map::new();
-
-    for (key, value) in proto_attrs {
-        let json_value = serde_json::from_str(value)
-            .unwrap_or_else(|_| serde_json::Value::String(value.clone()));
-
-        result.insert(key.clone(), json_value);
-    }
-
-    result
 }
 
 #[cfg(test)]
@@ -170,12 +200,13 @@ mod test {
     use cosmrs::AccountId;
     use tendermint::block;
 
+    use super::KEY_CONTRACT_ADDRESS;
     use crate::Event;
 
     fn make_event_with_contract_address(contract_address: &AccountId) -> Event {
         let mut attributes = serde_json::Map::new();
         attributes.insert(
-            "_contract_address".to_string(),
+            KEY_CONTRACT_ADDRESS.to_string(),
             contract_address.to_string().into(),
         );
         Event::Abci {
@@ -271,7 +302,7 @@ mod test {
         attrs.insert("key1".to_string(), "value1".to_string());
         attrs.insert("key2".to_string(), "42".to_string());
         attrs.insert(
-            "_contract_address".to_string(),
+            KEY_CONTRACT_ADDRESS.to_string(),
             contract_address_string.clone(),
         );
 


### PR DESCRIPTION
- **feat(minor-ampd): implement gRPC method subscribe for the blockchain service**
- **remove static trait bound from SubscribeStream**
- **use Fn instead of FnMut**
- **extract event filtering into event_filters.rs**
- **address PR feedback and create error.rs for the grpc mod**
- **improve tests**
- **address feedback**
- **feat(minor-ampd): implement gRPC method broadcast for the blockchain service**

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
