### PR TITLE
feat(xrpl-ampd): remove XRPLSigningStartedEvent

### DIFF
--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -55,8 +55,8 @@ pub enum Config {
         rpc_timeout: Option<Duration>,
     },
     XRPLMultisigSigner {
-        multisig_prover_contract: TMAddress,
-        multisig_contract: TMAddress,
+        cosmwasm_contract: TMAddress,
+        chain_name: ChainName,
     },
     MvxMsgVerifier {
         cosmwasm_contract: TMAddress,

--- a/ampd/src/handlers/xrpl_multisig.rs
+++ b/ampd/src/handlers/xrpl_multisig.rs
@@ -12,6 +12,8 @@ use events_derive;
 use events_derive::try_from;
 use hex::encode;
 use multisig::msg::ExecuteMsg;
+use multisig::types::MsgToSign;
+use router_api::ChainName;
 use serde::de::Error as DeserializeError;
 use serde::{Deserialize, Deserializer};
 use tokio::sync::watch::Receiver;
@@ -25,13 +27,14 @@ use crate::tofnd::{Algorithm, MessageDigest};
 use crate::types::{PublicKey, TMAddress};
 
 #[derive(Debug, Deserialize)]
-#[try_from("wasm-xrpl_signing_started")]
-struct XRPLSigningStartedEvent {
+#[try_from("wasm-signing_started")]
+struct SigningStartedEvent {
     session_id: u64,
     #[serde(deserialize_with = "deserialize_public_keys")]
     pub_keys: HashMap<TMAddress, PublicKey>,
-    unsigned_tx: HexBinary,
+    msg: MsgToSign,
     expires_at: u64,
+    chain: ChainName,
 }
 
 fn deserialize_public_keys<'de, D>(
@@ -51,8 +54,8 @@ where
 
 pub struct Handler<S> {
     verifier: TMAddress,
-    multisig_prover: TMAddress,
     multisig: TMAddress,
+    chain: ChainName,
     signer: S,
     latest_block_height: Receiver<u64>,
 }
@@ -64,14 +67,14 @@ where
     pub fn new(
         verifier: TMAddress,
         multisig: TMAddress,
-        multisig_prover: TMAddress,
+        chain: ChainName,
         signer: S,
         latest_block_height: Receiver<u64>,
     ) -> Self {
         Self {
             verifier,
             multisig,
-            multisig_prover,
+            chain,
             signer,
             latest_block_height,
         }
@@ -103,15 +106,16 @@ where
     type Err = Error;
 
     async fn handle(&self, event: &events::Event) -> error_stack::Result<Vec<Any>, Error> {
-        if !event.is_from_contract(self.multisig_prover.as_ref()) {
+        if !event.is_from_contract(self.multisig.as_ref()) {
             return Ok(vec![]);
         }
 
-        let XRPLSigningStartedEvent {
+        let SigningStartedEvent {
             session_id,
             pub_keys,
-            unsigned_tx,
+            msg,
             expires_at,
+            chain,
         } = match event.try_into() as error_stack::Result<_, _> {
             Err(report) if matches!(report.current_context(), EventTypeMismatch(_)) => {
                 return Ok(vec![]);
@@ -119,9 +123,17 @@ where
             result => result.change_context(DeserializeEvent)?,
         };
 
+        if !chain.eq(&self.chain) {
+            info!(
+                session_id = session_id.to_string(),
+                "skipping signing session for different chain"
+            );
+            return Ok(vec![]);
+        }
+
         info!(
             session_id = session_id,
-            msg = unsigned_tx.to_hex(),
+            msg = encode(&msg),
             "get signing request",
         );
 
@@ -145,7 +157,7 @@ where
                 let xrpl_address = XRPLAccountId::from(&multisig_pub_key);
 
                 let msg_digest = MessageDigest::from(
-                    xrpl_types::types::message_to_sign(unsigned_tx.to_vec(), &xrpl_address)
+                    xrpl_types::types::message_to_sign(msg.as_ref().to_vec(), &xrpl_address)
                         .map_err(|_e| Error::MessageToSign)?,
                 );
 
@@ -187,9 +199,11 @@ mod test {
     use cosmrs::AccountId;
     use cosmwasm_std::{HexBinary, Uint64};
     use error_stack::{Report, Result};
+    use multisig::events::Event;
     use multisig::key::PublicKey;
+    use multisig::types::MsgToSign;
     use rand::rngs::OsRng;
-    use serde_json::to_string;
+    use router_api::ChainName;
     use tendermint::abci;
     use tokio::sync::watch;
 
@@ -198,40 +212,7 @@ mod test {
     use crate::tofnd;
     use crate::tofnd::grpc::MockMultisig;
 
-    pub enum XRPLMultisigProverEvent {
-        XRPLSigningStarted {
-            session_id: Uint64,
-            verifier_set_id: String,
-            pub_keys: HashMap<String, PublicKey>,
-            unsigned_tx: HexBinary,
-            expires_at: u64,
-        },
-    }
-
-    impl From<XRPLMultisigProverEvent> for cosmwasm_std::Event {
-        fn from(other: XRPLMultisigProverEvent) -> Self {
-            match other {
-                XRPLMultisigProverEvent::XRPLSigningStarted {
-                    session_id,
-                    verifier_set_id,
-                    pub_keys,
-                    unsigned_tx,
-                    expires_at,
-                } => cosmwasm_std::Event::new("xrpl_signing_started")
-                    .add_attribute("session_id", session_id)
-                    .add_attribute("verifier_set_id", verifier_set_id)
-                    .add_attribute(
-                        "pub_keys",
-                        to_string(&pub_keys)
-                            .expect("violated invariant: pub_keys are not serializable"),
-                    )
-                    .add_attribute("unsigned_tx", unsigned_tx.to_hex())
-                    .add_attribute("expires_at", expires_at.to_string()),
-            }
-        }
-    }
-
-    const MULTISIG_PROVER_ADDRESS: &str = "axelarvaloper1zh9wrak6ke4n6fclj5e8yk397czv430ygs5jz7";
+    const MULTISIG_ADDRESS: &str = "axelarvaloper1zh9wrak6ke4n6fclj5e8yk397czv430ygs5jz7";
     const PREFIX: &str = "axelar";
 
     fn rand_public_key() -> multisig::key::PublicKey {
@@ -243,7 +224,7 @@ mod test {
         ))
     }
 
-    fn rand_unsigned_tx() -> HexBinary {
+    fn rand_message() -> HexBinary {
         let digest: [u8; 32] = rand::random();
         HexBinary::from(digest.as_slice())
     }
@@ -253,17 +234,18 @@ mod test {
             .map(|_| (TMAddress::random(PREFIX).to_string(), rand_public_key()))
             .collect::<HashMap<String, multisig::key::PublicKey>>();
 
-        let poll_started = XRPLMultisigProverEvent::XRPLSigningStarted {
+        let poll_started = Event::SigningStarted {
             session_id: Uint64::one(),
             verifier_set_id: "verifier_set_id".to_string(),
             pub_keys,
-            unsigned_tx: rand_unsigned_tx(),
+            msg: MsgToSign::unchecked(rand_message()),
+            chain_name: "xrpl".parse().unwrap(),
             expires_at: 100u64,
         };
 
         let mut event: cosmwasm_std::Event = poll_started.into();
         event.ty = format!("wasm-{}", event.ty);
-        event = event.add_attribute("_contract_address", MULTISIG_PROVER_ADDRESS);
+        event = event.add_attribute("_contract_address", MULTISIG_ADDRESS);
 
         events::Event::try_from(abci::Event::new(
             event.ty,
@@ -280,7 +262,7 @@ mod test {
     fn handler(
         verifier: TMAddress,
         multisig: TMAddress,
-        multisig_prover: TMAddress,
+        chain: ChainName,
         signer: MockMultisig,
         latest_block_height: u64,
     ) -> Handler<MockMultisig> {
@@ -291,7 +273,7 @@ mod test {
 
         let (_, rx) = watch::channel(latest_block_height);
 
-        Handler::new(verifier, multisig, multisig_prover, signer, rx)
+        Handler::new(verifier, multisig, chain, signer, rx)
     }
 
     #[test]
@@ -306,7 +288,7 @@ mod test {
             }
             _ => panic!("incorrect event type"),
         }
-        let event: Result<XRPLSigningStartedEvent, events::Error> = (&event).try_into();
+        let event: Result<SigningStartedEvent, events::Error> = (&event).try_into();
 
         assert!(matches!(
             event.unwrap_err().current_context(),
@@ -333,7 +315,7 @@ mod test {
             _ => panic!("incorrect event type"),
         }
 
-        let event: Result<XRPLSigningStartedEvent, events::Error> = (&event).try_into();
+        let event: Result<SigningStartedEvent, events::Error> = (&event).try_into();
 
         assert!(matches!(
             event.unwrap_err().current_context(),
@@ -343,20 +325,20 @@ mod test {
 
     #[test]
     fn should_deserialize_event() {
-        let event: Result<XRPLSigningStartedEvent, events::Error> =
+        let event: Result<SigningStartedEvent, events::Error> =
             (&signing_started_event()).try_into();
 
         assert!(event.is_ok());
     }
 
     #[tokio::test]
-    async fn should_not_handle_event_if_multisig_prover_address_does_not_match() {
+    async fn should_not_handle_event_if_multisig_address_does_not_match() {
         let client = MockMultisig::default();
 
         let handler = handler(
             TMAddress::random(PREFIX),
             TMAddress::random(PREFIX),
-            TMAddress::random(PREFIX),
+            "xrpl".parse().unwrap(),
             client,
             100u64,
         );
@@ -376,8 +358,8 @@ mod test {
 
         let handler = handler(
             TMAddress::random(PREFIX),
-            TMAddress::random(PREFIX),
-            TMAddress::from(MULTISIG_PROVER_ADDRESS.parse::<AccountId>().unwrap()),
+            TMAddress::from(MULTISIG_ADDRESS.parse::<AccountId>().unwrap()),
+            "xrpl".parse().unwrap(),
             client,
             100u64,
         );
@@ -396,13 +378,13 @@ mod test {
             .returning(move |_, _, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
 
         let event = signing_started_event();
-        let signing_started: XRPLSigningStartedEvent =
+        let signing_started: SigningStartedEvent =
             ((&event).try_into() as Result<_, _>).unwrap();
         let verifier = signing_started.pub_keys.keys().next().unwrap().clone();
         let handler = handler(
             verifier,
-            TMAddress::random(PREFIX),
-            TMAddress::from(MULTISIG_PROVER_ADDRESS.parse::<AccountId>().unwrap()),
+            TMAddress::from(MULTISIG_ADDRESS.parse::<AccountId>().unwrap()),
+            "xrpl".parse().unwrap(),
             client,
             99u64,
         );
@@ -421,15 +403,37 @@ mod test {
             .returning(move |_, _, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
 
         let event = signing_started_event();
-        let signing_started: XRPLSigningStartedEvent =
+        let signing_started: SigningStartedEvent =
             ((&event).try_into() as Result<_, _>).unwrap();
         let verifier = signing_started.pub_keys.keys().next().unwrap().clone();
         let handler = handler(
             verifier,
-            TMAddress::random(PREFIX),
-            TMAddress::from(MULTISIG_PROVER_ADDRESS.parse::<AccountId>().unwrap()),
+            TMAddress::from(MULTISIG_ADDRESS.parse::<AccountId>().unwrap()),
+            "xrpl".parse().unwrap(),
             client,
             101u64,
+        );
+
+        assert_eq!(handler.handle(&event).await.unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn should_not_handle_event_if_chain_does_not_match() {
+        let mut client = MockMultisig::default();
+        client
+            .expect_sign()
+            .returning(move |_, _, _, _| Err(Report::from(tofnd::error::Error::SignFailed)));
+
+        let event = signing_started_event();
+        let signing_started: SigningStartedEvent =
+            ((&event).try_into() as Result<_, _>).unwrap();
+        let verifier = signing_started.pub_keys.keys().next().unwrap().clone();
+        let handler = handler(
+            verifier,
+            TMAddress::from(MULTISIG_ADDRESS.parse::<AccountId>().unwrap()),
+            "not-xrpl".parse().unwrap(),
+            client,
+            100u64,
         );
 
         assert_eq!(handler.handle(&event).await.unwrap(), vec![]);

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -345,14 +345,14 @@ where
                     )
                 }
                 handlers::config::Config::XRPLMultisigSigner {
-                    multisig_contract,
-                    multisig_prover_contract,
+                    cosmwasm_contract,
+                    chain_name,
                 } => self.create_handler_task(
                     "xrpl-multisig-signer",
                     handlers::xrpl_multisig::Handler::new(
                         verifier.clone(),
-                        multisig_contract,
-                        multisig_prover_contract,
+                        cosmwasm_contract,
+                        chain_name,
                         self.multisig_client.clone(),
                         self.block_height_monitor.latest_block_height(),
                     ),

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -92,8 +92,7 @@ pub fn execute(
                 deps,
                 env,
                 verifier_set_id,
-                msg.try_into()
-                    .map_err(axelar_wasm_std::error::ContractError::from)?,
+                msg.into(),
                 chain_name,
                 sig_verifier,
             )

--- a/contracts/multisig/src/types.rs
+++ b/contracts/multisig/src/types.rs
@@ -1,7 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::HexBinary;
 
-use crate::ContractError;
 
 #[cw_serde]
 pub struct MsgToSign(HexBinary);
@@ -33,42 +32,10 @@ pub enum MultisigState {
     },
 }
 
-const MESSAGE_HASH_LEN: usize = 32;
 
-impl TryFrom<HexBinary> for MsgToSign {
-    type Error = ContractError;
-
-    fn try_from(other: HexBinary) -> Result<Self, Self::Error> {
-        if other.len() != MESSAGE_HASH_LEN {
-            return Err(ContractError::InvalidMessageFormat {
-                reason: "Invalid input length".into(),
-            });
-        }
-
-        Ok(MsgToSign(other))
+impl From<HexBinary> for MsgToSign {
+    fn from(value: HexBinary) -> Self {
+        MsgToSign(value)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test::common::ecdsa_test_data;
-
-    #[test]
-    fn test_try_from_hexbinary_to_message() {
-        let hex = ecdsa_test_data::message();
-        let message = MsgToSign::try_from(hex.clone()).unwrap();
-        assert_eq!(HexBinary::from(message), hex);
-    }
-
-    #[test]
-    fn test_try_from_hexbinary_to_message_fails() {
-        let hex = HexBinary::from_hex("283786d844a7c4d1d424837074d0c8ec71becdcba4dd42b5307cb543a0e2c8b81c10ad541defd5ce84d2a608fc454827d0b65b4865c8192a2ea1736a5c4b72021b").unwrap();
-        assert_eq!(
-            MsgToSign::try_from(hex.clone()).unwrap_err(),
-            ContractError::InvalidMessageFormat {
-                reason: "Invalid input length".into()
-            }
-        );
-    }
-}


### PR DESCRIPTION
## Description

This PR complements the changes made to XRPLMultisigProver here to enable a stateless `VerifySignature` sig_verifier function: https://github.com/commonprefix/axelar-amplifier/pull/15. Since the full unsigned TX will be passed to the multisig contract from now on, the XRPL `ampd` process can now listen to the multisig contract instead of the XRPLMultisigProver, exactly like the EVM `ampd`.

**NOTE**: The following changes needs to be made to the verifiers' ampd config:

```diff
[[handlers]]
-multisig_contract="axelar14a4ar5jh7ue4wg28jwsspf23r8k68j7g5d6d3fsttrhp42ajn4xq6zayy5"
+cosmwasm_contract="axelar14a4ar5jh7ue4wg28jwsspf23r8k68j7g5d6d3fsttrhp42ajn4xq6zayy5"
-multisig_prover_contract="axelar18wq8qjlq6vfg2jw2fmvgyphjxrndc7529wq07pvlpnk0j2uvv5fqqqr4gv"
+chain_name="xrpl"
type="XRPLMultisigSigner"
```

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
