### PR TITLE
chore(ampd): add curl, wget, grpc to ampd

### DIFF
--- a/ampd/Dockerfile
+++ b/ampd/Dockerfile
@@ -24,7 +24,20 @@ COPY ./ampd/build.rs ./ampd/build.rs
 RUN cargo install --locked --path ./ampd
 
 FROM debian:bookworm-slim AS runner
-RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
+
+ARG GRPCURL_VERSION=1.9.3
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    wget \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz \
+    && tar -xvf grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz \
+    && mv grpcurl /usr/local/bin/grpcurl \
+    && chmod +x /usr/local/bin/grpcurl \
+    && rm grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz
 RUN addgroup --system --gid 1001 axelard && adduser --home /home/axelard --system --uid 1000 --ingroup axelard axelard
 WORKDIR /home/axelard
 RUN mkdir /.ampd && chown axelard /.ampd


### PR DESCRIPTION
## Description
- Added curl, wget, and grpcurl v1.9.3 into ampd's Dockerfile to enable better testing in the container.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
