### PR TITLE
refactor(router): modify lib.rs  AXE-7322

### DIFF
--- a/contracts/router/src/lib.rs
+++ b/contracts/router/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod contract;
-pub mod events;
+mod events;
 pub mod msg;
-pub mod state;
+mod state;


### PR DESCRIPTION
updated pub mod to private mod 
msg contract mod remain pub because of integration test 




Description

We created the following convention:
types used in msg.rs must be one of the following
types defined in the msg module
imported types from external crates
imported types from this crate's exported  module
the exported module gets re-exported in the top level lib.rs, to allow for more ergonomic use:


mod exported;
pub use exported::*;
other contract modules can import types from anywhere, but must map those types to validated internal types as soon as possible if necessary