### PR TITLE
chore(ampd-sdk): add support for tonic status codes

### DIFF
--- a/packages/ampd-sdk/src/event/event_handler.rs
+++ b/packages/ampd-sdk/src/event/event_handler.rs
@@ -234,7 +234,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::grpc::client::{Error as ClientError, MockClient};
+    use crate::grpc::client::MockClient;
+    use crate::grpc::error::Error as ClientError;
 
     fn setup_handler() -> MockEventHandler {
         let mut handler = MockEventHandler::new();

--- a/packages/ampd-sdk/src/grpc/error.rs
+++ b/packages/ampd-sdk/src/grpc/error.rs
@@ -1,0 +1,123 @@
+use report::ResultExt;
+use thiserror::Error;
+use tonic::Code;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to connect to the grpc endpoint")]
+    GrpcConnection(#[from] tonic::transport::Error),
+
+    #[error("invalid argument provided: {0}")]
+    InvalidArgument(String),
+
+    #[error("client cannot keep up with the event stream: {0}")]
+    DataLoss(String),
+
+    #[error("internal server error: {0}")]
+    InternalError(String),
+
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
+
+    #[error("operation failed: {0}")]
+    OperationFailed(String),
+
+    #[error("unknown gRPC error: {0}")]
+    UnknownGrpcError(String),
+
+    #[error("failed to convert event")]
+    EventConversion,
+
+    #[error("invalid {0} address")]
+    InvalidAddress(&'static str),
+
+    #[error("missing event in response")]
+    InvalidResponse,
+
+    #[error("query response is not valid json")]
+    InvalidJson,
+
+    #[error("invalid contracts response")]
+    InvalidContractsResponse,
+
+    #[error("invalid byte array")]
+    InvalidByteArray,
+}
+
+impl From<tonic::Status> for Error {
+    fn from(status: tonic::Status) -> Self {
+        let message = status.message().to_string();
+        match status.code() {
+            Code::InvalidArgument => Error::InvalidArgument(message),
+            Code::DataLoss => Error::DataLoss(message),
+            Code::Internal => Error::InternalError(message),
+            Code::Unavailable => Error::ServiceUnavailable(message),
+            Code::Unknown => Error::OperationFailed(message),
+            _ => Error::UnknownGrpcError(format!("{}: {}", status.code(), message)),
+        }
+    }
+}
+
+impl Error {
+    pub fn grpc_code(&self) -> Option<Code> {
+        match self {
+            Error::InvalidArgument(_) => Some(Code::InvalidArgument),
+            Error::DataLoss(_) => Some(Code::DataLoss),
+            Error::InternalError(_) => Some(Code::Internal),
+            Error::ServiceUnavailable(_) => Some(Code::Unavailable),
+            Error::OperationFailed(_) => Some(Code::Unknown),
+            _ => None,
+        }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Error::DataLoss(_) | Error::ServiceUnavailable(_) | Error::InternalError(_)
+        )
+    }
+
+    pub fn is_client_error(&self) -> bool {
+        matches!(
+            self,
+            Error::InvalidArgument(_)
+                | Error::InvalidAddress(_)
+                | Error::InvalidJson
+                | Error::InvalidByteArray
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_conversion() {
+        let status = tonic::Status::invalid_argument("Invalid filter");
+        let error = Error::from(status);
+        assert!(matches!(error, Error::InvalidArgument(_)));
+        assert!(error.is_client_error());
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn test_grpc_code_mapping() {
+        let error = Error::InvalidArgument("test_error".to_string());
+        assert_eq!(error.grpc_code(), Some(Code::InvalidArgument));
+
+        let error = Error::DataLoss("test_error".to_string());
+        assert_eq!(error.grpc_code(), Some(Code::DataLoss));
+    }
+
+    #[test]
+    fn test_error_categorization() {
+        assert!(Error::DataLoss("test".to_string()).is_retryable());
+        assert!(Error::ServiceUnavailable("test_error".to_string()).is_retryable());
+        assert!(!Error::InvalidArgument("test_error".to_string()).is_retryable());
+
+        assert!(Error::InvalidArgument("test_error".to_string()).is_client_error());
+        assert!(Error::InvalidJson.is_client_error());
+        assert!(!Error::InternalError("test_error".to_string()).is_client_error());
+    }
+}

--- a/packages/ampd-sdk/src/grpc/mod.rs
+++ b/packages/ampd-sdk/src/grpc/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod error;


### PR DESCRIPTION
## Description
AXE-9549

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
