### PR TITLE
feat(xrpl-types): implement TryFrom<String> for XRPLMessageType

### DIFF
--- a/packages/xrpl-types/src/error.rs
+++ b/packages/xrpl-types/src/error.rs
@@ -83,6 +83,9 @@ pub enum XRPLError {
 
     #[error("unsupported key type")]
     UnsupportedKeyType,
+
+    #[error("unsupported message type")]
+    UnsupportedMessageType,
 }
 
 impl From<XRPLError> for StdError {

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -56,6 +56,21 @@ impl std::fmt::Display for XRPLMessageType {
     }
 }
 
+impl TryFrom<String> for XRPLMessageType {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "proof" => Ok(XRPLMessageType::Proof),
+            "interchain_transfer" => Ok(XRPLMessageType::InterchainTransfer),
+            "call_contract" => Ok(XRPLMessageType::CallContract),
+            "add_gas" => Ok(XRPLMessageType::AddGas),
+            "add_reserves" => Ok(XRPLMessageType::AddReserves),
+            _ => Err(format!("Invalid XRPL message type: {}", s)),
+        }
+    }
+}
+
 impl XRPLMessage {
     pub fn tx_id(&self) -> HexTxHash {
         match self {
@@ -425,5 +440,38 @@ impl WithPayload<XRPLMessage> {
 impl<T: Clone + Into<XRPLMessage>> From<WithPayload<T>> for XRPLMessage {
     fn from(val: WithPayload<T>) -> Self {
         val.message.into()
+    }
+}
+
+mod test {
+    use super::XRPLMessageType;
+
+    #[test]
+    fn test_xrpl_message_type_from_string() {
+        let msg_type = XRPLMessageType::try_from("interchain_transfer".to_string());
+        assert_eq!(msg_type, Ok(XRPLMessageType::InterchainTransfer));
+        assert_eq!(msg_type.unwrap().to_string(), "interchain_transfer");
+
+        let msg_type = XRPLMessageType::try_from("call_contract".to_string());
+        assert_eq!(msg_type, Ok(XRPLMessageType::CallContract));
+        assert_eq!(msg_type.unwrap().to_string(), "call_contract");
+
+        let msg_type = XRPLMessageType::try_from("add_gas".to_string());
+        assert_eq!(msg_type, Ok(XRPLMessageType::AddGas));
+        assert_eq!(msg_type.unwrap().to_string(), "add_gas");
+
+        let msg_type = XRPLMessageType::try_from("add_reserves".to_string());
+        assert_eq!(msg_type, Ok(XRPLMessageType::AddReserves));
+        assert_eq!(msg_type.unwrap().to_string(), "add_reserves");
+
+        let msg_type = XRPLMessageType::try_from("proof".to_string());
+        assert_eq!(msg_type, Ok(XRPLMessageType::Proof));
+        assert_eq!(msg_type.unwrap().to_string(), "proof");
+
+        let msg_type = XRPLMessageType::try_from("invalid".to_string());
+        assert_eq!(
+            msg_type,
+            Err("Invalid XRPL message type: invalid".to_string())
+        );
     }
 }

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{Attribute, HexBinary};
 use router_api::{ChainNameRaw, CrossChainId, FIELD_DELIMITER};
 use sha3::{Digest, Keccak256};
 
+use crate::error::XRPLError;
 use crate::types::{xrpl_account_id_string, XRPLAccountId, XRPLPaymentAmount};
 use crate::{hex_option, hex_tx_hash};
 
@@ -59,7 +60,7 @@ impl std::fmt::Display for XRPLMessageType {
 }
 
 impl FromStr for XRPLMessageType {
-    type Err = String;
+    type Err = XRPLError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -68,7 +69,7 @@ impl FromStr for XRPLMessageType {
             "call_contract" => Ok(XRPLMessageType::CallContract),
             "add_gas" => Ok(XRPLMessageType::AddGas),
             "add_reserves" => Ok(XRPLMessageType::AddReserves),
-            _ => Err(format!("Invalid XRPL message type: {}", s)),
+            _ => Err(XRPLError::UnsupportedMessageType),
         }
     }
 }
@@ -448,6 +449,8 @@ impl<T: Clone + Into<XRPLMessage>> From<WithPayload<T>> for XRPLMessage {
 mod test {
     use std::str::FromStr;
 
+    use crate::error::XRPLError;
+
     use super::XRPLMessageType;
 
     #[test]
@@ -473,9 +476,6 @@ mod test {
         assert_eq!(msg_type.unwrap().to_string(), "proof");
 
         let msg_type = XRPLMessageType::from_str("invalid");
-        assert_eq!(
-            msg_type,
-            Err("Invalid XRPL message type: invalid".to_string())
-        );
+        assert_eq!(msg_type, Err(XRPLError::UnsupportedMessageType));
     }
 }

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -450,9 +450,8 @@ impl<T: Clone + Into<XRPLMessage>> From<WithPayload<T>> for XRPLMessage {
 mod test {
     use std::str::FromStr;
 
-    use crate::error::XRPLError;
-
     use super::XRPLMessageType;
+    use crate::error::XRPLError;
 
     #[test]
     fn test_xrpl_message_type_from_string() {

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -446,6 +446,7 @@ impl<T: Clone + Into<XRPLMessage>> From<WithPayload<T>> for XRPLMessage {
     }
 }
 
+#[cfg(test)]
 mod test {
     use std::str::FromStr;
 

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use axelar_wasm_std::msg_id::HexTxHash;
 use axelar_wasm_std::nonempty;
 use cosmwasm_schema::cw_serde;
@@ -56,11 +58,11 @@ impl std::fmt::Display for XRPLMessageType {
     }
 }
 
-impl TryFrom<String> for XRPLMessageType {
-    type Error = String;
+impl FromStr for XRPLMessageType {
+    type Err = String;
 
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        match s.as_str() {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
             "proof" => Ok(XRPLMessageType::Proof),
             "interchain_transfer" => Ok(XRPLMessageType::InterchainTransfer),
             "call_contract" => Ok(XRPLMessageType::CallContract),
@@ -444,31 +446,33 @@ impl<T: Clone + Into<XRPLMessage>> From<WithPayload<T>> for XRPLMessage {
 }
 
 mod test {
+    use std::str::FromStr;
+
     use super::XRPLMessageType;
 
     #[test]
     fn test_xrpl_message_type_from_string() {
-        let msg_type = XRPLMessageType::try_from("interchain_transfer".to_string());
+        let msg_type = XRPLMessageType::from_str("interchain_transfer");
         assert_eq!(msg_type, Ok(XRPLMessageType::InterchainTransfer));
         assert_eq!(msg_type.unwrap().to_string(), "interchain_transfer");
 
-        let msg_type = XRPLMessageType::try_from("call_contract".to_string());
+        let msg_type = XRPLMessageType::from_str("call_contract");
         assert_eq!(msg_type, Ok(XRPLMessageType::CallContract));
         assert_eq!(msg_type.unwrap().to_string(), "call_contract");
 
-        let msg_type = XRPLMessageType::try_from("add_gas".to_string());
+        let msg_type = XRPLMessageType::from_str("add_gas");
         assert_eq!(msg_type, Ok(XRPLMessageType::AddGas));
         assert_eq!(msg_type.unwrap().to_string(), "add_gas");
 
-        let msg_type = XRPLMessageType::try_from("add_reserves".to_string());
+        let msg_type = XRPLMessageType::from_str("add_reserves");
         assert_eq!(msg_type, Ok(XRPLMessageType::AddReserves));
         assert_eq!(msg_type.unwrap().to_string(), "add_reserves");
 
-        let msg_type = XRPLMessageType::try_from("proof".to_string());
+        let msg_type = XRPLMessageType::from_str("proof");
         assert_eq!(msg_type, Ok(XRPLMessageType::Proof));
         assert_eq!(msg_type.unwrap().to_string(), "proof");
 
-        let msg_type = XRPLMessageType::try_from("invalid".to_string());
+        let msg_type = XRPLMessageType::from_str("invalid");
         assert_eq!(
             msg_type,
             Err("Invalid XRPL message type: invalid".to_string())


### PR DESCRIPTION
## Description

Implements the `TryFrom<String>` trait for `XRPLMessageType`. This is currently used only by the relayer.