### PR TITLE
fix(service-registry): remove internal verifier weight state from public interface

### DIFF
--- a/contracts/multisig-prover/src/test/test_utils.rs
+++ b/contracts/multisig-prover/src/test/test_utils.rs
@@ -1,11 +1,10 @@
-use axelar_wasm_std::VerificationStatus;
+use axelar_wasm_std::{nonempty, VerificationStatus};
 use cosmwasm_std::testing::MockApi;
 use cosmwasm_std::{from_json, to_json_binary, QuerierResult, Uint128, WasmQuery};
 use multisig::msg::Signer;
 use multisig::multisig::Multisig;
 use multisig::types::MultisigState;
 use multisig::verifier_set::VerifierSet;
-use service_registry::VERIFIER_WEIGHT;
 use service_registry_api::{AuthorizationState, BondingState, Verifier, WeightedVerifier};
 
 use super::test_data::{self, TestOperator};
@@ -159,7 +158,7 @@ fn service_registry_mock_querier_handler(
                         authorization_state: AuthorizationState::Authorized,
                         service_name: SERVICE_NAME.to_string(),
                     },
-                    weight: VERIFIER_WEIGHT,
+                    weight: nonempty::Uint128::one(),
                 })
                 .collect::<Vec<WeightedVerifier>>(),
         ),

--- a/contracts/multisig-prover/src/test/test_utils.rs
+++ b/contracts/multisig-prover/src/test/test_utils.rs
@@ -125,6 +125,7 @@ fn mock_multisig(operators: Vec<TestOperator>) -> Multisig {
     }
 }
 
+// TODO: this makes explicit assumptions about the weight distribution strategy of the service registry, it's probably better to change it into an integration test
 fn service_registry_mock_querier_handler(
     msg: service_registry_api::msg::QueryMsg,
     operators: Vec<TestOperator>,

--- a/contracts/service-registry/src/lib.rs
+++ b/contracts/service-registry/src/lib.rs
@@ -6,4 +6,3 @@ mod state;
 pub use service_registry_api::{
     AuthorizationState, BondingState, Service, Verifier, WeightedVerifier,
 };
-pub use state::VERIFIER_WEIGHT;

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -128,7 +128,7 @@ mod test {
     use multisig::test::common::{build_verifier_set, ecdsa_test_data};
     use router_api::{ChainName, CrossChainId, Message};
     use service_registry::{
-        AuthorizationState, BondingState, Verifier, WeightedVerifier, VERIFIER_WEIGHT,
+        AuthorizationState, BondingState, Verifier, WeightedVerifier,
     };
     use sha3::{Digest, Keccak256, Keccak512};
     use starknet_checked_felt::CheckedFelt;
@@ -215,7 +215,7 @@ mod test {
                         .into_iter()
                         .map(|v| WeightedVerifier {
                             verifier_info: v,
-                            weight: VERIFIER_WEIGHT,
+                            weight: nonempty::Uint128::one(),
                         })
                         .collect::<Vec<WeightedVerifier>>(),
                 )

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -175,6 +175,7 @@ mod test {
         verifiers
     }
 
+    // TODO: this makes explicit assumptions about the weight distribution strategy of the service registry, it's probably better to change it into an integration test
     fn setup(
         verifiers: Vec<Verifier>,
         msg_id_format: &MessageIdFormat,

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -127,9 +127,7 @@ mod test {
     use multisig::key::KeyType;
     use multisig::test::common::{build_verifier_set, ecdsa_test_data};
     use router_api::{ChainName, CrossChainId, Message};
-    use service_registry::{
-        AuthorizationState, BondingState, Verifier, WeightedVerifier,
-    };
+    use service_registry::{AuthorizationState, BondingState, Verifier, WeightedVerifier};
     use sha3::{Digest, Keccak256, Keccak512};
     use starknet_checked_felt::CheckedFelt;
 


### PR DESCRIPTION


## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
