### PR TITLE
feat(minor-ampd): implement crypto service method sign

### DIFF
--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -69,11 +69,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
 
     let sender = pub_key.account_id(PREFIX).change_context(Error::Tofnd)?;
 
-    let address_hash: [u8; 32] = Keccak256::digest(sender.as_ref().as_bytes())
-        .as_slice()
-        .try_into()
-        .expect("wrong length");
-
+    let address_hash: [u8; 32] = Keccak256::digest(sender.as_ref().as_bytes()).into();
     let signed_sender_address = multisig_client
         .sign(
             &multisig_address.to_string(),

--- a/ampd/src/grpc/crypto_service.rs
+++ b/ampd/src/grpc/crypto_service.rs
@@ -1,6 +1,7 @@
 use ampd_proto::crypto_service_server::CryptoService;
 use ampd_proto::{KeyRequest, KeyResponse, SignRequest, SignResponse};
 use async_trait::async_trait;
+use sha3::{Digest, Keccak256};
 use tonic::{Request, Response, Status};
 
 use crate::grpc::{reqs, status};
@@ -24,8 +25,26 @@ impl<T> CryptoService for Service<T>
 where
     T: Multisig + Send + Sync + 'static,
 {
-    async fn sign(&self, _req: Request<SignRequest>) -> Result<Response<SignResponse>, Status> {
-        Err(Status::unimplemented("sign method is not implemented yet"))
+    async fn sign(&self, req: Request<SignRequest>) -> Result<Response<SignResponse>, Status> {
+        let (id, algorithm, msg) = reqs::validate_sign(req)
+            .inspect_err(status::log("invalid sign request"))
+            .map_err(status::StatusExt::into_status)?;
+        // TODO: memoize the key
+        let pub_key = self
+            .0
+            .keygen(&id, algorithm)
+            .await
+            .inspect_err(status::log("query key error"))
+            .map_err(status::StatusExt::into_status)?;
+        let msg_hash: [u8; 32] = Keccak256::digest(msg.as_ref()).into();
+
+        self.0
+            .sign(&id, msg_hash, pub_key, algorithm)
+            .await
+            .map(|signature| SignResponse { signature })
+            .map(Response::new)
+            .inspect_err(status::log("sign error"))
+            .map_err(status::StatusExt::into_status)
     }
 
     async fn key(&self, req: Request<KeyRequest>) -> Result<Response<KeyResponse>, Status> {
@@ -47,10 +66,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ampd_proto::{Algorithm, KeyId, KeyRequest};
+    use ampd_proto::{Algorithm, KeyId, KeyRequest, SignRequest};
     use error_stack::report;
     use mockall::predicate;
     use rand::rngs::OsRng;
+    use sha3::{Digest, Keccak256};
     use tonic::{Code, Request};
 
     use super::*;
@@ -141,6 +161,164 @@ mod tests {
         });
 
         let err = service.key(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::Internal);
+    }
+
+    #[tokio::test]
+    async fn sign_should_return_signature_on_valid_request() {
+        let key_id = "test_key";
+        let algorithm = Algorithm::Ecdsa;
+        let message = vec![1, 2, 3, 4];
+        let signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
+        let verifying_key = signing_key.verifying_key();
+        let pub_key = PublicKey::new_secp256k1(verifying_key.to_sec1_bytes()).unwrap();
+        let expected_signature_val = vec![5, 6, 7, 8]; // Mock signature
+
+        let msg_hash: [u8; 32] = Keccak256::digest(&message).into();
+
+        let mut multisig = MockMultisig::new();
+        multisig
+            .expect_keygen()
+            .with(
+                predicate::eq(key_id),
+                predicate::eq(tofnd::Algorithm::Ecdsa),
+            )
+            .return_once(move |_, _| Ok(pub_key));
+        multisig
+            .expect_sign()
+            .with(
+                predicate::eq(key_id),
+                predicate::eq(msg_hash),
+                predicate::eq(pub_key),
+                predicate::eq(tofnd::Algorithm::Ecdsa),
+            )
+            .return_once(move |_, _, _, _| Ok(expected_signature_val.clone()));
+
+        let service = Service::from(multisig);
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: key_id.to_string(),
+                algorithm: algorithm.into(),
+            }),
+            msg: message,
+        });
+
+        let res = service.sign(request).await.unwrap();
+        assert_eq!(res.get_ref().signature, vec![5, 6, 7, 8]);
+    }
+
+    #[tokio::test]
+    async fn sign_should_return_error_on_invalid_request() {
+        let multisig = MockMultisig::new();
+        let service = Service::from(multisig);
+
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: "".to_string(),
+                algorithm: Algorithm::Ecdsa.into(),
+            }),
+            msg: vec![1, 2, 3, 4],
+        });
+
+        let err = service.sign(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: "test_key".to_string(),
+                algorithm: Algorithm::Ecdsa.into(),
+            }),
+            msg: vec![],
+        });
+
+        let err = service.sign(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn sign_should_return_error_on_invalid_algorithm() {
+        let multisig = MockMultisig::new();
+        let service = Service::from(multisig);
+
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: "test_key".to_string(),
+                algorithm: 999,
+            }),
+            msg: vec![1, 2, 3, 4],
+        });
+
+        let err = service.sign(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn sign_should_propagate_keygen_errors() {
+        let key_id = "test_key";
+        let algorithm = Algorithm::Ecdsa;
+        let message = vec![1, 2, 3, 4];
+
+        let mut multisig = MockMultisig::new();
+        multisig
+            .expect_keygen()
+            .with(
+                predicate::eq(key_id),
+                predicate::eq(tofnd::Algorithm::Ecdsa),
+            )
+            .return_once(|_, _| Err(report!(tofnd::Error::InvalidKeygenResponse)));
+
+        let service = Service::from(multisig);
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: key_id.to_string(),
+                algorithm: algorithm.into(),
+            }),
+            msg: message,
+        });
+
+        let err = service.sign(request).await.unwrap_err();
+        assert_eq!(err.code(), Code::Internal);
+    }
+
+    #[tokio::test]
+    async fn sign_should_propagate_sign_errors() {
+        let key_id = "test_key";
+        let algorithm = Algorithm::Ecdsa;
+        let message = vec![1, 2, 3, 4];
+        let signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
+        let verifying_key = signing_key.verifying_key();
+        let pub_key = PublicKey::new_secp256k1(verifying_key.to_sec1_bytes()).unwrap();
+
+        let msg_hash: [u8; 32] = Keccak256::digest(&message).into();
+
+        let mut multisig = MockMultisig::new();
+        multisig
+            .expect_keygen()
+            .with(
+                predicate::eq(key_id),
+                predicate::eq(tofnd::Algorithm::Ecdsa),
+            )
+            .return_once(move |_, _| Ok(pub_key));
+        multisig
+            .expect_sign()
+            .with(
+                predicate::eq(key_id),
+                predicate::eq(msg_hash),
+                predicate::eq(pub_key),
+                predicate::eq(tofnd::Algorithm::Ecdsa),
+            )
+            .return_once(|_, _, _, _| Err(report!(tofnd::Error::InvalidSignResponse)));
+
+        let service = Service::from(multisig);
+        let request = Request::new(SignRequest {
+            key_id: Some(KeyId {
+                id: key_id.to_string(),
+                algorithm: algorithm.into(),
+            }),
+            msg: message,
+        });
+
+        let err = service.sign(request).await.unwrap_err();
         assert_eq!(err.code(), Code::Internal);
     }
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
