### PR TITLE
refactor: create prover and verifier api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,6 +5047,7 @@ dependencies = [
  "k256",
  "multisig",
  "multisig-prover",
+ "multisig-prover-api",
  "rand 0.8.5",
  "report",
  "rewards",
@@ -6322,6 +6323,7 @@ dependencies = [
  "k256",
  "msgs-derive",
  "multisig",
+ "multisig-prover-api",
  "prost 0.12.6",
  "report",
  "router-api",
@@ -6335,6 +6337,15 @@ dependencies = [
  "sui-gateway",
  "thiserror 1.0.69",
  "voting-verifier",
+]
+
+[[package]]
+name = "multisig-prover-api"
+version = "1.0.0"
+dependencies = [
+ "axelar-wasm-std",
+ "cosmwasm-schema",
+ "multisig",
 ]
 
 [[package]]
@@ -12605,6 +12616,17 @@ dependencies = [
  "sha3 0.10.8",
  "starknet-checked-felt",
  "thiserror 1.0.69",
+ "voting-verifier-api",
+]
+
+[[package]]
+name = "voting-verifier-api"
+version = "1.0.0"
+dependencies = [
+ "axelar-wasm-std",
+ "cosmwasm-schema",
+ "router-api",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ mockall = "0.12.1"
 msgs-derive = { version = "^1.0.0", path = "packages/msgs-derive" }
 multisig = { version = "^2.0.0", path = "contracts/multisig" }
 multisig-prover = { version = "^1.1.1", path = "contracts/multisig-prover" }
+multisig-prover-api = { version = "1.0.0", path = "packages/multisig-prover-api" }
 num-traits = { version = "0.2.14", default-features = false }
 quote = "1.0.38"
 rand = "0.8.5"
@@ -113,6 +114,7 @@ tokio-stream = "0.1.11"
 tokio-util = "0.7.11"
 typed-builder = "0.18.2"
 voting-verifier = { version = "^1.1.0", path = "contracts/voting-verifier" }
+voting-verifier-api = { version = "1.0.0", path = "packages/voting-verifier-api" }
 axelar-core-std = { version = "^1.0.0", path = "packages/axelar-core-std" }
 proc-macro2 = "1.0.92"
 valuable = "0.1.1"

--- a/contracts/multisig-prover/Cargo.toml
+++ b/contracts/multisig-prover/Cargo.toml
@@ -51,6 +51,7 @@ itertools = "0.11.0"
 k256 = { workspace = true }
 msgs-derive = { workspace = true }
 multisig = { workspace = true, features = ["library"] }
+multisig-prover-api = { workspace = true }
 report = { workspace = true }
 router-api = { workspace = true }
 semver = { workspace = true }

--- a/contracts/multisig-prover/src/contract.rs
+++ b/contracts/multisig-prover/src/contract.rs
@@ -128,6 +128,7 @@ mod tests {
     };
     use multisig::msg::Signer;
     use multisig::verifier_set::VerifierSet;
+    use multisig_prover_api::encoding::Encoder;
     use prost::Message;
     use router_api::CrossChainId;
 
@@ -139,7 +140,6 @@ mod tests {
         mock_querier_handler, ADMIN, COORDINATOR_ADDRESS, GATEWAY_ADDRESS, GOVERNANCE,
         MULTISIG_ADDRESS, SERVICE_NAME, SERVICE_REGISTRY_ADDRESS, VOTING_VERIFIER_ADDRESS,
     };
-    use crate::Encoder;
 
     const RELAYER: &str = "relayer";
     const MULTISIG_SESSION_ID: Uint64 = Uint64::one();

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -424,6 +424,7 @@ mod tests {
 
     use axelar_wasm_std::Threshold;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi};
+    use multisig_prover_api::encoding::Encoder;
     use router_api::ChainName;
 
     use super::{different_set_in_progress, next_verifier_set, should_update_verifier_set};
@@ -556,7 +557,7 @@ mod tests {
             service_name: "validators".to_string(),
             chain_name: ChainName::try_from("ethereum".to_owned()).unwrap(),
             verifier_set_diff_threshold: 0,
-            encoder: crate::Encoder::Abi,
+            encoder: Encoder::Abi,
             key_type: multisig::key::KeyType::Ecdsa,
             domain_separator: [0; 32],
         }

--- a/contracts/multisig-prover/src/encoding/mod.rs
+++ b/contracts/multisig-prover/src/encoding/mod.rs
@@ -3,22 +3,14 @@ mod bcs;
 mod stellar_xdr;
 
 use axelar_wasm_std::hash::Hash;
-use cosmwasm_schema::cw_serde;
 use cosmwasm_std::HexBinary;
 use error_stack::Result;
 use multisig::msg::SignerWithSig;
 use multisig::verifier_set::VerifierSet;
+use multisig_prover_api::encoding::Encoder;
 
 use crate::error::ContractError;
 use crate::Payload;
-
-#[cw_serde]
-#[derive(Copy)]
-pub enum Encoder {
-    Abi,
-    Bcs,
-    StellarXdr,
-}
 
 pub trait EncoderExt {
     fn digest(

--- a/contracts/multisig-prover/src/lib.rs
+++ b/contracts/multisig-prover/src/lib.rs
@@ -6,7 +6,6 @@ pub mod msg;
 mod payload;
 mod state;
 
-pub use encoding::Encoder;
 pub use payload::Payload;
 
 #[cfg(test)]

--- a/contracts/multisig-prover/src/msg.rs
+++ b/contracts/multisig-prover/src/msg.rs
@@ -4,58 +4,11 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{HexBinary, Uint64};
 use msgs_derive::EnsurePermissions;
 use multisig::key::KeyType;
+pub use multisig_prover_api::msg::InstantiateMsg;
 use router_api::CrossChainId;
 
 pub use crate::contract::MigrateMsg;
-use crate::{Encoder, Payload};
-
-#[cw_serde]
-pub struct InstantiateMsg {
-    /// Address that can execute all messages that either have unrestricted or admin permission level, such as Updateverifier set.
-    /// Should be set to a trusted address that can react to unexpected interruptions to the contract's operation.
-    pub admin_address: String,
-    /// Address that can call all messages of unrestricted, admin and governance permission level, such as UpdateSigningThreshold.
-    /// This address can execute messages that bypasses verification checks to rescue the contract if it got into an otherwise unrecoverable state due to external forces.
-    /// On mainnet, it should match the address of the Cosmos governance module.
-    pub governance_address: String,
-    /// Address of the gateway on axelar associated with the destination chain. For example, if this prover is creating proofs to
-    /// be relayed to Ethereum, this is the address of the gateway on Axelar for Ethereum.
-    pub gateway_address: String,
-    /// Address of the multisig contract on axelar.
-    pub multisig_address: String,
-    /// Address of the coordinator contract on axelar.
-    pub coordinator_address: String,
-    /// Address of the service registry contract on axelar.
-    pub service_registry_address: String,
-    /// Address of the voting verifier contract on axelar associated with the destination chain. For example, if this prover is creating
-    /// proofs to be relayed to Ethereum, this is the address of the voting verifier for Ethereum.
-    pub voting_verifier_address: String,
-    /// Threshold of weighted signatures required for signing to be considered complete
-    pub signing_threshold: MajorityThreshold,
-    /// Name of service in the service registry for which verifiers are registered.
-    pub service_name: String,
-    /// Name of chain for which this prover contract creates proofs.
-    pub chain_name: String,
-    /// Maximum tolerable difference between currently active verifier set and registered verifier set.
-    /// The verifier set registered in the service registry must be different by more than this number
-    /// of verifiers before calling UpdateVerifierSet. For example, if this is set to 1, UpdateVerifierSet
-    /// will fail unless the registered verifier set and active verifier set differ by more than 1.
-    pub verifier_set_diff_threshold: u32,
-    /// Type of encoding to use for signed payload. Blockchains can encode their execution payloads in various ways (ABI, BCS, etc).
-    /// This defines the specific encoding type to use for this prover, which should correspond to the encoding type used by the gateway
-    /// deployed on the destination chain.
-    pub encoder: Encoder,
-    /// Public key type verifiers use for signing payload. Different blockchains support different cryptographic signature algorithms (ECDSA, Ed25519, etc).
-    /// This defines the specific signature algorithm to use for this prover, which should correspond to the signature algorithm used by the gateway
-    /// deployed on the destination chain. The multisig contract supports multiple public keys per verifier (each a different type of key), and this
-    /// parameter controls which registered public key to use for signing for each verifier registered to the destination chain.
-    pub key_type: KeyType,
-    /// An opaque value created to distinguish distinct chains that the external gateway should be initialized with.
-    /// Value must be a String in hex format without `0x`, e.g. "598ba04d225cec385d1ce3cf3c9a076af803aa5c614bc0e0d176f04ac8d28f55".
-    #[serde(with = "axelar_wasm_std::hex")] // (de)serialization with hex module
-    #[schemars(with = "String")] // necessary attribute in conjunction with #[serde(with ...)]
-    pub domain_separator: Hash,
-}
+use crate::Payload;
 
 #[cw_serde]
 #[derive(EnsurePermissions)]

--- a/contracts/multisig-prover/src/msg.rs
+++ b/contracts/multisig-prover/src/msg.rs
@@ -1,9 +1,7 @@
-use axelar_wasm_std::hash::Hash;
 use axelar_wasm_std::MajorityThreshold;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{HexBinary, Uint64};
 use msgs_derive::EnsurePermissions;
-use multisig::key::KeyType;
 pub use multisig_prover_api::msg::InstantiateMsg;
 use router_api::CrossChainId;
 

--- a/contracts/multisig-prover/src/state.rs
+++ b/contracts/multisig-prover/src/state.rs
@@ -5,9 +5,9 @@ use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use multisig::key::KeyType;
 use multisig::verifier_set::VerifierSet;
+use multisig_prover_api::encoding::Encoder;
 use router_api::ChainName;
 
-use crate::encoding::Encoder;
 use crate::payload::{Payload, PayloadId};
 
 #[cw_serde]

--- a/contracts/voting-verifier/Cargo.toml
+++ b/contracts/voting-verifier/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { workspace = true }
 service-registry = { workspace = true, features = ["library"] }
 service-registry-api = { workspace = true }
 thiserror = { workspace = true }
+voting-verifier-api = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7.7", features = ["getrandom"] }

--- a/contracts/voting-verifier/src/msg.rs
+++ b/contracts/voting-verifier/src/msg.rs
@@ -1,40 +1,12 @@
-use axelar_wasm_std::address::AddressFormat;
-use axelar_wasm_std::msg_id::MessageIdFormat;
 use axelar_wasm_std::voting::{PollId, PollStatus, Vote, WeightedPoll};
 use axelar_wasm_std::{nonempty, MajorityThreshold, VerificationStatus};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use msgs_derive::EnsurePermissions;
 use multisig::verifier_set::VerifierSet;
-use router_api::{ChainName, Message};
+use router_api::Message;
+pub use voting_verifier_api::msg::InstantiateMsg;
 
 pub use crate::contract::MigrateMsg;
-
-#[cw_serde]
-pub struct InstantiateMsg {
-    /// Address that can call all messages of unrestricted governance permission level, like UpdateVotingThreshold.
-    /// It can execute messages that bypasses verification checks to rescue the contract if it got into an otherwise unrecoverable state due to external forces.
-    /// On mainnet it should match the address of the Cosmos governance module.
-    pub governance_address: nonempty::String,
-    /// Service registry contract address on axelar.
-    pub service_registry_address: nonempty::String,
-    /// Name of service in the service registry for which verifiers are registered.
-    pub service_name: nonempty::String,
-    /// Axelar's gateway contract address on the source chain
-    pub source_gateway_address: nonempty::String,
-    /// Threshold of weighted votes required for voting to be considered complete for a particular message
-    pub voting_threshold: MajorityThreshold,
-    /// The number of blocks after which a poll expires
-    pub block_expiry: nonempty::Uint64,
-    /// The number of blocks to wait for on the source chain before considering a transaction final
-    pub confirmation_height: u64,
-    /// Name of the source chain
-    pub source_chain: ChainName,
-    /// Rewards contract address on axelar.
-    pub rewards_address: nonempty::String,
-    /// Format that incoming messages should use for the id field of CrossChainId
-    pub msg_id_format: MessageIdFormat,
-    pub address_format: AddressFormat,
-}
 
 #[cw_serde]
 #[derive(EnsurePermissions)]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -39,6 +39,7 @@ interchain-token-service = { workspace = true }
 k256 = { workspace = true }
 multisig = { workspace = true }
 multisig-prover = { workspace = true }
+multisig-prover-api = { workspace = true }
 rand = { workspace = true }
 report = { workspace = true }
 rewards = { workspace = true }

--- a/integration-tests/src/multisig_prover_contract.rs
+++ b/integration-tests/src/multisig_prover_contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{Addr, DepsMut, Env};
 use cw_multi_test::{ContractWrapper, Executor};
 use multisig::key::KeyType;
 use multisig_prover::contract::{execute, instantiate, query};
-use multisig_prover::Encoder;
+use multisig_prover_api::encoding::Encoder;
 
 use crate::contract::Contract;
 use crate::protocol::{emptying_deps_mut, Protocol};

--- a/packages/multisig-prover-api/Cargo.toml
+++ b/packages/multisig-prover-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "multisig-prover-api"
+version = "1.0.0"
+rust-version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+axelar-wasm-std = { workspace = true, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+multisig = { workspace = true, features = ["library"] }
+
+[lints]
+workspace = true

--- a/packages/multisig-prover-api/src/encoding.rs
+++ b/packages/multisig-prover-api/src/encoding.rs
@@ -1,0 +1,9 @@
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+#[derive(Copy)]
+pub enum Encoder {
+    Abi,
+    Bcs,
+    StellarXdr,
+}

--- a/packages/multisig-prover-api/src/lib.rs
+++ b/packages/multisig-prover-api/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod encoding;
+pub mod msg;

--- a/packages/multisig-prover-api/src/msg.rs
+++ b/packages/multisig-prover-api/src/msg.rs
@@ -1,0 +1,54 @@
+use axelar_wasm_std::hash::Hash;
+use axelar_wasm_std::MajorityThreshold;
+use cosmwasm_schema::cw_serde;
+use multisig::key::KeyType;
+
+use crate::encoding::Encoder;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Address that can execute all messages that either have unrestricted or admin permission level, such as Updateverifier set.
+    /// Should be set to a trusted address that can react to unexpected interruptions to the contract's operation.
+    pub admin_address: String,
+    /// Address that can call all messages of unrestricted, admin and governance permission level, such as UpdateSigningThreshold.
+    /// This address can execute messages that bypasses verification checks to rescue the contract if it got into an otherwise unrecoverable state due to external forces.
+    /// On mainnet, it should match the address of the Cosmos governance module.
+    pub governance_address: String,
+    /// Address of the gateway on axelar associated with the destination chain. For example, if this prover is creating proofs to
+    /// be relayed to Ethereum, this is the address of the gateway on Axelar for Ethereum.
+    pub gateway_address: String,
+    /// Address of the multisig contract on axelar.
+    pub multisig_address: String,
+    /// Address of the coordinator contract on axelar.
+    pub coordinator_address: String,
+    /// Address of the service registry contract on axelar.
+    pub service_registry_address: String,
+    /// Address of the voting verifier contract on axelar associated with the destination chain. For example, if this prover is creating
+    /// proofs to be relayed to Ethereum, this is the address of the voting verifier for Ethereum.
+    pub voting_verifier_address: String,
+    /// Threshold of weighted signatures required for signing to be considered complete
+    pub signing_threshold: MajorityThreshold,
+    /// Name of service in the service registry for which verifiers are registered.
+    pub service_name: String,
+    /// Name of chain for which this prover contract creates proofs.
+    pub chain_name: String,
+    /// Maximum tolerable difference between currently active verifier set and registered verifier set.
+    /// The verifier set registered in the service registry must be different by more than this number
+    /// of verifiers before calling UpdateVerifierSet. For example, if this is set to 1, UpdateVerifierSet
+    /// will fail unless the registered verifier set and active verifier set differ by more than 1.
+    pub verifier_set_diff_threshold: u32,
+    /// Type of encoding to use for signed payload. Blockchains can encode their execution payloads in various ways (ABI, BCS, etc).
+    /// This defines the specific encoding type to use for this prover, which should correspond to the encoding type used by the gateway
+    /// deployed on the destination chain.
+    pub encoder: Encoder,
+    /// Public key type verifiers use for signing payload. Different blockchains support different cryptographic signature algorithms (ECDSA, Ed25519, etc).
+    /// This defines the specific signature algorithm to use for this prover, which should correspond to the signature algorithm used by the gateway
+    /// deployed on the destination chain. The multisig contract supports multiple public keys per verifier (each a different type of key), and this
+    /// parameter controls which registered public key to use for signing for each verifier registered to the destination chain.
+    pub key_type: KeyType,
+    /// An opaque value created to distinguish distinct chains that the external gateway should be initialized with.
+    /// Value must be a String in hex format without `0x`, e.g. "598ba04d225cec385d1ce3cf3c9a076af803aa5c614bc0e0d176f04ac8d28f55".
+    #[serde(with = "axelar_wasm_std::hex")] // (de)serialization with hex module
+    #[schemars(with = "String")] // necessary attribute in conjunction with #[serde(with ...)]
+    pub domain_separator: Hash,
+}

--- a/packages/voting-verifier-api/Cargo.toml
+++ b/packages/voting-verifier-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "voting-verifier-api"
+version = "1.0.0"
+rust-version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+axelar-wasm-std = { workspace = true, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+router-api = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/voting-verifier-api/src/lib.rs
+++ b/packages/voting-verifier-api/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod msg;

--- a/packages/voting-verifier-api/src/msg.rs
+++ b/packages/voting-verifier-api/src/msg.rs
@@ -1,0 +1,32 @@
+use axelar_wasm_std::address::AddressFormat;
+use axelar_wasm_std::msg_id::MessageIdFormat;
+use axelar_wasm_std::{nonempty, MajorityThreshold};
+use cosmwasm_schema::cw_serde;
+use router_api::ChainName;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Address that can call all messages of unrestricted governance permission level, like UpdateVotingThreshold.
+    /// It can execute messages that bypasses verification checks to rescue the contract if it got into an otherwise unrecoverable state due to external forces.
+    /// On mainnet it should match the address of the Cosmos governance module.
+    pub governance_address: nonempty::String,
+    /// Service registry contract address on axelar.
+    pub service_registry_address: nonempty::String,
+    /// Name of service in the service registry for which verifiers are registered.
+    pub service_name: nonempty::String,
+    /// Axelar's gateway contract address on the source chain
+    pub source_gateway_address: nonempty::String,
+    /// Threshold of weighted votes required for voting to be considered complete for a particular message
+    pub voting_threshold: MajorityThreshold,
+    /// The number of blocks after which a poll expires
+    pub block_expiry: nonempty::Uint64,
+    /// The number of blocks to wait for on the source chain before considering a transaction final
+    pub confirmation_height: u64,
+    /// Name of the source chain
+    pub source_chain: ChainName,
+    /// Rewards contract address on axelar.
+    pub rewards_address: nonempty::String,
+    /// Format that incoming messages should use for the id field of CrossChainId
+    pub msg_id_format: MessageIdFormat,
+    pub address_format: AddressFormat,
+}


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
