### PR TITLE
feat(service-registry): enforce max verifier set limit in service registry

### DIFF
--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -262,7 +262,7 @@ mod test {
                 .expect("Failed to get authorized verifier count");
 
         let actual_count = crate::state::VERIFIERS
-            .prefix(&service_name.to_string()) 
+            .prefix(&service_name.to_string())
             .range(&deps.storage, None, None, cosmwasm_std::Order::Ascending)
             .filter_map(|item| item.ok().map(|(_, verifier)| verifier))
             .filter(|verifier| verifier.authorization_state == AuthorizationState::Authorized)

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -2860,7 +2860,6 @@ mod test {
         );
         assert!(res.is_ok());
 
-        // First batch: authorize 3 verifiers
         let verifiers_1 = vec![
             api.addr_make("verifier1").to_string(),
             api.addr_make("verifier2").to_string(),
@@ -2878,7 +2877,6 @@ mod test {
         );
         assert!(res.is_ok());
 
-        // Second batch: try to authorize 2 more verifiers (should fail as it would exceed max)
         let verifiers_2 = vec![
             api.addr_make("verifier4").to_string(),
             api.addr_make("verifier5").to_string(),
@@ -2901,7 +2899,6 @@ mod test {
             ContractError::VerifierLimitExceed(4, 1)
         ));
 
-        // Third batch: authorize 1 more verifier  -> 4 verifiers authorized -> should success
         let verifier_3 = vec![api.addr_make("verifier4").to_string()];
         let res = execute(
             deps.as_mut(),
@@ -2940,7 +2937,6 @@ mod test {
         );
         assert!(res.is_ok());
 
-        // Authorize 3 verifiers
         let verifiers = vec![
             api.addr_make("verifier1").to_string(),
             api.addr_make("verifier2").to_string(),
@@ -2958,7 +2954,6 @@ mod test {
         );
         assert!(res.is_ok());
 
-        // Try to update max verifiers to 2 -> should fail
         let res = execute(
             deps.as_mut(),
             mock_env(),
@@ -2981,7 +2976,6 @@ mod test {
             ContractError::MaxVerifiersSetBelowCurrent(2, 3)
         ));
 
-        // update to 4 -> should succed
         let res = execute(
             deps.as_mut(),
             mock_env(),

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -352,7 +352,7 @@ mod test {
         Vec<String>,
     ) {
         let mut deps = setup();
-        let api = deps.api.clone();
+        let api = deps.api;
         let service_name = "validators";
 
         // Register service
@@ -393,7 +393,7 @@ mod test {
             },
         )
         .expect("Failed to authorize verifiers");
-        check_authorized_verifier_count(&deps, &service_name.into(), 5);
+        check_authorized_verifier_count(&deps, &service_name.to_string(), 5);
 
         (deps, api, service_name.into(), verifiers)
     }
@@ -3023,14 +3023,14 @@ mod test {
         );
         assert!(res.is_ok());
 
-        check_authorized_verifier_count(&deps, &service_name.into(), 0);
+        check_authorized_verifier_count(&deps, &service_name.to_string(), 0);
     }
 
     #[test]
     fn re_authorizing_same_verifiers_does_not_increase_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5();
 
-        check_authorized_verifier_count(&deps, &service_name.clone().into(), 5);
+        check_authorized_verifier_count(&deps, &service_name.clone(), 5);
         let res = execute(
             deps.as_mut(),
             mock_env(),
@@ -3040,11 +3040,11 @@ mod test {
                     api.addr_make("verifier1").to_string(),
                     api.addr_make("verifier2").to_string(),
                 ],
-                service_name: service_name.clone().into(),
+                service_name: service_name.clone(),
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name.into(), 5);
+        check_authorized_verifier_count(&deps, &service_name, 5);
     }
     #[test]
     fn unauthorize_verifiers_reduces_count() {
@@ -3063,7 +3063,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name.into(), 3);
+        check_authorized_verifier_count(&deps, &service_name, 3);
     }
     #[test]
     fn jailing_and_unjailing_affects_authorized_count() {
@@ -3093,7 +3093,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name.into(), 5);
+        check_authorized_verifier_count(&deps, &service_name, 5);
     }
     #[test]
     fn jailing_from_none_does_not_affect_count() {
@@ -3110,7 +3110,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name.into(), 5);
+        check_authorized_verifier_count(&deps, &service_name, 5);
     }
     #[test]
     fn jailing_unauthorized_verifier_does_not_affect_authorized_count() {
@@ -3128,6 +3128,6 @@ mod test {
         );
         assert!(res.is_ok());
 
-        check_authorized_verifier_count(&deps, &service_name.into(), 5);
+        check_authorized_verifier_count(&deps, &service_name, 5);
     }
 }

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -2896,7 +2896,7 @@ mod test {
         assert!(err_contains!(
             err.report,
             ContractError,
-            ContractError::VerifierLimitExceed(4, 1)
+            ContractError::VerifierLimitExceed
         ));
 
         let verifier_3 = vec![api.addr_make("verifier4").to_string()];

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -262,7 +262,7 @@ mod test {
                 .expect("Failed to get authorized verifier count");
 
         let actual_count = crate::state::VERIFIERS
-            .prefix(&service_name.to_string()) // No need to convert to string again
+            .prefix(&service_name.to_string()) 
             .range(&deps.storage, None, None, cosmwasm_std::Order::Ascending)
             .filter_map(|item| item.ok().map(|(_, verifier)| verifier))
             .filter(|verifier| verifier.authorization_state == AuthorizationState::Authorized)
@@ -393,8 +393,6 @@ mod test {
             },
         )
         .expect("Failed to authorize verifiers");
-
-        // Verify count is correct
         check_authorized_verifier_count(&deps, &service_name.into(), 5);
 
         (deps, api, service_name.into(), verifiers)
@@ -2839,7 +2837,7 @@ mod test {
         assert_eq!(expected_chains, actual_chains);
     }
     #[test]
-    fn max_verifiers_limit_is_enforced_when_authroized_verifiers() {
+    fn max_verifiers_limit_is_enforced_when_authorized_verifiers() {
         let mut deps = setup();
         let api = deps.api;
 

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -252,6 +252,7 @@ mod test {
 
         deps
     }
+
     fn check_authorized_verifier_count(
         deps: &OwnedDeps<MockStorage, MockApi, MockQuerier, Empty>,
         service_name: &String,
@@ -395,6 +396,7 @@ mod test {
 
         (deps, api, service_name.into(), verifiers)
     }
+
     #[test]
     fn register_service() {
         let mut deps = setup();
@@ -2834,6 +2836,7 @@ mod test {
             verifier_details.supported_chains.into_iter().collect();
         assert_eq!(expected_chains, actual_chains);
     }
+
     #[test]
     fn max_verifiers_limit_is_enforced_when_authorized_verifiers() {
         let mut deps = setup();
@@ -2992,6 +2995,7 @@ mod test {
         );
         assert!(res.is_ok());
     }
+
     #[test]
     fn register_service_initializes_with_zero_authorized_verifiers() {
         let mut deps = setup();
@@ -3058,7 +3062,7 @@ mod test {
         check_authorized_verifier_count(&deps, &service_name, 3);
     }
     #[test]
-    fn jailing_and_unjailing_affects_authorized_count() {
+    fn jailing_and_unjailing_authorized_verifier_affects_authorized_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();
 
         let res = execute(
@@ -3085,6 +3089,7 @@ mod test {
         assert!(res.is_ok());
         check_authorized_verifier_count(&deps, &service_name, 5);
     }
+
     #[test]
     fn jailing_from_none_does_not_affect_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();
@@ -3102,6 +3107,7 @@ mod test {
         assert!(res.is_ok());
         check_authorized_verifier_count(&deps, &service_name, 5);
     }
+
     #[test]
     fn jailing_unauthorized_verifier_does_not_affect_authorized_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();
@@ -3117,7 +3123,6 @@ mod test {
             },
         );
         assert!(res.is_ok());
-
         check_authorized_verifier_count(&deps, &service_name, 5);
     }
 }

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -253,7 +253,7 @@ mod test {
         deps
     }
 
-    fn check_authorized_verifier_count(
+    fn assert_authorized_counter_is_valid(
         deps: &OwnedDeps<MockStorage, MockApi, MockQuerier, Empty>,
         service_name: &String,
         expected: u16,
@@ -268,6 +268,7 @@ mod test {
             .filter_map(|item| item.ok().map(|(_, verifier)| verifier))
             .filter(|verifier| verifier.authorization_state == AuthorizationState::Authorized)
             .count();
+
         let actual_count = u16::try_from(actual_count).expect("actual count should fit in u16");
 
         assert_eq!(
@@ -392,7 +393,7 @@ mod test {
         );
         assert!(res.is_ok());
 
-        check_authorized_verifier_count(&deps, &service_name.to_string(), 5);
+        assert_authorized_counter_is_valid(&deps, &service_name.to_string(), 5);
 
         (deps, api, service_name.into(), verifiers)
     }
@@ -2899,7 +2900,7 @@ mod test {
         assert!(err_contains!(
             err.report,
             ContractError,
-            ContractError::VerifierLimitExceed
+            ContractError::VerifierLimitExceeded
         ));
 
         let verifier_3 = vec![api.addr_make("verifier4").to_string()];
@@ -3019,14 +3020,14 @@ mod test {
         );
         assert!(res.is_ok());
 
-        check_authorized_verifier_count(&deps, &service_name.to_string(), 0);
+        assert_authorized_counter_is_valid(&deps, &service_name.to_string(), 0);
     }
 
     #[test]
     fn re_authorizing_same_verifiers_does_not_increase_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();
 
-        check_authorized_verifier_count(&deps, &service_name.clone(), 5);
+        assert_authorized_counter_is_valid(&deps, &service_name.clone(), 5);
         let res = execute(
             deps.as_mut(),
             mock_env(),
@@ -3040,7 +3041,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name, 5);
+        assert_authorized_counter_is_valid(&deps, &service_name, 5);
     }
 
     #[test]
@@ -3060,7 +3061,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name, 3);
+        assert_authorized_counter_is_valid(&deps, &service_name, 3);
     }
 
     #[test]
@@ -3077,7 +3078,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name.clone(), 4);
+        assert_authorized_counter_is_valid(&deps, &service_name.clone(), 4);
 
         let res = execute(
             deps.as_mut(),
@@ -3089,7 +3090,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name, 5);
+        assert_authorized_counter_is_valid(&deps, &service_name, 5);
     }
 
     #[test]
@@ -3107,7 +3108,7 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name, 5);
+        assert_authorized_counter_is_valid(&deps, &service_name, 5);
     }
 
     #[test]
@@ -3125,6 +3126,6 @@ mod test {
             },
         );
         assert!(res.is_ok());
-        check_authorized_verifier_count(&deps, &service_name, 5);
+        assert_authorized_counter_is_valid(&deps, &service_name, 5);
     }
 }

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -3042,6 +3042,7 @@ mod test {
         assert!(res.is_ok());
         check_authorized_verifier_count(&deps, &service_name, 5);
     }
+
     #[test]
     fn unauthorize_verifiers_reduces_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();
@@ -3061,6 +3062,7 @@ mod test {
         assert!(res.is_ok());
         check_authorized_verifier_count(&deps, &service_name, 3);
     }
+
     #[test]
     fn jailing_and_unjailing_authorized_verifier_affects_authorized_count() {
         let (mut deps, api, service_name, _verifiers) = setup_and_authorize_5_verifiers();

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -2895,6 +2895,7 @@ mod test {
                 service_name: service_name.into(),
             },
         );
+
         let err = res.unwrap_err();
 
         assert!(err_contains!(
@@ -2902,18 +2903,6 @@ mod test {
             ContractError,
             ContractError::VerifierLimitExceeded
         ));
-
-        let verifier_3 = vec![api.addr_make("verifier4").to_string()];
-        let res = execute(
-            deps.as_mut(),
-            mock_env(),
-            message_info(&api.addr_make(GOVERNANCE_ADDRESS), &[]),
-            ExecuteMsg::AuthorizeVerifiers {
-                verifiers: verifier_3.clone(),
-                service_name: service_name.into(),
-            },
-        );
-        assert!(res.is_ok());
     }
 
     #[test]

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -34,7 +34,7 @@ pub fn register_service(
             description,
         },
     )?;
-    
+
     Ok(Response::new())
 }
 

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -34,6 +34,7 @@ pub fn register_service(
             description,
         },
     )?;
+    
     Ok(Response::new())
 }
 

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -34,7 +34,7 @@ pub fn register_service(
             description,
         },
     )?;
-    state::save_service_in_authroized_verifiers_count(deps.storage, &service_name)?;
+    state::save_servicename_in_counter(deps.storage, &service_name)?;
     Ok(Response::new())
 }
 fn validate_max_verifiers_not_exceed(

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -8,7 +8,7 @@ use super::*;
 use crate::events::Event;
 use crate::state::{
     self, save_new_service, update_count_based_on_state_transition, ServiceParamsOverride,
-    UpdatedServiceParams, VerifierCountOperation,
+    UpdatedServiceParams,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -25,7 +25,7 @@ pub fn register_service(
 ) -> Result<Response, ContractError> {
     save_new_service(
         deps.storage,
-        &service_name.clone(),
+        &service_name,
         Service {
             name: service_name.clone(),
             coordinator_contract,
@@ -77,15 +77,18 @@ pub fn update_verifier_authorization_status(
     if auth_state == AuthorizationState::Authorized {
         ensure_authorization_max_limit_respected(&deps, &service_name, &verifiers)?;
     }
+
     for verifier in verifiers {
         let previous_auth_state =
             state::get_verifier_auth_state(deps.storage, &service_name, &verifier)?;
+
         state::update_verifier_auth_state(
             deps.storage,
             &service_name,
             &verifier,
             auth_state.clone(),
         )?;
+
         update_count_based_on_state_transition(
             deps.storage,
             &service_name,

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -6,7 +6,7 @@ use state::VERIFIERS;
 
 use super::*;
 use crate::events::Event;
-use crate::state::{self, save_new_service, ServiceParamsOverride, UpdatedServiceParams};
+use crate::state::{self, ServiceParamsOverride, UpdatedServiceParams};
 
 #[allow(clippy::too_many_arguments)]
 pub fn register_service(
@@ -20,7 +20,7 @@ pub fn register_service(
     unbonding_period_days: u16,
     description: String,
 ) -> Result<Response, ContractError> {
-    save_new_service(
+    state::save_new_service(
         deps.storage,
         &service_name,
         Service {
@@ -47,9 +47,9 @@ pub fn update_verifier_authorization_status(
 
     state::update_verifier_authorization_status(
         deps.storage,
-        &service_name,
-        &auth_state,
-        &verifiers,
+        service_name.clone(),
+        auth_state.clone(),
+        verifiers,
     )?;
 
     if auth_state == AuthorizationState::Authorized {

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -103,7 +103,7 @@ fn update_count_based_on_state_transition(
     auth_state: &AuthorizationState,
     old_state: Option<AuthorizationState>,
 ) -> Result<(), ContractError> {
-    Ok(match (old_state, auth_state.clone()) {
+    match (old_state, auth_state.clone()) {
         (Some(old), new) => match (old, new) {
             (AuthorizationState::Authorized, AuthorizationState::NotAuthorized)
             | (AuthorizationState::Authorized, AuthorizationState::Jailed) => {
@@ -119,7 +119,8 @@ fn update_count_based_on_state_transition(
             state::update_authorized_count(storage, service_name, CountOperation::Increment)?;
         }
         _ => {}
-    })
+    };
+    Ok(())
 }
 
 pub fn update_service(

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -45,9 +45,12 @@ pub fn update_verifier_authorization_status(
 ) -> Result<Response, ContractError> {
     ensure_service_exists(deps.storage, &service_name)?;
 
-    for verifier in verifiers {
-        state::update_verifier_status(deps.storage, &service_name, &auth_state, verifier)?;
-    }
+    state::update_verifier_authorization_status(
+        deps.storage,
+        &service_name,
+        &auth_state,
+        &verifiers,
+    )?;
 
     if auth_state == AuthorizationState::Authorized {
         ensure_authorization_max_limit_respected(deps.storage, &service_name)?;

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -6,10 +6,7 @@ use state::VERIFIERS;
 
 use super::*;
 use crate::events::Event;
-use crate::state::{
-    self, save_new_service, ServiceParamsOverride,
-    UpdatedServiceParams,
-};
+use crate::state::{self, save_new_service, ServiceParamsOverride, UpdatedServiceParams};
 
 #[allow(clippy::too_many_arguments)]
 pub fn register_service(
@@ -58,8 +55,6 @@ pub fn update_verifier_authorization_status(
 
     Ok(Response::new())
 }
-
-
 
 pub fn update_service(
     deps: DepsMut,

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -22,9 +22,9 @@ pub fn register_service(
 ) -> Result<Response, ContractError> {
     state::save_new_service(
         deps.storage,
-        &service_name,
+        &service_name.clone(),
         Service {
-            name: service_name.clone(),
+            name: service_name,
             coordinator_contract,
             min_num_verifiers,
             max_num_verifiers,

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -238,8 +238,10 @@ pub fn update_verifier_authorization_status(
                             let old_state = Some(verifier.authorization_state.clone());
                             let operation =
                                 determine_auth_verifier_count_operation(&old_state, &auth_state);
-                            auth_verifiers_diff_counter =
-                                apply_operation_to_diff_counter(auth_verifiers_diff_counter, operation)?;
+                            auth_verifiers_diff_counter = apply_operation_to_diff_counter(
+                                auth_verifiers_diff_counter,
+                                operation,
+                            )?;
                             verifier.authorization_state = auth_state.clone();
                             Ok(verifier)
                         }
@@ -247,8 +249,10 @@ pub fn update_verifier_authorization_status(
                         None => {
                             let operation =
                                 determine_auth_verifier_count_operation(&None, &auth_state);
-                            auth_verifiers_diff_counter =
-                                apply_operation_to_diff_counter(auth_verifiers_diff_counter, operation)?;
+                            auth_verifiers_diff_counter = apply_operation_to_diff_counter(
+                                auth_verifiers_diff_counter,
+                                operation,
+                            )?;
                             Ok(Verifier {
                                 address: verifier_addr.clone(),
                                 bonding_state: BondingState::Unbonded,
@@ -401,17 +405,13 @@ fn apply_operation_to_diff_counter(
     operation: Option<VerifierCountOperation>,
 ) -> Result<i16, ContractError> {
     match operation {
-        Some(VerifierCountOperation::Increment) => {
-            current
-                .checked_add(1)
-                .ok_or(ContractError::AuthorizedVerifiersIntegerOverflow)
-        }
-        Some(VerifierCountOperation::Decrement) => {
-            Ok(current
-                .checked_sub(1)
-                .expect("authorized verifiers count should not underflow"))
-        }
-        None => Ok(current), 
+        Some(VerifierCountOperation::Increment) => current
+            .checked_add(1)
+            .ok_or(ContractError::AuthorizedVerifiersIntegerOverflow),
+        Some(VerifierCountOperation::Decrement) => Ok(current
+            .checked_sub(1)
+            .expect("authorized verifiers count should not underflow")),
+        None => Ok(current),
     }
 }
 
@@ -444,8 +444,6 @@ fn update_authorized_count_by_diff(
         .change_context(ContractError::StorageError)?;
     Ok(())
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -1285,8 +1285,11 @@ mod tests {
             let mut current = 5i32;
             let initial_value = current;
 
-            let result =
-                update_auth_verifier_count_change_tracker(&mut current, &previous_state, &new_state);
+            let result = update_auth_verifier_count_change_tracker(
+                &mut current,
+                &previous_state,
+                &new_state,
+            );
 
             assert!(result.is_ok(), "Test failed for: {}", description);
             assert_eq!(

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -231,7 +231,8 @@ pub fn update_verifier_authorization_status(
                     let previous_state = existing_verifier
                         .as_ref()
                         .map(|verifier| verifier.authorization_state.clone());
-                    update_auth_verifier_count_change(
+
+                    update_auth_verifier_count_change_tracker(
                         &mut authorized_count_change,
                         &previous_state,
                         auth_state,
@@ -376,7 +377,7 @@ pub fn deregister_chains_support(
     Ok(())
 }
 
-fn update_auth_verifier_count_change(
+fn update_auth_verifier_count_change_tracker(
     current: &mut i32,
     previous_state: &Option<AuthorizationState>,
     auth_state: &AuthorizationState,
@@ -1183,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_authorized_verifier_count_operation() {
+    fn test_update_verifier_authroization_status_succeed() {
         let mut deps = mock_dependencies();
         let service = save_mock_service(deps.as_mut().storage);
         let count = number_of_authorized_verifiers(deps.as_ref().storage, &service.name).unwrap();
@@ -1251,7 +1252,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_auth_verifier_count_change() {
+    fn test_update_auth_verifier_count_change_succeed() {
         let test_cases = vec![
             // (previous_state, new_state, expected_change, description)
             (
@@ -1285,7 +1286,7 @@ mod tests {
             let initial_value = current;
 
             let result =
-                update_auth_verifier_count_change(&mut current, &previous_state, &new_state);
+                update_auth_verifier_count_change_tracker(&mut current, &previous_state, &new_state);
 
             assert!(result.is_ok(), "Test failed for: {}", description);
             assert_eq!(
@@ -1300,7 +1301,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_authorized_count_change() {
+    fn test_apply_authorized_count_change_should_suceed() {
         let mut deps = mock_dependencies();
         let service = save_mock_service(deps.as_mut().storage);
 
@@ -1328,7 +1329,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_authorized_count_change_overflow() {
+    fn test_apply_authorized_count_change_should_fail_when_overflow() {
         let mut deps = mock_dependencies();
         let service = save_mock_service(deps.as_mut().storage);
 

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -208,7 +208,7 @@ pub fn count_verifiers_updated_to_authorized(
             _ => {}
         }
     }
-    u16::try_from(count).change_context(ContractError::AuthorizedVerifiersExceedu16)
+    Ok(count)
 }
 
 pub fn increment_authorized_count(

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -159,7 +159,7 @@ pub fn update_verifier_auth_state(
         .change_context(ContractError::StorageError)
 }
 
-pub fn save_service_in_authroized_verifiers_count(
+pub fn save_servicename_in_counter(
     storage: &mut dyn Storage,
     service_name: &ServiceName,
 ) -> error_stack::Result<(), ContractError> {
@@ -1192,7 +1192,7 @@ mod tests {
     fn test_authorized_verifier_count_operation() {
         let mut deps = mock_dependencies();
         let service = save_mock_service(deps.as_mut().storage);
-        save_service_in_authroized_verifiers_count(deps.as_mut().storage, &service.name).unwrap();
+        save_servicename_in_counter(deps.as_mut().storage, &service.name).unwrap();
         let count = count_authorized_verifiers(deps.as_ref().storage, &service.name).unwrap();
         assert_eq!(count, 0);
         increment_authorized_count(deps.as_mut().storage, &service.name).unwrap();
@@ -1208,7 +1208,7 @@ mod tests {
     fn test_update_service_max_verifiers_below_current_should_fail() {
         let mut deps = mock_dependencies();
         let service = save_mock_service(deps.as_mut().storage);
-        save_service_in_authroized_verifiers_count(deps.as_mut().storage, &service.name).unwrap();
+        save_servicename_in_counter(deps.as_mut().storage, &service.name).unwrap();
 
         for _ in 0..5 {
             increment_authorized_count(deps.as_mut().storage, &service.name).unwrap();

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -219,6 +219,35 @@ pub fn remove_service_override(
     Ok(())
 }
 
+pub fn update_multiple_verifier_status(
+    storage: &mut dyn Storage,
+    service_name: &ServiceName,
+    auth_state: &AuthorizationState,
+    verifiers: Vec<Addr>,
+) -> error_stack::Result<(), ContractError> {
+    let mut authroized_verifiers_count_changed = 0;
+
+    for verifier in verifiers {
+        let old_state = VERIFIERS
+            .may_load(storage, (service_name, verifier))
+            .change_context(ContractError::StorageError)?
+            .map(|v| v.authorization_state);
+
+        total_verifier_count_changed += calculate_single_verifier_diff(&old_state, &auth_state);
+
+
+
+
+}
+
+fn calculate_single_verifier_diff(old_state: &Option<AuthorizationState>, auth_state: &AuthorizationState) -> i16 {
+    match (old_state, auth_state) {
+        (Some(NotAuthorized) | Some(Jailed), Authorized) | (None, Authorized) => 1,
+        (Some(Authorized), NotAuthorized) | (Some(Authorized), Jailed) => -1,
+        _ => 0,
+    }
+}
+
 pub fn update_verifier_status(
     storage: &mut dyn Storage,
     service_name: &String,

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -6,7 +6,7 @@ use error_stack::{bail, report, ResultExt as _};
 use report::ResultExt;
 use router_api::ChainName;
 use service_registry_api::error::ContractError;
-use service_registry_api::AuthorizationState::{Authorized, Jailed, NotAuthorized};
+use service_registry_api::AuthorizationState::Authorized;
 use service_registry_api::{AuthorizationState, BondingState, Service, Verifier};
 type ServiceName = String;
 type VerifierAddress = Addr;

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -189,17 +189,21 @@ pub fn count_verifiers_updated_to_authorized(
     service_name: &ServiceName,
     verifiers: &[Addr],
 ) -> error_stack::Result<u16, ContractError> {
-    let mut count = 0;
+    let mut count: u16 = 0;
     for verifier in verifiers {
         match VERIFIERS
             .may_load(storage, (service_name, verifier))
             .change_context(ContractError::StorageError)?
         {
             Some(existing) if existing.authorization_state != AuthorizationState::Authorized => {
-                count += 1;
+                count = count
+                    .checked_add(1)
+                    .ok_or(ContractError::AuthorizedVerifiersExceedu16)?;
             }
             None => {
-                count += 1;
+                count = count
+                    .checked_add(1)
+                    .ok_or(ContractError::AuthorizedVerifiersExceedu16)?;
             }
             _ => {}
         }

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -89,7 +89,7 @@ const SERVICES: Map<&ServiceName, Service> = Map::new("services");
 const SERVICE_OVERRIDES: Map<(&ServiceName, &ChainName), ServiceParamsOverride> =
     Map::new("service_overrides");
 
-pub const AUTHORIZED_VERIFIER_COUNT: Map<&str, u16> = Map::new("authorized_verifier_count");
+pub const AUTHORIZED_VERIFIER_COUNT: Map<&ServiceName, u16> = Map::new("authorized_verifier_count");
 
 pub fn service(
     storage: &dyn Storage,
@@ -213,6 +213,8 @@ pub fn count_authorized_verifiers(
     Ok(count)
     
 }
+// validtion for min 
+// max < min
 pub fn update_service(
     storage: &mut dyn Storage,
     service_name: &ServiceName,

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -1226,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_number_of_authorized_return_err_verifiers_service_not_found() {
+    fn test_number_of_authorized_verifiers_return_err_when_service_not_found() {
         let deps = mock_dependencies();
         let nonexistent_service = "nonexistent_service".to_string();
         let result = number_of_authorized_verifiers(deps.as_ref().storage, &nonexistent_service);
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_auth_verifier_count_change_succeed() {
+    fn test_calculate_auth_verifier_count_change_succeed() {
         let test_cases = vec![
             // (previous_state, new_state, expected_change, description)
             (

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -161,7 +161,7 @@ pub fn update_service(
 ) -> error_stack::Result<Service, ContractError> {
     if let Some(Some(max_verifiers_limit)) = updated_service_params.max_num_verifiers {
         let current_authorized = number_of_authorized_verifiers(storage, service_name)?;
-        
+
         ensure!(
             max_verifiers_limit >= current_authorized,
             ContractError::MaxVerifiersSetBelowCurrent(max_verifiers_limit, current_authorized)
@@ -219,24 +219,17 @@ pub fn remove_service_override(
     Ok(())
 }
 
-pub fn update_verifier_status(storage: &mut dyn Storage, service_name: &String, auth_state: &AuthorizationState, verifier: Addr) 
--> error_stack::Result<(), ContractError> {
-    let previous_auth_state =
-        get_verifier_auth_state(storage, service_name, &verifier)?;
+pub fn update_verifier_status(
+    storage: &mut dyn Storage,
+    service_name: &String,
+    auth_state: &AuthorizationState,
+    verifier: Addr,
+) -> error_stack::Result<(), ContractError> {
+    let previous_auth_state = get_verifier_auth_state(storage, service_name, &verifier)?;
 
-    update_verifier_auth_state(
-        storage,
-        service_name,
-        &verifier,
-        auth_state.clone(),
-    )?;
+    update_verifier_auth_state(storage, service_name, &verifier, auth_state.clone())?;
 
-    update_count_based_on_state_transition(
-        storage,
-        service_name,
-        auth_state,
-        previous_auth_state,
-    )?;
+    update_count_based_on_state_transition(storage, service_name, auth_state, previous_auth_state)?;
     Ok(())
 }
 
@@ -439,9 +432,6 @@ fn update_authorized_count(
         .change_context(ContractError::StorageError)?;
     Ok(())
 }
-
-
-
 
 #[cfg(test)]
 mod tests {
@@ -1207,6 +1197,7 @@ mod tests {
             VerifierCountOperation::Increment,
         )
         .unwrap();
+
         let count = number_of_authorized_verifiers(deps.as_ref().storage, &service.name).unwrap();
         assert_eq!(count, 1);
 
@@ -1216,15 +1207,6 @@ mod tests {
             VerifierCountOperation::Decrement,
         )
         .unwrap();
-        let count = number_of_authorized_verifiers(deps.as_ref().storage, &service.name).unwrap();
-        assert_eq!(count, 0);
-
-        let result = update_authorized_count(
-            deps.as_mut().storage,
-            &service.name,
-            VerifierCountOperation::Decrement,
-        );
-        assert!(result.is_err());
     }
 
     #[test]

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -1341,11 +1341,6 @@ mod tests {
             .unwrap();
 
         let result = apply_authorized_count_change(deps.as_mut().storage, &service.name, 1);
-
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("not more than 65535 authorized verifiers allowed"));
     }
 }

--- a/contracts/service-registry/src/state.rs
+++ b/contracts/service-registry/src/state.rs
@@ -384,8 +384,9 @@ fn calculate_auth_verifier_count_change(
     auth_state: &AuthorizationState,
 ) -> i16 {
     match (previous_state, auth_state) {
-        (Some(NotAuthorized) | Some(Jailed), Authorized) | (None, Authorized) => 1,
-        (Some(Authorized), NotAuthorized) | (Some(Authorized), Jailed) => -1,
+        (Some(Authorized), Authorized) => 0,
+        (Some(Authorized), _) => -1,
+        (_, Authorized) => 1,
         _ => 0,
     }
 }

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -976,7 +976,7 @@ pub fn register_in_service_registry(
             service_name: protocol.service_name.to_string(),
         },
     );
-    assert!(response.is_ok());
+    assert!(response.is_ok()); // failed here
 
     for verifier in verifiers {
         let response = protocol.app.send_tokens(

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -976,7 +976,7 @@ pub fn register_in_service_registry(
             service_name: protocol.service_name.to_string(),
         },
     );
-    assert!(response.is_ok()); // failed here
+    assert!(response.is_ok());
 
     for verifier in verifiers {
         let response = protocol.app.send_tokens(

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -17,8 +17,8 @@ pub enum ContractError {
     AuthorizedVerifiersExceedu16,
     #[error("verifiers count is negative")]
     AuthorizedVerifiersNegative,
-    #[error("max verifiers limit {0} exceeded by {1} verifiers")]
-    VerifierLimitExceed(u16, u16),
+    #[error("max verifiers limit exceeded")]
+    VerifierLimitExceed,
     #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
     MaxVerifiersSetBelowCurrent(u16, u16),
     #[error("unauthorized")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -11,11 +11,14 @@ pub enum ContractError {
 
     #[error(transparent)]
     Overflow(#[from] OverflowError),
-
     #[error(transparent)]
     NonEmpty(#[from] nonempty::Error),
+    #[error("Verifiers count exceeds u16 limit")]
+    AuthorizedVerifiersExceedu16,
+    #[error("Verifiers count is negative")]
+    AuthorizedVerifiersNegative,
     #[error("max verifiers limit {0} exceeded by {1} verifiers")]
-    MaxVerifiersExceeded(u16, u16),
+    VerifierLimitExceed(u16, u16),
     #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
     MaxVerifiersSetBelowCurrent(u16, u16),
     #[error("authorized verifier count is less than 0, counter is corrupted")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -14,7 +14,12 @@ pub enum ContractError {
 
     #[error(transparent)]
     NonEmpty(#[from] nonempty::Error),
-
+    #[error("max verifiers limit {0} exceeded by {1} verifiers")]
+    MaxVerifiersExceeded(u16, u16),
+    #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
+    MaxVerifiersSetBelowCurrent(u16, u16),
+    #[error("authorized verifier count is less than 0, counter is corrupted")]
+    AuthurizedCounterFailed,
     #[error("unauthorized")]
     Unauthorized,
     #[error("service name already exists")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -13,12 +13,12 @@ pub enum ContractError {
     Overflow(#[from] OverflowError),
     #[error(transparent)]
     NonEmpty(#[from] nonempty::Error),
-    #[error("verifiers count exceeds u16 limit")]
-    AuthorizedVerifiersExceedu16,
+    #[error("not more than 65535 authorized verifiers allowed")]
+    AuthorizedVerifiersIntegerOverflow,
     #[error("verifiers count is negative")]
     AuthorizedVerifiersNegative,
     #[error("max verifiers limit exceeded")]
-    VerifierLimitExceed,
+    VerifierLimitExceeded,
     #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
     MaxVerifiersSetBelowCurrent(u16, u16),
     #[error("unauthorized")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -21,8 +21,6 @@ pub enum ContractError {
     VerifierLimitExceed(u16, u16),
     #[error("max verifiers limit {0} is below current authorized verifiers {1}")]
     MaxVerifiersSetBelowCurrent(u16, u16),
-    #[error("authorized verifier count is less than 0, counter is corrupted")]
-    AuthurizedCounterFailed,
     #[error("unauthorized")]
     Unauthorized,
     #[error("service name already exists")]

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -13,9 +13,9 @@ pub enum ContractError {
     Overflow(#[from] OverflowError),
     #[error(transparent)]
     NonEmpty(#[from] nonempty::Error),
-    #[error("Verifiers count exceeds u16 limit")]
+    #[error("verifiers count exceeds u16 limit")]
     AuthorizedVerifiersExceedu16,
-    #[error("Verifiers count is negative")]
+    #[error("verifiers count is negative")]
     AuthorizedVerifiersNegative,
     #[error("max verifiers limit {0} exceeded by {1} verifiers")]
     VerifierLimitExceed(u16, u16),

--- a/packages/service-registry-api/src/error.rs
+++ b/packages/service-registry-api/src/error.rs
@@ -15,8 +15,6 @@ pub enum ContractError {
     NonEmpty(#[from] nonempty::Error),
     #[error("not more than 65535 authorized verifiers allowed")]
     AuthorizedVerifiersIntegerOverflow,
-    #[error("verifiers count is negative")]
-    AuthorizedVerifiersNegative,
     #[error("max verifiers limit exceeded")]
     VerifierLimitExceeded,
     #[error("max verifiers limit {0} is below current authorized verifiers {1}")]


### PR DESCRIPTION
## Description
AXE-9631
Added counter storage: AUTHORIZED_VERIFIER_COUNT map tracks authorized verifiers per service
prevent AuthorizeVerifiers if that exceeds the allowable number of verifiers
prevent UpdateService if a new lower max is set and that is below the current number of authorized verifiers


## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
