### PR TITLE
refactor(coordinator): update module visibility

### DIFF
--- a/contracts/coordinator/src/exported.rs
+++ b/contracts/coordinator/src/exported.rs
@@ -1,0 +1,1 @@
+pub use crate::client::Client;

--- a/contracts/coordinator/src/lib.rs
+++ b/contracts/coordinator/src/lib.rs
@@ -1,6 +1,6 @@
 mod client;
-pub use client::Client;
-
 pub mod contract;
+mod exported;
 pub mod msg;
 mod state;
+pub use exported::*;


### PR DESCRIPTION
**changes:** 
add exported.rs file 
check: no user type is risky 

AXE-7329
**Description**

We created the following convention:
types used in `msg.rs` must be one of the following

> types defined in the msg module
> imported types from external crates
> imported types from this crate's exported  module

the exported module gets re-exported in the top level `lib.rs`, to allow for more ergonomic use:


```
mod exported;
pub use exported::*;
```
other contract modules can import types from anywhere, but must map those types to validated internal types as soon as possible if necessary

**IMPORTANT**: As we modify the message types, we also need to check for missed validations. For example, the PoolId in the rewards contract currently uses Addr as a field type, which then goes unchecked. In these cases, we need a separate msg object that gets converted (+validation) into the corresponding state object at the beginning of the msg execution

PoolId [usage](https://github.com/axelarnetwork/axelar-amplifier/blob/1a8a4ccf5fc7ac202138342020d4619dce145e24/contracts/rewards/src/msg.rs#L74)
PoolId [definition](https://github.com/axelarnetwork/axelar-amplifier/blob/1a8a4ccf5fc7ac202138342020d4619dce145e24/contracts/rewards/src/state.rs#L46)
