### PR TITLE
refactor(coordinator): refactor coordinator messages

### DIFF
--- a/contracts/coordinator/src/contract/query.rs
+++ b/contracts/coordinator/src/contract/query.rs
@@ -50,7 +50,7 @@ pub fn verifier_details_with_provers(
             verifier_address: verifier_address.to_string(),
         })?;
 
-    active_prover_set.sort_by_key(|addr| addr.to_string());
+    active_prover_set.sort();
 
     Ok(VerifierInfo {
         verifier: verifier_details.verifier,

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -128,7 +128,7 @@ pub struct VerifierInfo {
     pub verifier: Verifier,
     pub weight: nonempty::Uint128,
     pub supported_chains: Vec<ChainName>,
-    pub actively_signing_for: HashSet<Addr>,
+    pub actively_signing_for: Vec<Addr>,
 }
 
 #[cw_serde]

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -344,10 +344,12 @@ pub fn assert_verifier_details_are_equal(
         verifier.supported_chains.clone().into_iter().collect();
     assert_eq!(verifier_info_chains, verifier_chains);
 
-    let available_provers: HashSet<Addr> = chains
+    let mut available_provers: Vec<Addr> = chains
         .iter()
         .map(|chain| chain.multisig_prover.contract_addr.clone())
         .collect();
+
+    available_provers.sort_by_key(|addr| addr.to_string());
 
     assert_eq!(verifier_info.actively_signing_for, available_provers);
 }

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -349,7 +349,7 @@ pub fn assert_verifier_details_are_equal(
         .map(|chain| chain.multisig_prover.contract_addr.clone())
         .collect();
 
-    available_provers.sort_by_key(|addr| addr.to_string());
+    available_provers.sort();
 
     assert_eq!(verifier_info.actively_signing_for, available_provers);
 }

--- a/packages/multisig-prover-api/src/msg.rs
+++ b/packages/multisig-prover-api/src/msg.rs
@@ -30,6 +30,7 @@ pub struct InstantiateMsg {
     pub signing_threshold: MajorityThreshold,
     /// Name of service in the service registry for which verifiers are registered.
     pub service_name: String,
+    /// TODO: Change to ChainName
     /// Name of chain for which this prover contract creates proofs.
     pub chain_name: String,
     /// Maximum tolerable difference between currently active verifier set and registered verifier set.


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
