### PR TITLE
refactor(coordinator): refactor coordinator events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,6 +5051,8 @@ dependencies = [
  "cw-multi-test",
  "error-stack",
  "ethers-core",
+ "events",
+ "events-derive",
  "gateway",
  "gateway-api",
  "goldie",

--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -22,8 +22,6 @@ pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(thiserror::Error, Debug, IntoContractError)]
 pub enum Error {
-    #[error("coordinator instantiation failed")]
-    Instantiate,
     #[error("coordinator query failed")]
     Query,
     #[error("coordinator execution failed")]
@@ -37,26 +35,17 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let config = Config {
         service_registry: address::validate_cosmwasm_address(deps.api, &msg.service_registry)?,
         router: address::validate_cosmwasm_address(deps.api, &msg.router_address)?,
         multisig: address::validate_cosmwasm_address(deps.api, &msg.multisig_address)?,
     };
-    CONFIG
-        .save(deps.storage, &config)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    CONFIG.save(deps.storage, &config)?;
 
-    let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)
-        .change_context(Error::Instantiate)?;
-
-    permission_control::set_governance(deps.storage, &governance)
-        .map_err(|err| error_stack::Report::new(err))
-        .change_context(Error::Instantiate)?;
+    let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)?;
+    permission_control::set_governance(deps.storage, &governance)?;
 
     Ok(Response::default())
 }

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use axelar_wasm_std::nonempty;
 use cosmwasm_std::{Addr, Binary, DepsMut, Env, MessageInfo, Response, WasmMsg, WasmQuery};
 use error_stack::{Result, ResultExt};
-use router_api::{chain_name, ChainName};
+use router_api::ChainName;
 
 use crate::events::{ContractInstantiation, Event};
 use crate::msg::{DeploymentParams, ProverMsg, VerifierMsg};

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -292,15 +292,15 @@ pub fn instantiate_chain_contracts(
                 .add_event(Event::ContractsInstantiated {
                     gateway: ContractInstantiation {
                         address: gateway_address.clone(),
-                        code_id: params.gateway.code_id
+                        code_id: params.gateway.code_id,
                     },
                     voting_verifier: ContractInstantiation {
                         address: verifier_address,
-                        code_id: params.verifier.code_id
+                        code_id: params.verifier.code_id,
                     },
                     multisig_prover: ContractInstantiation {
                         address: multisig_prover_address.clone(),
-                        code_id: params.prover.code_id
+                        code_id: params.prover.code_id,
                     },
                     chain_name: params.prover.msg.chain_name,
                     deployment_name: deployment_name.clone(),

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 use axelar_wasm_std::nonempty;
 use cosmwasm_std::{Addr, Binary, DepsMut, Env, MessageInfo, Response, WasmMsg, WasmQuery};
 use error_stack::{Result, ResultExt};
-use router_api::ChainName;
+use router_api::{chain_name, ChainName};
 
-use crate::events::ContractInstantiated;
+use crate::events::{ContractInstantiation, Event};
 use crate::msg::{DeploymentParams, ProverMsg, VerifierMsg};
 use crate::state::{
     load_config, save_chain_contracts, save_deployed_contracts, save_prover_for_chain,
@@ -207,7 +207,7 @@ fn instantiate_prover(
             voting_verifier_address: verifier_address.to_string().clone(),
             signing_threshold: prover_msg.signing_threshold,
             service_name: prover_msg.service_name.to_string(),
-            chain_name: prover_msg.chain_name.clone(),
+            chain_name: prover_msg.chain_name.to_string(),
             verifier_set_diff_threshold: prover_msg.verifier_set_diff_threshold,
             encoder: prover_msg.encoder,
             key_type: prover_msg.key_type,
@@ -262,16 +262,11 @@ pub fn instantiate_chain_contracts(
                 &ctx,
                 params.gateway.label.clone(),
                 config.router.clone(),
-                verifier_address,
+                verifier_address.clone(),
             )
             .change_context(Error::InstantiateContracts)?;
 
-            response = response
-                .add_message(msg)
-                .add_event(ContractInstantiated::Gateway {
-                    address: gateway_address.clone(),
-                    code_id: params.gateway.code_id,
-                });
+            response = response.add_message(msg);
 
             let (msg, voting_verifier_address) = instantiate_verifier(
                 &ctx,
@@ -280,12 +275,7 @@ pub fn instantiate_chain_contracts(
                 &params.verifier.msg,
             )?;
 
-            response = response
-                .add_message(msg)
-                .add_event(ContractInstantiated::VotingVerifier {
-                    address: voting_verifier_address.clone(),
-                    code_id: params.verifier.code_id,
-                });
+            response = response.add_message(msg);
 
             let (msg, multisig_prover_address) = instantiate_prover(
                 &ctx,
@@ -299,9 +289,21 @@ pub fn instantiate_chain_contracts(
 
             response = response
                 .add_message(msg)
-                .add_event(ContractInstantiated::MultisigProver {
-                    address: multisig_prover_address.clone(),
-                    code_id: params.prover.code_id,
+                .add_event(Event::ContractsInstantiated {
+                    gateway: ContractInstantiation {
+                        address: gateway_address.clone(),
+                        code_id: params.gateway.code_id
+                    },
+                    voting_verifier: ContractInstantiation {
+                        address: verifier_address,
+                        code_id: params.verifier.code_id
+                    },
+                    multisig_prover: ContractInstantiation {
+                        address: multisig_prover_address.clone(),
+                        code_id: params.prover.code_id
+                    },
+                    chain_name: params.prover.msg.chain_name,
+                    deployment_name: deployment_name.clone(),
                 });
 
             save_deployed_contracts(
@@ -310,7 +312,7 @@ pub fn instantiate_chain_contracts(
                 ChainContracts {
                     gateway: gateway_address,
                     voting_verifier: voting_verifier_address,
-                    multisig_prover: multisig_prover_address.clone(),
+                    multisig_prover: multisig_prover_address,
                 },
             )
             .change_context(Error::InstantiateContracts)?;

--- a/contracts/coordinator/src/events.rs
+++ b/contracts/coordinator/src/events.rs
@@ -1,9 +1,21 @@
-use axelar_wasm_std::IntoEvent;
+use axelar_wasm_std::{nonempty, IntoEvent};
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
+use router_api::ChainName;
 
 #[derive(IntoEvent)]
-pub enum ContractInstantiated {
-    Gateway { address: Addr, code_id: u64 },
-    VotingVerifier { address: Addr, code_id: u64 },
-    MultisigProver { address: Addr, code_id: u64 },
+pub enum Event {
+    ContractsInstantiated {
+        gateway: ContractInstantiation,
+        voting_verifier: ContractInstantiation,
+        multisig_prover: ContractInstantiation,
+        chain_name: ChainName,
+        deployment_name: nonempty::String,
+    },
+}
+
+#[cw_serde]
+pub struct ContractInstantiation {
+    pub address: Addr,
+    pub code_id: u64,
 }

--- a/contracts/coordinator/src/lib.rs
+++ b/contracts/coordinator/src/lib.rs
@@ -1,7 +1,6 @@
 mod client;
 pub use client::Client;
-
 pub mod contract;
-mod events;
+pub mod events;
 pub mod msg;
 mod state;

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -84,7 +84,7 @@ pub struct ProverMsg {
     pub multisig_address: String,
     pub signing_threshold: MajorityThreshold,
     pub service_name: String,
-    pub chain_name: String,
+    pub chain_name: ChainName,
     pub verifier_set_diff_threshold: u32,
     pub encoder: Encoder,
     pub key_type: KeyType,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -32,6 +32,8 @@ cosmwasm-std = { workspace = true }
 cw-multi-test = { workspace = true, features = ["cosmwasm_1_2"] }
 error-stack = { workspace = true }
 ethers-core = { workspace = true }
+events = { workspace = true }
+events-derive = { workspace = true }
 gateway = { workspace = true }
 gateway-api = { workspace = true }
 goldie = { workspace = true }

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -8,6 +8,7 @@ use coordinator::events::ContractInstantiation;
 use coordinator::msg::{
     ContractDeploymentInfo, DeploymentParams, ManualDeploymentParams, ProverMsg, VerifierMsg,
 };
+use cosmwasm_std::testing::MockApi;
 use cosmwasm_std::{Binary, HexBinary};
 use cw_multi_test::AppResponse;
 use error_stack::Report;

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -49,12 +49,10 @@ struct ContractsInstantiated {
     _deployment_name: nonempty::String,
 }
 
-fn deserialize_json_attribute<'de, T, D>(
-    deserializer: D,
-) -> Result<T, D::Error>
+fn deserialize_json_attribute<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
-    T: DeserializeOwned
+    T: DeserializeOwned,
 {
     let json: String = Deserialize::deserialize(deserializer)?;
     serde_json::from_str::<T>(&json).map_err(D::Error::custom)

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -42,8 +42,8 @@ struct ContractsInstantiated {
     voting_verifier: ContractInstantiation,
     #[serde(deserialize_with = "deserialize_contract_instantiation")]
     multisig_prover: ContractInstantiation,
-    chain_name: ChainName,
-    deployment_name: nonempty::String,
+    _chain_name: ChainName,
+    _deployment_name: nonempty::String,
 }
 
 fn deserialize_contract_instantiation<'de, D>(

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -43,8 +43,6 @@ struct ContractsInstantiated {
     voting_verifier: ContractInstantiation,
     #[serde(deserialize_with = "deserialize_contract_instantiation")]
     multisig_prover: ContractInstantiation,
-    _chain_name: ChainName,
-    _deployment_name: nonempty::String,
 }
 
 fn deserialize_contract_instantiation<'de, D>(

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -43,6 +43,10 @@ struct ContractsInstantiated {
     voting_verifier: ContractInstantiation,
     #[serde(deserialize_with = "deserialize_contract_instantiation")]
     multisig_prover: ContractInstantiation,
+    #[serde(rename = "chain_name")]
+    _chain_name: ChainName,
+    #[serde(rename = "deployment_name")]
+    _deployment_name: nonempty::String,
 }
 
 fn deserialize_contract_instantiation<'de, D>(


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
