### PR TITLE
chore(ampd): replace todo! with unimplemented status code

### DIFF
--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -95,14 +95,18 @@ where
         &self,
         _req: Request<AddressRequest>,
     ) -> Result<Response<AddressResponse>, Status> {
-        todo!("implement address method")
+        Err(Status::unimplemented(
+            "address method is not implemented yet",
+        ))
     }
 
     async fn contracts(
         &self,
         _req: Request<ContractsRequest>,
     ) -> Result<Response<ContractsResponse>, Status> {
-        todo!("implement contracts method")
+        Err(Status::unimplemented(
+            "contracts method is not implemented yet",
+        ))
     }
 }
 

--- a/ampd/src/grpc/crypto_service.rs
+++ b/ampd/src/grpc/crypto_service.rs
@@ -14,10 +14,10 @@ impl Service {
 #[async_trait]
 impl CryptoService for Service {
     async fn sign(&self, _req: Request<SignRequest>) -> Result<Response<SignResponse>, Status> {
-        todo!("implement sign method")
+        Err(Status::unimplemented("sign method is not implemented yet"))
     }
 
     async fn key(&self, _req: Request<KeyRequest>) -> Result<Response<KeyResponse>, Status> {
-        todo!("implement key method")
+        Err(Status::unimplemented("key method is not implemented yet"))
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
