### PR TITLE
feat: create goldie-utils package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "error-stack",
  "gateway-api",
  "goldie",
+ "goldie-utils",
  "integration-tests",
  "itertools 0.14.0",
  "msgs-derive",
@@ -4241,6 +4242,14 @@ dependencies = [
  "serde_json",
  "upon",
  "yansi",
+]
+
+[[package]]
+name = "goldie-utils"
+version = "1.0.0"
+dependencies = [
+ "goldie",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ gateway = { version = "^1.1.1", path = "contracts/gateway" }
 gateway-api = { version = "^1.0.0", path = "packages/gateway-api" }
 gateway-event-stack = { git = "https://github.com/eigerco/solana-axelar.git", rev = "f167d2b" }
 goldie = { version = "0.5" }
+goldie-utils = { version = "^1.0.0", path = "packages/goldie-utils"}
 heck = "0.5.0"
 hex = "0.4.3"
 humantime-serde = "1.1.1"

--- a/packages/goldie-utils/Cargo.toml
+++ b/packages/goldie-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "goldie-utils"
+version = "1.0.0"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+goldie = { workspace = true }
+serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/goldie-utils/src/lib.rs
+++ b/packages/goldie-utils/src/lib.rs
@@ -1,0 +1,71 @@
+extern crate std;
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+#[doc(hidden)]
+pub fn __source_file(file: &str) -> PathBuf {
+    goldie::cargo_workspace_dir(env!("CARGO_MANIFEST_DIR")).join(file)
+}
+
+#[doc(hidden)]
+pub fn __assert_matches_golden_file(
+    actual: impl AsRef<str>,
+    source_file: impl AsRef<Path>,
+    function_path: impl AsRef<str>,
+) {
+    if let Err(err) = goldie::Goldie::new(source_file, function_path).assert(actual) {
+        ::std::panic!("{}", err);
+    }
+}
+
+#[doc(hidden)]
+pub fn __assert_matches_golden_file_json(
+    actual: impl Serialize,
+    source_file: impl AsRef<Path>,
+    function_path: impl AsRef<str>,
+) {
+    if let Err(err) = goldie::Goldie::new(source_file, function_path).assert_json(actual) {
+        ::std::panic!("{}", err);
+    }
+}
+
+#[macro_export]
+macro_rules! assert_matches_golden_file {
+    ($actual:expr) => {{
+        const fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            ::std::any::type_name::<T>()
+        }
+
+        // because f() will be defined inside the parent function, we can strip away the suffix to get the parent function name
+        let mut function_path = type_name_of(f).strip_suffix("::f").unwrap_or("");
+        while let Some(rest) = function_path.strip_suffix("::{{closure}}") {
+            function_path = rest;
+        }
+
+        let source_file = $crate::__source_file(file!());
+        $crate::__assert_matches_golden_file($actual, source_file, function_path);
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_matches_golden_file_json {
+    ($actual:expr) => {{
+        const fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            ::std::any::type_name::<T>()
+        }
+
+        // because f() will be defined inside the parent function, we can strip away the suffix to get the parent function name
+        let mut function_path = type_name_of(f).strip_suffix("::f").unwrap_or("");
+        while let Some(rest) = function_path.strip_suffix("::{{closure}}") {
+            function_path = rest;
+        }
+
+        let source_file = $crate::__source_file(file!());
+        $crate::__assert_matches_golden_file_json($actual, source_file, function_path);
+    }};
+}


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
