### PR TITLE
feat(minor-ampd): implement gRPC method broadcast for the blockchain service

### DIFF
--- a/ampd/src/broadcaster_v2/broadcaster.rs
+++ b/ampd/src/broadcaster_v2/broadcaster.rs
@@ -99,7 +99,7 @@ where
             .into();
         let account = cosmos::account(&mut client, &address)
             .await
-            .change_context(Error::QueryAccount)?;
+            .change_context(Error::AccountQuery)?;
 
         Ok(Self {
             client,
@@ -184,7 +184,7 @@ where
             .build()
             .sign_with(&self.chain_id, self.acc_number, sign_fn)
             .await
-            .change_context(Error::TxSigning)?;
+            .change_context(Error::SignTx)?;
 
         match cosmos::broadcast(&mut self.client, tx).await {
             Ok(tx_response) => {
@@ -215,7 +215,7 @@ where
 {
     let account = cosmos::account(client, address)
         .await
-        .change_context(Error::QueryAccount)?;
+        .change_context(Error::AccountQuery)?;
     *acc_sequence = account.sequence;
 
     Ok(())
@@ -322,7 +322,7 @@ mod tests {
 
         let result = Broadcaster::new(mock_client, chain_id, pub_key).await;
 
-        assert_err_contains!(result, Error, Error::QueryAccount);
+        assert_err_contains!(result, Error, Error::AccountQuery);
     }
 
     #[tokio::test]
@@ -502,7 +502,7 @@ mod tests {
 
         let result = broadcaster.broadcast(vec![dummy_msg()], fee, sign_fn).await;
 
-        assert_err_contains!(result, Error, Error::TxSigning);
+        assert_err_contains!(result, Error, Error::SignTx);
         assert_eq!(*broadcaster.acc_sequence.read().await, sequence);
     }
 

--- a/ampd/src/broadcaster_v2/msg_queue.rs
+++ b/ampd/src/broadcaster_v2/msg_queue.rs
@@ -100,9 +100,9 @@ where
         &mut self,
         msg: Any,
     ) -> Result<impl Future<Output = Result<(String, u64)>> + Send> {
-        let attachment = json!({ "msg": msg });
+        let attachment = json!({ "msg": &msg });
         let rx = self
-            .enqueue_with_channel(msg.clone())
+            .enqueue_with_channel(msg)
             .await
             .map_err(|err| err.attach_printable(attachment.clone()))?;
 

--- a/ampd/src/broadcaster_v2/msg_queue.rs
+++ b/ampd/src/broadcaster_v2/msg_queue.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use axelar_wasm_std::nonempty;
 use cosmrs::{Any, Gas};
 use error_stack::{report, Report, ResultExt};
-use futures::{FutureExt, Stream};
+use futures::{FutureExt, Stream, TryFutureExt};
 use pin_project_lite::pin_project;
 use report::{ErrorExt, LoggableError};
 use serde_json::json;
@@ -100,13 +100,19 @@ where
         &mut self,
         msg: Any,
     ) -> Result<impl Future<Output = Result<(String, u64)>> + Send> {
-        let rx = self.enqueue_with_channel(msg).await?;
+        let attachment = json!({ "msg": msg });
+        let rx = self
+            .enqueue_with_channel(msg.clone())
+            .await
+            .map_err(|err| err.attach_printable(attachment.clone()))?;
 
-        Ok(rx.map(|result| match result {
-            Ok(Ok(result)) => Ok(result),
-            Ok(Err(err)) => Err(err),
-            Err(err) => Err(err.into_report()),
-        }))
+        Ok(rx
+            .map(|result| match result {
+                Ok(Ok(result)) => Ok(result),
+                Ok(Err(err)) => Err(err),
+                Err(err) => Err(err.into_report()),
+            })
+            .map_err(move |err| err.attach_printable(attachment)))
     }
 
     /// Enqueues a message without waiting for its result
@@ -225,16 +231,13 @@ impl MsgQueue {
         msg_cap: usize,
         gas_cap: Gas,
         duration: time::Duration,
-    ) -> Result<(
-        impl Stream<Item = nonempty::Vec<QueueMsg>>,
-        MsgQueueClient<T>,
-    )>
+    ) -> (Pin<Box<MsgQueue>>, MsgQueueClient<T>)
     where
         T: cosmos::CosmosClient,
     {
         let (tx, rx) = mpsc::channel(msg_cap);
 
-        Ok((
+        (
             Box::pin(MsgQueue {
                 stream: ReceiverStream::new(rx).fuse(),
                 deadline: time::sleep(duration),
@@ -242,7 +245,7 @@ impl MsgQueue {
                 duration,
             }),
             MsgQueueClient { broadcaster, tx },
-        ))
+        )
     }
 }
 
@@ -297,12 +300,10 @@ impl Stream for MsgQueue {
 
 fn handle_queue_error(msg: QueueMsg, err: Error) {
     let QueueMsg {
-        msg,
-        tx_res_callback,
-        ..
+        tx_res_callback, ..
     } = msg;
 
-    let err = report!(err).attach_printable(json!({ "msg": msg }));
+    let err = report!(err);
     warn!(
         error = LoggableError::from(&err).as_value(),
         "message dropped"
@@ -434,8 +435,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())
@@ -492,8 +492,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let actual = msg_queue.next().await.unwrap();
@@ -566,8 +565,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
 
         let handles: Vec<_> = (0..client_count)
             .map(|_| {
@@ -627,8 +625,7 @@ mod tests {
             10,
             1000u64,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         assert_err_contains!(
             msg_queue_client.enqueue_and_forget(dummy_msg()).await,
@@ -675,8 +672,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let _ = msg_queue.next().await;
@@ -722,8 +718,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())
@@ -782,8 +777,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(3),
-        )
-        .unwrap();
+        );
         let handle = tokio::spawn(async move {
             let actual = msg_queue.next().await.unwrap();
             assert_eq!(actual.as_ref().len(), 10);
@@ -849,8 +843,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         let rx = msg_queue_client.enqueue(dummy_msg()).await.unwrap();
         let handle = tokio::spawn(async move {
@@ -904,8 +897,7 @@ mod tests {
             10,
             gas_cap,
             time::Duration::from_secs(1),
-        )
-        .unwrap();
+        );
 
         msg_queue_client
             .enqueue_and_forget(dummy_msg())

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -6,37 +6,33 @@ use ampd_proto::{
     ContractsResponse, QueryRequest, QueryResponse, SubscribeRequest, SubscribeResponse,
 };
 use async_trait::async_trait;
-use futures::{Stream, TryStreamExt};
+use futures::{FutureExt, Stream, TryStreamExt};
 use report::LoggableError;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
 use tracing::error;
+use typed_builder::TypedBuilder;
 use valuable::Valuable;
 
 use super::error::ErrorExt;
-use crate::event_sub;
-use crate::grpc::event_filters;
+use super::reqs;
+use crate::{broadcaster_v2, cosmos, event_sub};
 
-pub struct Service<E>
+#[derive(TypedBuilder)]
+pub struct Service<E, C>
 where
     E: event_sub::EventSub,
+    C: cosmos::CosmosClient,
 {
     event_sub: E,
-}
-
-impl<E> Service<E>
-where
-    E: event_sub::EventSub,
-{
-    pub fn new(event_sub: E) -> Self {
-        Self { event_sub }
-    }
+    msg_queue_client: broadcaster_v2::MsgQueueClient<C>,
 }
 
 #[async_trait]
-impl<E> BlockchainService for Service<E>
+impl<E, C> BlockchainService for Service<E, C>
 where
     E: event_sub::EventSub + Send + Sync + 'static,
+    C: cosmos::CosmosClient + Clone + Send + Sync + 'static,
 {
     type SubscribeStream = Pin<Box<dyn Stream<Item = Result<SubscribeResponse, Status>> + Send>>;
 
@@ -44,17 +40,11 @@ where
         &self,
         req: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
-        let SubscribeRequest {
-            filters,
-            include_block_begin_end,
-        } = req.into_inner();
-
-        let filters: event_filters::EventFilters = (filters, include_block_begin_end)
-            .try_into()
+        let filters = reqs::validate_subscribe(req)
             .inspect_err(|err| {
                 error!(
                     err = LoggableError::from(err).as_value(),
-                    "invalid event filters provided for event subscription"
+                    "invalid subscribe request"
                 );
             })
             .map_err(ErrorExt::into_status)?;
@@ -67,7 +57,7 @@ where
                     Err(_) => true,
                 })
                 .map_ok(Into::into)
-                .map_ok(|event| ampd_proto::SubscribeResponse { event: Some(event) })
+                .map_ok(|event| SubscribeResponse { event: Some(event) })
                 .inspect_err(|err| {
                     error!(
                         err = LoggableError::from(err).as_value(),
@@ -80,9 +70,37 @@ where
 
     async fn broadcast(
         &self,
-        _req: Request<BroadcastRequest>,
+        req: Request<BroadcastRequest>,
     ) -> Result<Response<BroadcastResponse>, Status> {
-        todo!("implement broadcast method")
+        let msg = reqs::validate_broadcast(req)
+            .inspect_err(|err| {
+                error!(
+                    err = LoggableError::from(err).as_value(),
+                    "invalid broadcast request"
+                );
+            })
+            .map_err(ErrorExt::into_status)?;
+
+        self.msg_queue_client
+            .clone()
+            .enqueue(msg)
+            .map(|rx| async {
+                match rx {
+                    Ok(rx) => rx.await,
+                    Err(err) => Err(err),
+                }
+            })
+            .await
+            .await
+            .map(|(tx_hash, index)| BroadcastResponse { tx_hash, index })
+            .map(Response::new)
+            .inspect_err(|err| {
+                error!(
+                    err = LoggableError::from(err).as_value(),
+                    "message broadcast error"
+                );
+            })
+            .map_err(ErrorExt::into_status)
     }
 
     async fn query(&self, _req: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
@@ -106,17 +124,71 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axelar_wasm_std::nonempty;
+    use cosmrs::proto::cosmos::auth::v1beta1::{BaseAccount, QueryAccountResponse};
+    use cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo;
+    use cosmrs::proto::cosmos::tx::v1beta1::SimulateResponse;
+    use cosmrs::{Any, Gas};
     use error_stack::report;
     use events::{self, Event};
+    use futures::future::join_all;
     use futures::{stream, StreamExt};
     use report::ErrorExt;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::{Code, Request};
 
     use super::*;
+    use crate::cosmos::MockCosmosClient;
     use crate::event_sub::{self, MockEventSub};
-    use crate::types::TMAddress;
+    use crate::types::{random_cosmos_public_key, TMAddress};
     use crate::PREFIX;
+
+    const GAS_CAP: Gas = 10000;
+
+    async fn setup(
+        mock_event_sub: MockEventSub,
+        mut mock_cosmos_client: MockCosmosClient,
+    ) -> (
+        Service<MockEventSub, MockCosmosClient>,
+        impl Stream<Item = nonempty::Vec<broadcaster_v2::QueueMsg>>,
+    ) {
+        mock_cosmos_client.expect_account().return_once(|_| {
+            Ok(QueryAccountResponse {
+                account: Some(
+                    Any::from_msg(&BaseAccount {
+                        address: TMAddress::random(PREFIX).to_string(),
+                        pub_key: None,
+                        account_number: 42,
+                        sequence: 10,
+                    })
+                    .unwrap(),
+                ),
+            })
+        });
+
+        let broadcaster = broadcaster_v2::Broadcaster::new(
+            mock_cosmos_client,
+            "chain_id".try_into().unwrap(),
+            random_cosmos_public_key(),
+        )
+        .await
+        .unwrap();
+        let (msg_queue, msg_queue_client) = broadcaster_v2::MsgQueue::new_msg_queue_and_client(
+            broadcaster,
+            100,
+            GAS_CAP,
+            Duration::from_secs(1),
+        );
+        let service = Service::builder()
+            .event_sub(mock_event_sub)
+            .msg_queue_client(msg_queue_client)
+            .build();
+
+        (service, msg_queue)
+    }
 
     #[tokio::test]
     async fn subscribe_should_stream_events_successfully() {
@@ -132,7 +204,7 @@ mod tests {
             .expect_subscribe()
             .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![], true))
             .await
@@ -148,9 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_should_return_error_if_any_filter_is_invalid() {
-        let mock_event_sub = MockEventSub::new();
-
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(MockEventSub::new(), MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter::default()],
@@ -158,6 +228,7 @@ mod tests {
             ))
             .await;
         assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -177,7 +248,7 @@ mod tests {
             tokio_stream::once(Err(report!(event_sub::Error::LatestBlockQuery))).boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -205,7 +276,7 @@ mod tests {
             .boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -233,7 +304,7 @@ mod tests {
             .boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -258,7 +329,7 @@ mod tests {
             tokio_stream::once(Err(BroadcastStreamRecvError::Lagged(10).into_report())).boxed()
         });
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(
                 vec![ampd_proto::EventFilter {
@@ -294,7 +365,7 @@ mod tests {
             r#type: "event_type_2".to_string(),
             ..Default::default()
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter], false))
             .await
@@ -332,7 +403,7 @@ mod tests {
             r#type: "test_event".to_string(),
             contract: expected.contract_address().unwrap().to_string(),
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter], false))
             .await
@@ -358,7 +429,7 @@ mod tests {
             .expect_subscribe()
             .return_once(move || stream::iter(events.into_iter().map(Result::Ok)).boxed());
 
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![], false))
             .await
@@ -408,7 +479,7 @@ mod tests {
             contract: expected[1].contract_address().unwrap().to_string(),
             ..Default::default()
         };
-        let service = Service::new(mock_event_sub);
+        let (service, _) = setup(mock_event_sub, MockCosmosClient::new()).await;
         let res = service
             .subscribe(subscribe_req(vec![filter_1, filter_2], false))
             .await
@@ -422,6 +493,120 @@ mod tests {
         assert!(event_stream.next().await.is_none());
     }
 
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_req_is_invalid() {
+        let (service, _) = setup(MockEventSub::new(), MockCosmosClient::new()).await;
+        let res = service.broadcast(broadcast_req(None)).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_enqueue_failed() {
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client.expect_clone().return_once(|| {
+            let mut mock_cosmos_client = MockCosmosClient::new();
+            mock_cosmos_client
+                .expect_simulate()
+                .return_once(|_| Err(Status::internal("simulate error").into_report()));
+
+            mock_cosmos_client
+        });
+
+        let (service, _) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        let res = service.broadcast(broadcast_req(Some(dummy_msg()))).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_error_if_broadcast_failed() {
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client.expect_clone().return_once(|| {
+            let mut mock_cosmos_client = MockCosmosClient::new();
+            mock_cosmos_client.expect_simulate().return_once(|_| {
+                Ok(SimulateResponse {
+                    gas_info: Some(GasInfo {
+                        gas_wanted: GAS_CAP + 1,
+                        gas_used: GAS_CAP + 1,
+                    }),
+                    result: None,
+                })
+            });
+
+            mock_cosmos_client
+        });
+
+        let (service, mut msg_queue) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        tokio::spawn(async move { while msg_queue.next().await.is_some() {} });
+        let res = service.broadcast(broadcast_req(Some(dummy_msg()))).await;
+        assert!(res.is_err_and(|status| status.code() == Code::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn broadcast_should_return_tx_hash_and_index() {
+        let tx_hash = "0x7cedbb3799cd99636045c84c5c55aef8a138f107ac8ba53a08cad1070ba4385b";
+        let msg_count = 10;
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client
+            .expect_clone()
+            .times(msg_count)
+            .returning(move || {
+                let mut mock_cosmos_client = MockCosmosClient::new();
+                mock_cosmos_client.expect_simulate().return_once(move |_| {
+                    Ok(SimulateResponse {
+                        gas_info: Some(GasInfo {
+                            gas_wanted: GAS_CAP / msg_count as u64,
+                            gas_used: GAS_CAP / msg_count as u64,
+                        }),
+                        result: None,
+                    })
+                });
+
+                mock_cosmos_client
+            });
+
+        let (service, mut msg_queue) = setup(MockEventSub::new(), mock_cosmos_client).await;
+        let service = Arc::new(service);
+        let handles = join_all(
+            (0..msg_count)
+                .map(|_| {
+                    let service = service.clone();
+
+                    tokio::spawn(async move {
+                        let res = service
+                            .broadcast(broadcast_req(Some(dummy_msg())))
+                            .await
+                            .unwrap()
+                            .into_inner();
+
+                        (res.tx_hash, res.index)
+                    })
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let msgs: Vec<_> = msg_queue.next().await.unwrap().into();
+        assert_eq!(msgs.len(), msg_count);
+        for (i, msg) in msgs.into_iter().enumerate() {
+            assert_eq!(msg.gas, GAS_CAP / msg_count as u64);
+            msg.tx_res_callback
+                .send(Ok((tx_hash.to_string(), i as u64)))
+                .unwrap();
+        }
+
+        let mut results = handles.await;
+        results.sort_by(|result_a, result_b| {
+            let result_a = result_a.as_ref().unwrap();
+            let result_b = result_b.as_ref().unwrap();
+
+            result_a.1.cmp(&result_b.1)
+        });
+        for (i, result) in results.into_iter().enumerate() {
+            let (tx_hash, index) = result.unwrap();
+            assert_eq!(tx_hash, tx_hash.to_string());
+            assert_eq!(index, i as u64);
+        }
+    }
+
     fn subscribe_req(
         filters: Vec<ampd_proto::EventFilter>,
         include_block_begin_end: bool,
@@ -430,6 +615,10 @@ mod tests {
             filters,
             include_block_begin_end,
         })
+    }
+
+    fn broadcast_req(msg: Option<Any>) -> Request<BroadcastRequest> {
+        Request::new(BroadcastRequest { msg })
     }
 
     fn block_begin_event(height: u64) -> Event {
@@ -462,6 +651,13 @@ mod tests {
                     )
                 })
                 .collect(),
+        }
+    }
+
+    fn dummy_msg() -> Any {
+        Any {
+            type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
+            value: vec![1, 2, 3, 4],
         }
     }
 }

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -1,8 +1,21 @@
 use error_stack::Report;
+use report::LoggableError;
 use tonic::Status;
+use tracing::error;
+use valuable::Valuable;
 
 use super::reqs;
 use crate::{broadcaster_v2, event_sub};
+
+pub fn log<Err>(msg: &str) -> impl Fn(&Report<Err>) + '_ {
+    move |err| {
+        error!(
+            component = "grpc",
+            err = LoggableError::from(err).as_value(),
+            msg
+        );
+    }
+}
 
 pub trait ErrorExt {
     fn into_status(self) -> Status;

--- a/ampd/src/grpc/error.rs
+++ b/ampd/src/grpc/error.rs
@@ -1,8 +1,8 @@
 use error_stack::Report;
 use tonic::Status;
 
-use super::event_filters;
-use crate::event_sub;
+use super::reqs;
+use crate::{broadcaster_v2, event_sub};
 
 pub trait ErrorExt {
     fn into_status(self) -> Status;
@@ -46,13 +46,17 @@ impl From<Status> for Error {
     }
 }
 
-impl From<&event_filters::Error> for Error {
-    fn from(err: &event_filters::Error) -> Self {
+impl From<&reqs::Error> for Error {
+    fn from(err: &reqs::Error) -> Self {
         match err {
-            event_filters::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
-            event_filters::Error::InvalidContractAddress(contract) => Status::invalid_argument(
-                format!("invalid contract address {} provided in filters", contract),
-            ),
+            reqs::Error::EmptyFilter => Status::invalid_argument("empty filter provided"),
+            reqs::Error::InvalidContractAddress(contract) => Status::invalid_argument(format!(
+                "invalid contract address {} provided in filters",
+                contract
+            )),
+            reqs::Error::EmptyBroadcastMsg => {
+                Status::invalid_argument("empty broadcast message provided")
+            }
         }
         .into()
     }
@@ -75,10 +79,34 @@ impl From<&event_sub::Error> for Error {
     }
 }
 
+impl From<&broadcaster_v2::Error> for Error {
+    fn from(err: &broadcaster_v2::Error) -> Self {
+        match err {
+            broadcaster_v2::Error::EstimateGas | broadcaster_v2::Error::GasExceedsGasCap { .. } => {
+                Status::invalid_argument("failed to estimate gas or gas exceeds gas cap")
+            }
+            broadcaster_v2::Error::AccountQuery | broadcaster_v2::Error::BroadcastTx => {
+                Status::unavailable("blockchain service is temporarily unavailable")
+            }
+            broadcaster_v2::Error::SignTx => {
+                Status::unavailable("signing service is temporarily unavailable")
+            }
+            broadcaster_v2::Error::EnqueueMsg
+            | broadcaster_v2::Error::FeeAdjustment
+            | broadcaster_v2::Error::InvalidPubKey
+            | broadcaster_v2::Error::ReceiveTxResult(_) => {
+                Status::internal("server encountered an error processing request")
+            }
+        }
+        .into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use error_stack::report;
     use tendermint::block::Height;
+    use tokio::sync::oneshot;
     use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tonic::Code;
 
@@ -87,11 +115,11 @@ mod tests {
     #[test]
     fn event_filters_errors_to_status() {
         assert_eq!(
-            event_filters::Error::EmptyFilter.into_status().code(),
+            reqs::Error::EmptyFilter.into_status().code(),
             Code::InvalidArgument
         );
         assert_eq!(
-            event_filters::Error::InvalidContractAddress("invalid_contract_address".to_string())
+            reqs::Error::InvalidContractAddress("invalid_contract_address".to_string())
                 .into_status()
                 .code(),
             Code::InvalidArgument
@@ -125,6 +153,55 @@ mod tests {
                 .into_status()
                 .code(),
             Code::DataLoss
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcaster_v2_errors_to_status() {
+        assert_eq!(
+            broadcaster_v2::Error::EstimateGas.into_status().code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            broadcaster_v2::Error::GasExceedsGasCap {
+                msg_type: "test_message".to_string(),
+                gas: 1000000,
+                gas_cap: 500000
+            }
+            .into_status()
+            .code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            broadcaster_v2::Error::AccountQuery.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::BroadcastTx.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::SignTx.into_status().code(),
+            Code::Unavailable
+        );
+        assert_eq!(
+            broadcaster_v2::Error::EnqueueMsg.into_status().code(),
+            Code::Internal
+        );
+        assert_eq!(
+            broadcaster_v2::Error::FeeAdjustment.into_status().code(),
+            Code::Internal
+        );
+        assert_eq!(
+            broadcaster_v2::Error::InvalidPubKey.into_status().code(),
+            Code::Internal
+        );
+        let (_, rx) = oneshot::channel::<u32>();
+        assert_eq!(
+            broadcaster_v2::Error::ReceiveTxResult(rx.await.unwrap_err())
+                .into_status()
+                .code(),
+            Code::Internal
         );
     }
 }

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -10,15 +10,15 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tonic::transport;
-use tower::layer::util::{Identity, Stack};
 use tower::limit::ConcurrencyLimitLayer;
+use typed_builder::TypedBuilder;
 
-use crate::event_sub::EventSub;
+use crate::{broadcaster_v2, cosmos, event_sub};
 
 mod blockchain_service;
 mod crypto_service;
 mod error;
-mod event_filters;
+mod reqs;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -64,32 +64,31 @@ where
     Ok(config)
 }
 
+#[derive(TypedBuilder)]
 pub struct Server {
-    addr: SocketAddr,
-    router: transport::server::Router<Stack<ConcurrencyLimitLayer, Identity>>,
+    config: Config,
+    event_sub: event_sub::EventSubscriber,
+    msg_queue_client: broadcaster_v2::MsgQueueClient<cosmos::CosmosGrpcClient>,
 }
 
 impl Server {
-    pub fn new<E>(config: &Config, event_sub: E) -> Self
-    where
-        E: EventSub + Send + Sync + 'static,
-    {
-        Self {
-            addr: SocketAddr::new(config.ip_addr, config.port),
-            // TODO: add TLS and optional public key pinning
-            router: transport::Server::builder()
-                .layer(ConcurrencyLimitLayer::new(config.concurrency_limit.into()))
-                .concurrency_limit_per_connection(config.concurrency_limit_per_connection.into())
-                .add_service(BlockchainServiceServer::new(
-                    blockchain_service::Service::new(event_sub),
-                ))
-                .add_service(CryptoServiceServer::new(crypto_service::Service::new())),
-        }
-    }
-
     pub async fn run(self, token: CancellationToken) -> Result<(), Error> {
-        self.router
-            .serve_with_shutdown(self.addr, token.cancelled_owned())
+        let addr = SocketAddr::new(self.config.ip_addr, self.config.port);
+        let router = transport::Server::builder()
+            .layer(ConcurrencyLimitLayer::new(
+                self.config.concurrency_limit.into(),
+            ))
+            .concurrency_limit_per_connection(self.config.concurrency_limit_per_connection.into())
+            .add_service(BlockchainServiceServer::new(
+                blockchain_service::Service::builder()
+                    .event_sub(self.event_sub)
+                    .msg_queue_client(self.msg_queue_client)
+                    .build(),
+            ))
+            .add_service(CryptoServiceServer::new(crypto_service::Service::new()));
+
+        router
+            .serve_with_shutdown(addr, token.cancelled_owned())
             .await
             .map_err(ErrorExt::into_report)
     }


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
