### PR TITLE
refactor(interchain-token-services-minor): msg and state separation

### DIFF
--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -10,8 +10,7 @@ use error_stack::{Report, ResultExt};
 use execute::{freeze_chain, unfreeze_chain};
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{self, TokenSupply};
-use crate::state::Config;
+use crate::state::{self, Config, TokenSupply};
 
 mod execute;
 mod migrations;

--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -10,7 +10,7 @@ use error_stack::{Report, ResultExt};
 use execute::{freeze_chain, unfreeze_chain};
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state;
+use crate::state::{self, TokenSupply};
 use crate::state::Config;
 
 mod execute;
@@ -117,7 +117,7 @@ pub fn execute(
             chain,
             origin_chain,
             decimals,
-            supply,
+            TokenSupply::try_from_msg_token_supply(supply)?,
         )
         .change_context(Error::RegisterP2pTokenInstance),
         ExecuteMsg::ModifySupply {

--- a/contracts/interchain-token-service/src/contract/execute/interceptors.rs
+++ b/contracts/interchain-token-service/src/contract/execute/interceptors.rs
@@ -4,10 +4,8 @@ use error_stack::{bail, ensure, report, Result, ResultExt};
 use router_api::ChainNameRaw;
 
 use super::Error;
-use crate::state::{self, TokenDeploymentType, TokenConfig, TokenInstance};
-use crate::{
-    DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata, TokenId,
-};
+use crate::state::{self, TokenConfig, TokenDeploymentType, TokenInstance};
+use crate::{DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata, TokenId};
 
 pub fn subtract_supply_amount(
     storage: &mut dyn Storage,
@@ -338,10 +336,8 @@ mod test {
     use super::{register_custom_token, Error};
     use crate::contract::execute::interceptors;
     use crate::msg::TruncationConfig;
-    use crate::state::{self, TokenDeploymentType, TokenInstance };
-    use crate::{
-        msg, DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata,
-    };
+    use crate::state::{self, TokenDeploymentType, TokenInstance};
+    use crate::{msg, DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata};
 
     #[test]
     fn register_custom_token_allows_reregistration() {

--- a/contracts/interchain-token-service/src/contract/execute/interceptors.rs
+++ b/contracts/interchain-token-service/src/contract/execute/interceptors.rs
@@ -4,10 +4,9 @@ use error_stack::{bail, ensure, report, Result, ResultExt};
 use router_api::ChainNameRaw;
 
 use super::Error;
-use crate::state::{self, TokenDeploymentType};
+use crate::state::{self, TokenDeploymentType, TokenConfig, TokenInstance};
 use crate::{
-    DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata, TokenConfig, TokenId,
-    TokenInstance,
+    DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata, TokenId,
 };
 
 pub fn subtract_supply_amount(
@@ -339,9 +338,9 @@ mod test {
     use super::{register_custom_token, Error};
     use crate::contract::execute::interceptors;
     use crate::msg::TruncationConfig;
-    use crate::state::{self, TokenDeploymentType};
+    use crate::state::{self, TokenDeploymentType, TokenInstance };
     use crate::{
-        msg, DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata, TokenInstance,
+        msg, DeployInterchainToken, InterchainTransfer, RegisterTokenMetadata,
     };
 
     #[test]

--- a/contracts/interchain-token-service/src/contract/execute/mod.rs
+++ b/contracts/interchain-token-service/src/contract/execute/mod.rs
@@ -7,10 +7,10 @@ use router_api::{Address, ChainName, ChainNameRaw, CrossChainId};
 use crate::events::Event;
 use crate::msg::SupplyModifier;
 use crate::primitives::HubMessage;
-use crate::state::{TokenDeploymentType, TokenConfig, TokenInstance, TokenSupply};
+use crate::state::{TokenConfig, TokenDeploymentType, TokenInstance, TokenSupply};
 use crate::{
     msg, state, DeployInterchainToken, InterchainTransfer, LinkToken, Message,
-    RegisterTokenMetadata, TokenId
+    RegisterTokenMetadata, TokenId,
 };
 
 mod interceptors;

--- a/contracts/interchain-token-service/src/lib.rs
+++ b/contracts/interchain-token-service/src/lib.rs
@@ -7,4 +7,4 @@ pub mod events;
 pub mod msg;
 pub mod shared;
 mod state;
-pub use state::{TokenConfig, TokenInstance, TokenSupply};
+pub use msg::{TokenConfig, TokenInstance, TokenSupply};

--- a/contracts/interchain-token-service/src/msg.rs
+++ b/contracts/interchain-token-service/src/msg.rs
@@ -3,18 +3,38 @@ use std::collections::HashMap;
 use axelar_wasm_std::nonempty;
 use axelarnet_gateway::AxelarExecutableMsg;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Uint256;
 use msgs_derive::EnsurePermissions;
 use router_api::{Address, ChainNameRaw};
 
 pub use crate::contract::MigrateMsg;
 use crate::shared::NumBits;
-use crate::state::{TokenConfig, TokenInstance};
-use crate::{TokenId, TokenSupply};
+use crate::TokenId;
 
 pub const DEFAULT_PAGINATION_LIMIT: u32 = 30;
 
 const fn default_pagination_limit() -> u32 {
     DEFAULT_PAGINATION_LIMIT
+}
+
+#[cw_serde]
+pub enum TokenSupply {
+    /// The total token supply bridged to this chain.
+    /// ITS Hub will not allow bridging back more than this amount of the token from the corresponding chain.
+    Tracked(Uint256),
+    /// The token supply bridged to this chain is not tracked.
+    Untracked,
+}
+
+#[cw_serde]
+pub struct TokenInstance {
+    pub supply: TokenSupply,
+    pub decimals: u8,
+}
+
+#[cw_serde]
+pub struct TokenConfig {
+    pub origin_chain: ChainNameRaw,
 }
 
 #[cw_serde]

--- a/contracts/interchain-token-service/src/state.rs
+++ b/contracts/interchain-token-service/src/state.rs
@@ -99,7 +99,9 @@ impl TokenSupply {
         .then(Ok)
     }
     // TODO: add verification
-    pub fn try_from_msg_token_supply(supply: msg::TokenSupply) -> Result<Self, axelar_wasm_std::address::Error> {
+    pub fn try_from_msg_token_supply(
+        supply: msg::TokenSupply,
+    ) -> Result<Self, axelar_wasm_std::address::Error> {
         match supply {
             msg::TokenSupply::Tracked(amount) => Ok(TokenSupply::Tracked(amount)),
             msg::TokenSupply::Untracked => Ok(TokenSupply::Untracked),
@@ -118,7 +120,7 @@ impl From<TokenInstance> for msg::TokenInstance {
     fn from(token_instance: TokenInstance) -> Self {
         Self {
             supply: token_instance.supply.into(),
-            decimals: token_instance.decimals
+            decimals: token_instance.decimals,
         }
     }
 }
@@ -141,7 +143,9 @@ impl TokenInstance {
     }
 
     // TODO: add verification
-    pub fn try_from_msg_token_instance(token_instance: msg::TokenInstance) -> Result<Self, axelar_wasm_std::address::Error> {
+    pub fn try_from_msg_token_instance(
+        token_instance: msg::TokenInstance,
+    ) -> Result<Self, axelar_wasm_std::address::Error> {
         Ok(Self {
             supply: TokenSupply::try_from_msg_token_supply(token_instance.supply)?,
             decimals: token_instance.decimals,
@@ -172,7 +176,9 @@ impl From<TokenConfig> for msg::TokenConfig {
 
 impl TokenConfig {
     // TODO: add verification
-    pub fn try_from_msg_token_config(token_config: msg::TokenConfig) -> Result<Self, axelar_wasm_std::address::Error> {
+    pub fn try_from_msg_token_config(
+        token_config: msg::TokenConfig,
+    ) -> Result<Self, axelar_wasm_std::address::Error> {
         Ok(Self {
             origin_chain: token_config.origin_chain,
         })

--- a/contracts/interchain-token-service/src/state.rs
+++ b/contracts/interchain-token-service/src/state.rs
@@ -70,6 +70,15 @@ pub enum TokenSupply {
     Untracked,
 }
 
+impl From<TokenSupply> for msg::TokenSupply {
+    fn from(supply: TokenSupply) -> Self {
+        match supply {
+            TokenSupply::Tracked(amount) => msg::TokenSupply::Tracked(amount),
+            TokenSupply::Untracked => msg::TokenSupply::Untracked,
+        }
+    }
+}
+
 impl TokenSupply {
     pub fn checked_add(self, amount: nonempty::Uint256) -> Result<Self, OverflowError> {
         match self {
@@ -89,6 +98,13 @@ impl TokenSupply {
         }
         .then(Ok)
     }
+    // TODO: add verification
+    pub fn try_from_msg_token_supply(supply: msg::TokenSupply) -> Result<Self, axelar_wasm_std::address::Error> {
+        match supply {
+            msg::TokenSupply::Tracked(amount) => Ok(TokenSupply::Tracked(amount)),
+            msg::TokenSupply::Untracked => Ok(TokenSupply::Untracked),
+        }
+    }
 }
 
 /// Information about a token on a specific chain.
@@ -96,6 +112,15 @@ impl TokenSupply {
 pub struct TokenInstance {
     pub supply: TokenSupply,
     pub decimals: u8,
+}
+
+impl From<TokenInstance> for msg::TokenInstance {
+    fn from(token_instance: TokenInstance) -> Self {
+        Self {
+            supply: token_instance.supply.into(),
+            decimals: token_instance.decimals
+        }
+    }
 }
 
 impl TokenInstance {
@@ -114,6 +139,14 @@ impl TokenInstance {
 
         Self { supply, decimals }
     }
+
+    // TODO: add verification
+    pub fn try_from_msg_token_instance(token_instance: msg::TokenInstance) -> Result<Self, axelar_wasm_std::address::Error> {
+        Ok(Self {
+            supply: TokenSupply::try_from_msg_token_supply(token_instance.supply)?,
+            decimals: token_instance.decimals,
+        })
+    }
 }
 
 /// The deployment type of the token.
@@ -127,6 +160,23 @@ pub enum TokenDeploymentType {
 #[cw_serde]
 pub struct TokenConfig {
     pub origin_chain: ChainNameRaw,
+}
+
+impl From<TokenConfig> for msg::TokenConfig {
+    fn from(token_config: TokenConfig) -> Self {
+        Self {
+            origin_chain: token_config.origin_chain,
+        }
+    }
+}
+
+impl TokenConfig {
+    // TODO: add verification
+    pub fn try_from_msg_token_config(token_config: msg::TokenConfig) -> Result<Self, axelar_wasm_std::address::Error> {
+        Ok(Self {
+            origin_chain: token_config.origin_chain,
+        })
+    }
 }
 
 type TokenAddress = nonempty::HexBinary;


### PR DESCRIPTION
## Description
- refactored ITS msg.rs to no longer depend on state.rs
- need to check verification/simply using the newly created msg.rs types everywhere

[AXE-7323
](https://axelarnetwork.atlassian.net/browse/AXE-7323)
## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
