### PR TITLE
refactor(service-registery): enforce max number of verifiers

### DIFF
--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -33,6 +33,10 @@ pub enum ContractError {
     NoFundsToBond,
     #[error("not enough verifiers")]
     NotEnoughVerifiers,
+    #[error("max verifiers limit {0} exceeded by {1} verifiers")]
+    MaxVerifiersExceeded(u16, u16),
+    #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
+    MaxVerifiersSetBelowCurrent(u16, u16),
     #[error("verifier is jailed")]
     VerifierJailed,
     #[error("failed to unbond verifier")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -41,6 +41,8 @@ pub enum ContractError {
     VerifierJailed,
     #[error("failed to unbond verifier")]
     FailedToUnbondVerifier,
+    #[error("too many verifiers")]
+    TooManyVerifiers,
 
     // Generic error to wrap cw_storage_plus errors
     // This should only be used for things that shouldn't happen, such as encountering


### PR DESCRIPTION
## Description
[AXE-9631]
prevent AuthorizeVerifiers if that exceeds the allowable number of verifiers
prevent UpdateService if a new lower max is set and that is below the current number of authorized verifiers
added a helper function count_authorized_verifiers
use type conversion u32 -> u16 when counting current authorized verifiers 

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes


[AXE-9631]: https://axelarnetwork.atlassian.net/browse/AXE-9631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ