### PR TITLE
fix(release): remove pat token for checkout

### DIFF
--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -67,7 +67,6 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
-          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -228,7 +227,6 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
-          token: ${{ secrets.AMPD_PROTO_REPO_ACCESS_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
- Remove the token for checkout by reverting this PR: https://github.com/axelarnetwork/axelar-amplifier/pull/783, since the repo is now public, token might not be required.