### PR TITLE
feat: macro for permissioning contracts to execute each other

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8550,6 +8550,7 @@ dependencies = [
  "itertools 0.14.0",
  "mockall 0.12.1",
  "msgs-derive",
+ "msgs-external-execute",
  "rand 0.8.5",
  "report",
  "router-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6229,6 +6229,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "msgs-external-execute"
+version = "1.0.0"
+dependencies = [
+ "axelar-wasm-std",
+ "cosmwasm-std",
+ "error-stack",
+ "itertools 0.14.0",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "msim-macros"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9c6636c399d5c60a1759f1670b1c07b3d408799a#9c6636c399d5c60a1759f1670b1c07b3d408799a"
@@ -8559,6 +8572,7 @@ dependencies = [
  "flagset",
  "hex",
  "msgs-derive",
+ "msgs-external-execute",
  "rand 0.8.5",
  "report",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ itertools = "0.14.0"
 k256 = { version = "0.13.1", features = ["ecdsa"] }
 mockall = "0.12.1"
 msgs-derive = { version = "^1.0.0", path = "packages/msgs-derive" }
+msgs-external-execute = { version = "^1.0.0", path = "packages/msgs-external-execute" }
 multisig = { version = "^2.1.0", path = "contracts/multisig" }
 multisig-prover = { version = "^1.1.1", path = "contracts/multisig-prover" }
 multisig-prover-api = { version = "1.0.0", path = "packages/multisig-prover-api" }

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -41,6 +41,7 @@ gateway-api = { workspace = true }
 itertools = { workspace = true }
 mockall = { workspace = true }
 msgs-derive = { workspace = true }
+msgs-external-execute = { workspace = true }
 report = { workspace = true }
 router-api = { workspace = true }
 semver = { workspace = true }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -12,8 +12,6 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state;
 use crate::state::{load_chain_by_gateway, load_config, Config};
 
-use msgs_external_execute::allow_external_execute;
-
 mod execute;
 mod migrations;
 mod query;
@@ -103,8 +101,8 @@ pub fn execute(
         ExecuteMsg::ExecuteFromCoordinator {
             original_sender,
             msg,
-        } => {
-            msg.route(
+        } => msg
+            .route(
                 deps,
                 env,
                 info,
@@ -112,8 +110,7 @@ pub fn execute(
                 execute,
                 router_api::msg::ExecuteMsg::execute_from_coordinator,
             )
-            .map_err(|_| Error::Unauthorized)
-        }
+            .map_err(|_| Error::Unauthorized),
     }?
     .then(Ok)
 }
@@ -141,20 +138,6 @@ fn find_coordinator_address(
     Ok(load_config(storage)
         .change_context(Error::CoordinatorNotFound)?
         .coordinator)
-}
-
-pub enum TestEnum {
-    One,
-    Two,
-}
-
-#[allow_external_execute]
-pub fn test(t: TestEnum) {
-    match t {
-        TestEnum::One => println!("ONE!"),
-        TestEnum::Two => println!("TWO!"),
-    }
-    println!("Test function");
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -1937,11 +1920,5 @@ mod test {
 
         assert!(res.is_err());
         // TODO: Test that error is correct type
-    }
-
-    #[test]
-    fn call_test() {
-        test_copy(TestEnum::One);
-        test(TestEnum::Two);
     }
 }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -109,7 +109,7 @@ pub fn execute(
                 env,
                 info,
                 original_sender, 
-                execute::execute_from_coordinator
+                execute,
             )
             .map_err(|_| Error::Unauthorized)
         }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -101,11 +101,14 @@ pub fn execute(
         ExecuteMsg::ExecuteFromCoordinator {
             original_sender,
             msg,
-        } => Ok(execute::execute_from_coordinator(
-            deps,
-            original_sender,
-            *msg,
-        )?),
+        } => {
+            msg.route(
+                deps, 
+                original_sender, 
+                execute::execute_from_coordinator
+            )
+            .map_err(|_| Error::Unauthorized)
+        }
     }?
     .then(Ok)
 }
@@ -1914,9 +1917,6 @@ mod test {
         );
 
         assert!(res.is_err());
-        assert!(res
-            .unwrap_err()
-            .to_string()
-            .contains(&Error::InvalidExecuteMsg.to_string()));
+        // TODO: Test that error is correct type
     }
 }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -108,8 +108,9 @@ pub fn execute(
                 deps,
                 env,
                 info,
-                original_sender, 
+                original_sender,
                 execute,
+                router_api::msg::ExecuteMsg::execute_from_coordinator,
             )
             .map_err(|_| Error::Unauthorized)
         }

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -3,11 +3,10 @@ use std::vec;
 
 use axelar_core_std::nexus;
 use axelar_wasm_std::flagset::FlagSet;
+use axelar_wasm_std::killswitch;
 use axelar_wasm_std::msg_id::{self, MessageIdFormat};
-use axelar_wasm_std::{address, killswitch};
 use cosmwasm_std::{
-    to_json_binary, Addr, DepsMut, Env, Event, MessageInfo, QuerierWrapper, Response, StdResult,
-    Storage, WasmMsg,
+    to_json_binary, Addr, Event, QuerierWrapper, Response, StdResult, Storage, WasmMsg,
 };
 use error_stack::{bail, ensure, report, Report, ResultExt};
 use itertools::Itertools;

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -6,7 +6,8 @@ use axelar_wasm_std::flagset::FlagSet;
 use axelar_wasm_std::msg_id::{self, MessageIdFormat};
 use axelar_wasm_std::{address, killswitch};
 use cosmwasm_std::{
-    to_json_binary, Addr, DepsMut, Env, Event, MessageInfo, QuerierWrapper, Response, StdResult, Storage, WasmMsg,
+    to_json_binary, Addr, DepsMut, Env, Event, MessageInfo, QuerierWrapper, Response, StdResult,
+    Storage, WasmMsg,
 };
 use error_stack::{bail, ensure, report, Report, ResultExt};
 use itertools::Itertools;

--- a/contracts/router/src/contract/execute.rs
+++ b/contracts/router/src/contract/execute.rs
@@ -261,23 +261,6 @@ pub fn route_messages(
         .add_events(msgs.into_iter().map(|msg| MessageRouted { msg })))
 }
 
-pub fn execute_from_coordinator(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    msg: router_api::msg::ExecuteMsg,
-) -> Result<Response, axelar_wasm_std::error::ContractError> {
-    match msg {
-        router_api::msg::ExecuteMsg::RegisterChain { .. } => crate::contract::execute (
-            deps,
-            env,
-            info,
-            msg
-        ),
-        _ => Err(Error::InvalidExecuteMsg.into()),
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;

--- a/packages/msgs-external-execute/Cargo.toml
+++ b/packages/msgs-external-execute/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "msgs-external-execute"
+version = "1.0.0"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+axelar-wasm-std = { workspace = true }
+cosmwasm-std = { workspace = true }
+error-stack = { workspace = true }
+itertools = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/msgs-external-execute/src/lib.rs
+++ b/packages/msgs-external-execute/src/lib.rs
@@ -1,0 +1,112 @@
+use cosmwasm_std::Response;
+use itertools::Itertools;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{punctuated::Punctuated, Data, DataEnum, DeriveInput, Expr, Ident, Path, Token};
+
+#[proc_macro_derive(ExternalExecute, attributes(permit))]
+pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    let ident = input.ident.clone();
+
+    match input.data.clone() {
+        Data::Enum(data) => build_implementation(ident, data),
+        _ => panic!("Only enums are supported"),
+    }
+}
+
+fn build_implementation(enum_type: Ident, data: DataEnum) -> TokenStream {
+    let route_function = build_route_implementation(data);
+
+    TokenStream::from(quote! {
+        impl #enum_type {
+            #route_function
+        }
+    })
+}
+
+fn build_route_implementation(data: DataEnum) -> proc_macro2::TokenStream {
+    let mut route_fn_tokens: Vec<(Ident, Vec<Path>)> = vec![];
+    let mut unique_args: Vec<Path> = vec![];
+
+    for v in data.variants {
+        println!("Variant: {:?}", v.ident.clone());
+        let variant = v.ident.clone();
+        for a in v.attrs.clone() {
+            if let syn::Meta::List(l) = a.clone().meta {
+                let attribute_name = l.path.segments.last().unwrap().ident.clone();
+                if attribute_name.to_string() != "permit" {
+                    continue;
+                }
+
+                println!("Last {:?}", l.path.segments.last().clone()); // permit
+
+                let argument = a
+                    .parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated)
+                    .expect("cannot parse arguments");
+
+                let mut permitted_contracts: Vec<Path> = argument
+                    .into_iter()
+                    .map(|arg| match arg {
+                        Expr::Path(path) => path.path.clone(),
+                        _ => panic!("expected a path"),
+                    })
+                    .collect();
+
+                route_fn_tokens.push((variant.clone(), permitted_contracts.clone()));
+                unique_args.append(&mut permitted_contracts.clone());
+            }
+        }
+    }
+
+    let unique_args: Vec<Path> = unique_args
+    .into_iter()
+    .unique()
+    .collect();
+
+    println!("Tokens: {:?}", route_fn_tokens.clone());
+    println!("Arguments: {:?}", unique_args);
+
+    let rm = route_match(route_fn_tokens);
+    let fs: Vec<_> = (0..unique_args.len()).map(|i| format_ident!("F{}", i)).collect();
+    let cs: Vec<_> = (0..unique_args.len()).map(|i| format_ident!("C{}", i)).collect();
+
+    proc_macro2::TokenStream::from(quote! {
+        pub fn route<#(#fs),*,#(#cs),*>(
+            &self,
+            deps: cosmwasm_std::DepsMut,
+            original_sender: Addr,
+            #(#unique_args: #fs),*
+        ) -> Result<cosmwasm_std::Response, axelar_wasm_std::permission_control::Error>
+            where #(#fs:FnOnce(cosmwasm_std::DepsMut, Addr, Self) -> error_stack::Result<cosmwasm_std::Response, #cs>),*,
+            #(#cs: error_stack::Context),*
+                {
+            #rm
+        }
+    })
+}
+
+fn route_match(routing_fns: Vec<(Ident, Vec<Path>)>) -> proc_macro2::TokenStream {
+    let (variants, routes): (Vec<_>, Vec<_>) = routing_fns.into_iter().unzip();
+    let sends = sends(routes.into_iter().flatten().collect());
+
+    proc_macro2::TokenStream::from(quote! {
+        match self {
+            #(#variants => {#sends}),*
+        }
+    })
+}
+
+fn sends(routes: Vec<Path>) -> proc_macro2::TokenStream {
+    proc_macro2::TokenStream::from(quote! {
+        #(
+            let res = #routes(deps, original_sender.clone(), self.clone());
+            if res.is_ok() {
+                return Ok(res.unwrap());
+            }
+        )*
+
+        Err(axelar_wasm_std::permission_control::Error::Unauthorized)
+    })
+}

--- a/packages/router-api/Cargo.toml
+++ b/packages/router-api/Cargo.toml
@@ -16,6 +16,7 @@ cw-storage-plus = { workspace = true }
 error-stack = { workspace = true }
 flagset = { version = "0.4.3", features = ["serde"] }
 msgs-derive = { workspace = true }
+msgs-external-execute = { workspace = true }
 report = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use axelar_wasm_std::msg_id::MessageIdFormat;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{Addr, Response};
 use msgs_derive::EnsurePermissions;
 use msgs_external_execute::ExternalExecute;
 

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -13,8 +13,8 @@ use crate::primitives::*;
 #[derive(EnsurePermissions, ExternalExecute)]
 pub enum ExecuteMsg {
     /// Registers a new chain with the router
-    #[permission(Governance)]
     #[permit(coordinator)]
+    #[permission(Governance)]
     RegisterChain {
         chain: ChainName,
         gateway_address: Address,

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -57,30 +57,6 @@ pub enum ExecuteMsg {
     },
 }
 
-impl ExecuteMsg {
-    pub fn execute_from_coordinator<F0>(
-        deps: DepsMut,
-        env: Env,
-        info: MessageInfo,
-        msg: ExecuteMsg,
-        exec: F0,
-    ) -> Result<Response, axelar_wasm_std::error::ContractError>
-    where
-        F0: FnOnce(
-            DepsMut,
-            Env,
-            MessageInfo,
-            Self,
-        )
-            -> Result<cosmwasm_std::Response, axelar_wasm_std::error::ContractError>,
-    {
-        match msg {
-            ExecuteMsg::RegisterChain { .. } => exec(deps, env, info, msg),
-            _ => Err(Error::InvalidExecuteMsg.into()),
-        }
-    }
-}
-
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -4,14 +4,16 @@ use axelar_wasm_std::msg_id::MessageIdFormat;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 use msgs_derive::EnsurePermissions;
+use msgs_external_execute::ExternalExecute;
 
 use crate::primitives::*;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(EnsurePermissions, ExternalExecute)]
 pub enum ExecuteMsg {
     /// Registers a new chain with the router
     #[permission(Governance)]
+    #[permit(coordinator)]
     RegisterChain {
         chain: ChainName,
         gateway_address: Address,


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes

Preliminary macro. It is functional, but could be optimized.