### PR TITLE
feat(minor-router): add coordinator execute endpoint to router

### DIFF
--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -64,8 +64,8 @@ pub fn execute(
     match msg.ensure_permissions(
         deps.storage,
         &info.sender,
-        find_coordinator_address,
         find_gateway_address(&info.sender),
+        find_coordinator_address,
     )? {
         ExecuteMsg::RegisterChain {
             chain,
@@ -98,6 +98,14 @@ pub fn execute(
         )?),
         ExecuteMsg::DisableRouting => execute::disable_routing(deps.storage),
         ExecuteMsg::EnableRouting => execute::enable_routing(deps.storage),
+        ExecuteMsg::ExecuteFromCoordinator {
+            original_sender,
+            msg,
+        } => Ok(execute::execute_from_coordinator(
+            deps,
+            original_sender,
+            *msg,
+        )?),
     }?
     .then(Ok)
 }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1843,4 +1843,50 @@ mod test {
         .unwrap_err();
         goldie::assert!(err.to_string());
     }
+
+    #[test]
+    fn only_coordinator_executes_coordinator_endpoint_succeeds() {
+        let mut deps = setup();
+        let api = deps.api;
+
+        let polygon = make_chain("polygon");
+
+        assert!(execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&api.addr_make(COORDINATOR_ADDRESS), &[]),
+            ExecuteMsg::ExecuteFromCoordinator {
+                original_sender: api.addr_make(GOVERNANCE_ADDRESS),
+                msg: Box::new(router_api::msg::ExecuteMsg::RegisterChain {
+                    chain: polygon.chain_name.clone(),
+                    gateway_address: polygon.gateway.to_string().try_into().unwrap(),
+                    msg_id_format: axelar_wasm_std::msg_id::MessageIdFormat::HexTxHashAndEventIndex,
+                }),
+            },
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn only_coordinator_executes_coordinator_endpoint_fails() {
+        let mut deps = setup();
+        let api = deps.api;
+
+        let polygon = make_chain("polygon");
+
+        assert!(execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&api.addr_make(ADMIN_ADDRESS), &[]),
+            ExecuteMsg::ExecuteFromCoordinator {
+                original_sender: api.addr_make(GOVERNANCE_ADDRESS),
+                msg: Box::new(router_api::msg::ExecuteMsg::RegisterChain {
+                    chain: polygon.chain_name.clone(),
+                    gateway_address: polygon.gateway.to_string().try_into().unwrap(),
+                    msg_id_format: axelar_wasm_std::msg_id::MessageIdFormat::HexTxHashAndEventIndex,
+                }),
+            },
+        )
+        .is_err());
+    }
 }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1874,7 +1874,7 @@ mod test {
 
         let polygon = make_chain("polygon");
 
-        assert!(execute(
+        let res = execute(
             deps.as_mut(),
             mock_env(),
             message_info(&api.addr_make(ADMIN_ADDRESS), &[]),
@@ -1886,7 +1886,37 @@ mod test {
                     msg_id_format: axelar_wasm_std::msg_id::MessageIdFormat::HexTxHashAndEventIndex,
                 }),
             },
-        )
-        .is_err());
+        );
+
+        assert!(res.is_err());
+        assert!(res.unwrap_err().to_string().contains(
+            &permission_control::Error::AddressNotWhitelisted {
+                expected: vec![api.addr_make(COORDINATOR_ADDRESS)],
+                actual: api.addr_make(ADMIN_ADDRESS)
+            }
+            .to_string()
+        ));
+    }
+
+    #[test]
+    fn coordinator_endpoint_only_allows_register_msg() {
+        let mut deps = setup();
+        let api = deps.api;
+
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&api.addr_make(COORDINATOR_ADDRESS), &[]),
+            ExecuteMsg::ExecuteFromCoordinator {
+                original_sender: api.addr_make(GOVERNANCE_ADDRESS),
+                msg: Box::new(ExecuteMsg::EnableRouting {}),
+            },
+        );
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains(&Error::InvalidExecuteMsg.to_string()));
     }
 }

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -6,8 +6,7 @@ use axelar_wasm_std::flagset::FlagSet;
 use axelar_wasm_std::msg_id::{self, MessageIdFormat};
 use axelar_wasm_std::{address, killswitch};
 use cosmwasm_std::{
-    to_json_binary, Addr, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage,
-    WasmMsg,
+    to_json_binary, Addr, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage, WasmMsg,
 };
 use error_stack::{bail, ensure, report, Report, ResultExt};
 use itertools::Itertools;

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -4,9 +4,9 @@ use std::vec;
 use axelar_core_std::nexus;
 use axelar_wasm_std::flagset::FlagSet;
 use axelar_wasm_std::msg_id::{self, MessageIdFormat};
-use axelar_wasm_std::{address, killswitch, permission_control};
+use axelar_wasm_std::{address, killswitch};
 use cosmwasm_std::{
-    to_json_binary, Addr, Deps, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage,
+    to_json_binary, Addr, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage,
     WasmMsg,
 };
 use error_stack::{bail, ensure, report, Report, ResultExt};
@@ -262,39 +262,32 @@ pub fn route_messages(
         .add_events(msgs.into_iter().map(|msg| MessageRouted { msg })))
 }
 
-fn validate_sender_can_register_chains(deps: Deps, sender: Addr) -> error_stack::Result<(), Error> {
-    if !permission_control::sender_role(deps.storage, &sender)
-        .map_err(|_| report!(Error::StoreFailure))?
-        .contains(permission_control::Permission::Governance)
-    {
-        Err(report!(Error::Unauthorized))
-    } else {
-        Ok(())
-    }
-}
-
 pub fn execute_from_coordinator(
     deps: DepsMut,
     original_sender: Addr,
     msg: router_api::msg::ExecuteMsg,
 ) -> error_stack::Result<Response, Error> {
-    match msg {
+    match msg
+        .ensure_permissions(
+            deps.storage,
+            &original_sender,
+            crate::contract::find_gateway_address(&original_sender),
+            crate::contract::find_coordinator_address,
+        )
+        .change_context(Error::Unauthorized)?
+    {
         router_api::msg::ExecuteMsg::RegisterChain {
             chain,
             gateway_address,
-            msg_id_format,
-        } => {
-            validate_sender_can_register_chains(deps.as_ref(), original_sender)?;
-
-            register_chain(
-                deps.storage,
-                deps.querier,
-                chain,
-                address::validate_cosmwasm_address(deps.api, &gateway_address)
-                    .change_context(Error::InvalidAddress)?,
-                msg_id_format,
-            )
-        }
+            ref msg_id_format,
+        } => register_chain(
+            deps.storage,
+            deps.querier,
+            chain,
+            address::validate_cosmwasm_address(deps.api, &gateway_address)
+                .change_context(Error::InvalidAddress)?,
+            msg_id_format.clone(),
+        ),
         _ => Err(report!(Error::InvalidExecuteMsg)),
     }
 }

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -6,7 +6,8 @@ use axelar_wasm_std::flagset::FlagSet;
 use axelar_wasm_std::msg_id::{self, MessageIdFormat};
 use axelar_wasm_std::{address, killswitch, permission_control};
 use cosmwasm_std::{
-    to_json_binary, Addr, Deps, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage, WasmMsg
+    to_json_binary, Addr, Deps, DepsMut, Event, QuerierWrapper, Response, StdResult, Storage,
+    WasmMsg,
 };
 use error_stack::{bail, ensure, report, Report, ResultExt};
 use itertools::Itertools;
@@ -16,7 +17,7 @@ use router_api::{ChainEndpoint, ChainName, Gateway, GatewayDirection, Message};
 use crate::events::{
     ChainFrozen, ChainRegistered, ChainUnfrozen, GatewayInfo, GatewayUpgraded, MessageRouted,
 };
-use crate::state::{chain_endpoints, load_config, Config};
+use crate::state::{chain_endpoints, Config};
 use crate::{events, state};
 
 pub fn register_chain(
@@ -263,8 +264,9 @@ pub fn route_messages(
 
 fn validate_sender_can_register_chains(deps: Deps, sender: Addr) -> error_stack::Result<(), Error> {
     if !permission_control::sender_role(deps.storage, &sender)
-    .map_err(|_| report!(Error::StoreFailure))?
-    .contains(permission_control::Permission::Governance) {
+        .map_err(|_| report!(Error::StoreFailure))?
+        .contains(permission_control::Permission::Governance)
+    {
         Err(report!(Error::Unauthorized))
     } else {
         Ok(())
@@ -289,7 +291,7 @@ pub fn execute_from_coordinator(
                 deps.querier,
                 chain,
                 address::validate_cosmwasm_address(deps.api, &gateway_address)
-                .change_context(Error::InvalidAddress)?,
+                    .change_context(Error::InvalidAddress)?,
                 msg_id_format,
             )
         }

--- a/packages/router-api/src/error.rs
+++ b/packages/router-api/src/error.rs
@@ -52,4 +52,10 @@ pub enum Error {
 
     #[error("failed to query the nexus module")]
     Nexus,
+
+    #[error("execute message is invalid")]
+    InvalidExecuteMsg,
+
+    #[error("unauthorized")]
+    Unauthorized,
 }

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -51,7 +51,7 @@ pub enum ExecuteMsg {
     ExecuteFromCoordinator {
         original_sender: Addr,
         msg: Box<ExecuteMsg>,
-    }
+    },
 }
 
 #[cw_serde]

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use axelar_wasm_std::msg_id::MessageIdFormat;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
 use msgs_derive::EnsurePermissions;
 
 use crate::primitives::*;
@@ -10,7 +11,7 @@ use crate::primitives::*;
 #[derive(EnsurePermissions)]
 pub enum ExecuteMsg {
     /// Registers a new chain with the router
-    #[permission(Governance, Specific(coordinator))]
+    #[permission(Governance)]
     RegisterChain {
         chain: ChainName,
         gateway_address: Address,
@@ -45,6 +46,12 @@ pub enum ExecuteMsg {
     /// Called by an incoming gateway
     #[permission(Specific(gateway))]
     RouteMessages(Vec<Message>),
+
+    #[permission(Specific(coordinator))]
+    ExecuteFromCoordinator {
+        original_sender: Addr,
+        msg: Box<ExecuteMsg>,
+    }
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
