### PR TITLE
refactor(coordinator): restructure state/msg interface for #7329

### DIFF
--- a/contracts/coordinator/src/lib.rs
+++ b/contracts/coordinator/src/lib.rs
@@ -3,4 +3,5 @@ pub use client::Client;
 
 pub mod contract;
 pub mod msg;
+pub mod shared;
 mod state;

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -4,14 +4,10 @@ use axelar_wasm_std::nonempty;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 use msgs_derive::EnsurePermissions;
-use router_api::ChainName;
 use service_registry_api::Verifier;
 
 pub use crate::contract::MigrateMsg;
-
-type ProverAddress = Addr;
-type GatewayAddress = Addr;
-type VerifierAddress = Addr;
+use crate::shared::{ChainName, GatewayAddress, ProverAddress, VerifierAddress};
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/contracts/coordinator/src/shared.rs
+++ b/contracts/coordinator/src/shared.rs
@@ -1,0 +1,6 @@
+use cosmwasm_std::Addr;
+pub use router_api::ChainName;
+
+pub type ProverAddress = Addr;
+pub type GatewayAddress = Addr;
+pub type VerifierAddress = Addr;

--- a/contracts/coordinator/src/state.rs
+++ b/contracts/coordinator/src/state.rs
@@ -4,13 +4,9 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Order, Storage};
 use cw_storage_plus::{index_list, Index, IndexList, IndexedMap, Item, MultiIndex, UniqueIndex};
 use error_stack::{report, Result, ResultExt};
-use router_api::ChainName;
 
 use crate::msg::ChainContractsResponse;
-
-type ProverAddress = Addr;
-type GatewayAddress = Addr;
-type VerifierAddress = Addr;
+use crate::shared::{ChainName, GatewayAddress, ProverAddress, VerifierAddress};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
