### PR TITLE
refactor(coordinator): simplify error in instantiate message endpoint

### DIFF
--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -22,8 +22,6 @@ pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(thiserror::Error, Debug, IntoContractError)]
 pub enum Error {
-    #[error("coordinator instantiation failed")]
-    Instantiate,
     #[error("coordinator query failed")]
     Query,
     #[error("coordinator execution failed")]
@@ -37,26 +35,17 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let config = Config {
         service_registry: address::validate_cosmwasm_address(deps.api, &msg.service_registry)?,
         router: address::validate_cosmwasm_address(deps.api, &msg.router_address)?,
         multisig: address::validate_cosmwasm_address(deps.api, &msg.multisig_address)?,
     };
-    CONFIG
-        .save(deps.storage, &config)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    CONFIG.save(deps.storage, &config)?;
 
-    let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)
-        .change_context(Error::Instantiate)?;
-
-    permission_control::set_governance(deps.storage, &governance)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)?;
+    permission_control::set_governance(deps.storage, &governance)?;
 
     Ok(Response::default())
 }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
