### PR TITLE
feat(minor-ampd): implement blockchain service method address

### DIFF
--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -95,7 +95,9 @@ where
         &self,
         _req: Request<AddressRequest>,
     ) -> Result<Response<AddressResponse>, Status> {
-        todo!("implement address method")
+        Ok(Response::new(AddressResponse {
+            address: self.msg_queue_client.address().to_string(),
+        }))
     }
 
     async fn contracts(
@@ -806,6 +808,50 @@ mod tests {
         let res = service.contract_state(req).await.unwrap().into_inner();
 
         assert_eq!(res.result, result);
+    }
+
+    #[tokio::test]
+    async fn address_should_return_msg_queue_client_address() {
+        let pub_key = random_cosmos_public_key();
+        let expected_address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+        let base_account = BaseAccount {
+            address: expected_address.to_string(),
+            pub_key: None,
+            account_number: 42,
+            sequence: 10,
+        };
+
+        let mut mock_cosmos_client = MockCosmosClient::new();
+        mock_cosmos_client.expect_account().return_once(move |_| {
+            Ok(QueryAccountResponse {
+                account: Some(Any::from_msg(&base_account).unwrap()),
+            })
+        });
+        let broadcaster = broadcaster_v2::Broadcaster::new(
+            mock_cosmos_client,
+            "chain-id".parse().unwrap(),
+            pub_key,
+        )
+        .await
+        .unwrap();
+
+        let (_, msg_queue_client) = broadcaster_v2::MsgQueue::new_msg_queue_and_client(
+            broadcaster,
+            10,
+            1000u64,
+            Duration::from_secs(1),
+        );
+
+        let service = Service::builder()
+            .event_sub(MockEventSub::new())
+            .msg_queue_client(msg_queue_client)
+            .cosmos_client(MockCosmosClient::new())
+            .build();
+
+        let req = Request::new(AddressRequest {});
+        let res = service.address(req).await.unwrap().into_inner();
+
+        assert_eq!(res.address, expected_address.to_string());
     }
 
     fn subscribe_req(


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
