### PR TITLE
feat(minor-coordinator): coordinator can register chains with router

### DIFF
--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -102,6 +102,10 @@ pub fn execute(
             params,
         } => execute::instantiate_chain_contracts(deps, env, info, deployment_name, salt, *params)
             .change_context(Error::InstantiateChainContracts),
+        ExecuteMsg::RegisterDeployment { deployment_name } =>
+            execute::register_deployment(deps, info.sender, deployment_name.clone())
+            .change_context(Error::RegisterDeployment(deployment_name))
+        ,
     }?
     .then(Ok)
 }

--- a/contracts/coordinator/src/contract/errors.rs
+++ b/contracts/coordinator/src/contract/errors.rs
@@ -1,3 +1,4 @@
+use axelar_wasm_std::nonempty;
 use cosmwasm_std::Addr;
 use router_api::ChainName;
 
@@ -9,6 +10,8 @@ pub enum Error {
     RegisterProverContract(Addr),
     #[error("failed to register contracts for chain {0}")]
     RegisterChain(ChainName),
+    #[error("failed to register deployment {0} with router")]
+    RegisterDeployment(nonempty::String),
     #[error("failed to set the active verifier set for contract {0}")]
     SetActiveVerifiers(Addr),
     #[error("failed to instantiate chain contracts")]
@@ -46,4 +49,6 @@ pub enum Error {
     UnableToPersistProtocol,
     #[error("contract config before migration not found")]
     OldConfigNotFound,
+    #[error("chain name {0} is invalid")]
+    InvalidChainName(String),
 }

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 
 use axelar_wasm_std::nonempty;
-use cosmwasm_std::{Addr, Binary, DepsMut, Env, MessageInfo, Response, WasmMsg, WasmQuery};
-use error_stack::{Result, ResultExt};
-use router_api::ChainName;
+use cosmwasm_std::{to_json_binary, Addr, Binary, DepsMut, Env, MessageInfo, Response, WasmMsg, WasmQuery};
+use error_stack::{report, Result, ResultExt};
+use router_api::{chain_name, ChainName};
 
 use crate::contract::errors::Error;
 use crate::events::{ContractInstantiation, Event};
@@ -291,6 +291,9 @@ pub fn instantiate_chain_contracts(
                 ctx.deps.storage,
                 deployment_name,
                 ChainContracts {
+                    chain_name: ChainName::try_from(params.prover.msg.chain_name.clone())
+                        .change_context(Error::InvalidChainName(params.prover.msg.chain_name))?,
+                    msg_id_format: params.verifier.msg.msg_id_format,
                     gateway: gateway_address,
                     voting_verifier: voting_verifier_address,
                     multisig_prover: multisig_prover_address,
@@ -301,4 +304,33 @@ pub fn instantiate_chain_contracts(
     }
 
     Ok(response)
+}
+
+pub fn register_deployment(
+    deps: DepsMut,
+    sender: Addr,
+    deployment_name: nonempty::String,
+) -> Result<Response, Error> {
+    let deployed_contracts = state::deployed_contracts(deps.storage, deployment_name.clone())
+        .change_context(Error::ChainContractsInfo)?;
+
+    let protocol_contracts = state::protocol_contracts(deps.storage)
+    .change_context(Error::ProtocolNotRegistered)?;
+
+    Ok(Response::new().add_message(
+        WasmMsg::Execute { 
+            contract_addr: protocol_contracts.router.to_string(), 
+            msg: to_json_binary(&router_api::msg::ExecuteMsg::ExecuteFromCoordinator {
+                original_sender: sender,
+                msg: Box::new(router_api::msg::ExecuteMsg::RegisterChain {
+                    chain: deployed_contracts.chain_name,
+                    gateway_address: router_api::Address::try_from(deployed_contracts.gateway.to_string())
+                    .change_context(Error::ChainContractsInfo)?,
+                    msg_id_format: deployed_contracts.msg_id_format,
+                }),
+            })
+            .change_context(Error::UnableToPersistProtocol)?, 
+            funds: vec![] 
+        }
+    ))
 }

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -59,6 +59,11 @@ pub enum ExecuteMsg {
         // Such an error will be flagged by "cargo clippy..."
         params: Box<DeploymentParams>,
     },
+
+    #[permission(Any)]
+    RegisterDeployment {
+        deployment_name: nonempty::String,
+    }
 }
 
 #[cw_serde]

--- a/contracts/coordinator/src/state.rs
+++ b/contracts/coordinator/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use axelar_wasm_std::msg_id::MessageIdFormat;
 use axelar_wasm_std::nonempty;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Order, StdError, Storage};
@@ -39,7 +40,10 @@ pub enum Error {
     StateRemoveFailed,
 
     #[error("deployment name {0} is in use")]
-    DeploymentName(nonempty::String),
+    DeploymentNameInUse(nonempty::String),
+
+    #[error("deployment name {0} is not registered")]
+    DeploymentNameNotRegistered(nonempty::String),
 }
 
 #[cw_serde]
@@ -64,6 +68,8 @@ pub fn protocol_contracts(storage: &dyn Storage) -> Result<ProtocolContracts, St
 
 #[cw_serde]
 pub struct ChainContracts {
+    pub chain_name: ChainName,
+    pub msg_id_format: MessageIdFormat,
     pub gateway: Addr,
     pub voting_verifier: Addr,
     pub multisig_prover: Addr,
@@ -200,7 +206,7 @@ pub fn validate_deployment_name_availability(
         .change_context(Error::StateParseFailed)?;
 
     match deployments {
-        Some(_) => Err(report!(Error::DeploymentName(deployment_name))),
+        Some(_) => Err(report!(Error::DeploymentNameInUse(deployment_name))),
         None => Ok(()),
     }
 }
@@ -213,6 +219,16 @@ pub fn save_deployed_contracts(
     DEPLOYED_CHAINS
         .save(storage, deployment_name.to_string(), &contracts)
         .change_context(Error::PersistingState)
+}
+
+pub fn deployed_contracts(
+    storage: &dyn Storage,
+    deployment_name: nonempty::String,
+) -> Result<ChainContracts, Error> {
+    DEPLOYED_CHAINS
+        .may_load(storage, deployment_name.to_string())
+        .change_context(Error::StateParseFailed)?
+        .ok_or(report!(Error::DeploymentNameNotRegistered(deployment_name)))
 }
 
 // Legacy prover storage - maintained for backward compatibility


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
