### PR TITLE
refactor(url): add support for sensitivity and redacted logging 

### DIFF
--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -17,7 +17,9 @@ use crate::{broadcaster, event_processor, grpc};
 #[serde(default)]
 pub struct Config {
     pub health_check_bind_addr: SocketAddrV4,
+    #[serde(deserialize_with = "Url::deserialize_sensitive")]
     pub tm_jsonrpc: Url,
+    #[serde(deserialize_with = "Url::deserialize_sensitive")]
     pub tm_grpc: Url,
     pub tm_grpc_timeout: Duration,
     pub event_processor: event_processor::Config,
@@ -34,8 +36,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            tm_jsonrpc: "http://localhost:26657".parse().unwrap(),
-            tm_grpc: "tcp://localhost:9090".parse().unwrap(),
+            tm_jsonrpc: Url::new_non_sensitive("http://localhost:26657").unwrap(),
+            tm_grpc: Url::new_non_sensitive("tcp://localhost:9090").unwrap(),
             tm_grpc_timeout: Duration::from_secs(5),
             broadcast: broadcaster::Config::default(),
             handlers: vec![],
@@ -461,15 +463,13 @@ mod tests {
         assert_eq!(cfg.tofnd_config.party_uid.as_str(), party_uid);
         assert_eq!(cfg.tofnd_config.key_uid.as_str(), key_uid);
     }
-
     #[test]
-    fn can_serialize_deserialize_config() {
+    fn serialization_roundtrip_preserves_data() {
         let cfg = config_template();
-
-        let serialized = toml::to_string_pretty(&cfg).expect("should work");
-        let deserialized: Config = toml::from_str(serialized.as_str()).expect("should work");
-
-        assert_eq!(cfg, deserialized);
+        let serialized1 = toml::to_string_pretty(&cfg).expect("should work");
+        let deserialized: Config = toml::from_str(serialized1.as_str()).expect("should work");
+        let serialized2 = toml::to_string_pretty(&deserialized).expect("should work");
+        assert_eq!(serialized1, serialized2);
     }
 
     #[test]
@@ -497,7 +497,7 @@ mod tests {
                     chain: Chain {
                         name: ChainName::from_str("Ethereum").unwrap(),
                         finalization: Finalization::RPCFinalizedBlock,
-                        rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                        rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     },
                     rpc_timeout: Some(Duration::from_secs(3)),
                     cosmwasm_contract: TMAddress::from(
@@ -511,7 +511,7 @@ mod tests {
                     chain: Chain {
                         name: ChainName::from_str("Fantom").unwrap(),
                         finalization: Finalization::ConfirmationHeight,
-                        rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                        rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     },
                     rpc_timeout: Some(Duration::from_secs(3)),
                 },
@@ -525,58 +525,58 @@ mod tests {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     rpc_timeout: Some(Duration::from_secs(3)),
                 },
                 HandlerConfig::SuiVerifierSetVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     rpc_timeout: Some(Duration::from_secs(3)),
                 },
                 HandlerConfig::MvxMsgVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    proxy_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    proxy_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::MvxVerifierSetVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    proxy_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    proxy_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::StellarMsgVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::StellarVerifierSetVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::StarknetMsgVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::StarknetVerifierSetVerifier {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                 },
                 HandlerConfig::SolanaMsgVerifier {
                     chain_name: ChainName::from_str("solana").unwrap(),
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     rpc_timeout: Some(Duration::from_secs(3)),
                 },
                 HandlerConfig::SolanaVerifierSetVerifier {
@@ -584,7 +584,7 @@ mod tests {
                     cosmwasm_contract: TMAddress::from(
                         AccountId::new("axelar", &[0u8; 32]).unwrap(),
                     ),
-                    rpc_url: Url::from_str("http://127.0.0.1").unwrap(),
+                    rpc_url: Url::new_non_sensitive("http://127.0.0.1").unwrap(),
                     rpc_timeout: Some(Duration::from_secs(3)),
                 },
             ],

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -54,12 +54,12 @@ impl Default for Config {
 impl Debug for Config {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Config")
-            .field("tm_jsonrpc", &REDACTED_VALUE)
-            .field("tm_grpc", &REDACTED_VALUE)
+            .field("tm_jsonrpc", &self.tm_jsonrpc)
+            .field("tm_grpc", &self.tm_grpc)
             .field("tm_grpc_timeout", &self.tm_grpc_timeout)
             .field("broadcast", &self.broadcast)
             .field("handlers", &self.handlers)
-            .field("tofnd_config", &REDACTED_VALUE)
+            .field("tofnd_config", &self.tofnd_config)
             .field("event_processor", &self.event_processor)
             .field("service_registry", &self.service_registry)
             .field("rewards", &self.rewards)

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -16,6 +16,7 @@ use crate::url::Url;
 #[derive(Clone, Deserialize, Serialize, PartialEq)]
 pub struct Chain {
     pub name: ChainName,
+    #[serde(deserialize_with = "Url::deserialize_sensitive")]
     pub rpc_url: Url,
     #[serde(default)]
     pub finalization: Finalization,
@@ -53,17 +54,20 @@ pub enum Config {
     },
     SuiMsgVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
         rpc_timeout: Option<Duration>,
     },
     SuiVerifierSetVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
         rpc_timeout: Option<Duration>,
     },
     XRPLMsgVerifier {
         cosmwasm_contract: TMAddress,
         chain_name: ChainName,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         chain_rpc_url: Url,
         rpc_timeout: Option<Duration>,
     },
@@ -73,37 +77,45 @@ pub enum Config {
     },
     MvxMsgVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         proxy_url: Url,
     },
     MvxVerifierSetVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         proxy_url: Url,
     },
     StellarMsgVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
     },
     StellarVerifierSetVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
     },
     StarknetMsgVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
     },
     StarknetVerifierSetVerifier {
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
     },
     SolanaMsgVerifier {
         chain_name: ChainName,
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
         rpc_timeout: Option<Duration>,
     },
     SolanaVerifierSetVerifier {
         chain_name: ChainName,
         cosmwasm_contract: TMAddress,
+        #[serde(deserialize_with = "Url::deserialize_sensitive")]
         rpc_url: Url,
         rpc_timeout: Option<Duration>,
     },
@@ -244,6 +256,7 @@ mod tests {
     use crate::evm::finalizer::Finalization;
     use crate::handlers::config::{deserialize_handler_configs, Chain, Config};
     use crate::types::TMAddress;
+    use crate::url::Url;
     use crate::PREFIX;
 
     #[test]
@@ -262,12 +275,12 @@ mod tests {
         let configs = vec![
             Config::SuiMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
                 rpc_timeout: None,
             },
             Config::SuiMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
                 rpc_timeout: None,
             },
         ];
@@ -281,12 +294,12 @@ mod tests {
         let configs = vec![
             Config::SuiVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
                 rpc_timeout: None,
             },
             Config::SuiVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
                 rpc_timeout: None,
             },
         ];
@@ -300,11 +313,11 @@ mod tests {
         let configs = vec![
             Config::MvxMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                proxy_url: "http://localhost:7545/".parse().unwrap(),
+                proxy_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
             Config::MvxMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                proxy_url: "http://localhost:7545/".parse().unwrap(),
+                proxy_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
         ];
 
@@ -317,11 +330,11 @@ mod tests {
         let configs = vec![
             Config::MvxVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                proxy_url: "http://localhost:7545/".parse().unwrap(),
+                proxy_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
             Config::MvxVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                proxy_url: "http://localhost:7545/".parse().unwrap(),
+                proxy_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
         ];
 
@@ -334,11 +347,11 @@ mod tests {
         let configs = vec![
             Config::StellarMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
             Config::StellarMsgVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
         ];
 
@@ -351,11 +364,11 @@ mod tests {
         let configs = vec![
             Config::StellarVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
             Config::StellarVerifierSetVerifier {
                 cosmwasm_contract: TMAddress::random(PREFIX),
-                rpc_url: "http://localhost:7545/".parse().unwrap(),
+                rpc_url: Url::new_non_sensitive("http://localhost:7545/").unwrap(),
             },
         ];
 
@@ -368,7 +381,7 @@ mod tests {
         let sample_config = Config::SolanaMsgVerifier {
             chain_name: ChainName::from_str("solana").unwrap(),
             cosmwasm_contract: TMAddress::random(PREFIX),
-            rpc_url: "http://localhost:8080/".parse().unwrap(),
+            rpc_url: Url::new_non_sensitive("http://localhost:8080/").unwrap(),
             rpc_timeout: None,
         };
 
@@ -383,7 +396,7 @@ mod tests {
         let sample_config = Config::SolanaVerifierSetVerifier {
             chain_name: ChainName::from_str("solana").unwrap(),
             cosmwasm_contract: TMAddress::random(PREFIX),
-            rpc_url: "http://localhost:8080/".parse().unwrap(),
+            rpc_url: Url::new_non_sensitive("http://localhost:8080/").unwrap(),
             rpc_timeout: None,
         };
 

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::fmt::Debug;
 use std::time::Duration;
 

--- a/ampd/src/json_rpc.rs
+++ b/ampd/src/json_rpc.rs
@@ -40,7 +40,7 @@ where
 }
 
 impl Client<Http> {
-    pub fn new_http(url: &Url, client: reqwest::Client) -> Self {
+    pub fn new_http(url: Url, client: reqwest::Client) -> Self {
         Client::new(Http::new_with_client(url, client))
     }
 }

--- a/ampd/src/json_rpc.rs
+++ b/ampd/src/json_rpc.rs
@@ -41,7 +41,7 @@ where
 
 impl Client<Http> {
     pub fn new_http(url: &Url, client: reqwest::Client) -> Self {
-        Client::new(Http::new_with_client(url.to_standard_url(), client))
+        Client::new(Http::new_with_client(url, client))
     }
 }
 

--- a/ampd/src/json_rpc.rs
+++ b/ampd/src/json_rpc.rs
@@ -41,7 +41,7 @@ where
 
 impl Client<Http> {
     pub fn new_http(url: &Url, client: reqwest::Client) -> Self {
-        Client::new(Http::new_with_client(url, client))
+        Client::new(Http::new_with_client(url.to_standard_url(), client))
     }
 }
 

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -511,7 +511,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
-                        rpc_url.to_standard_url(),
+                        rpc_url,
                     ))
                     .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),
@@ -527,7 +527,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
-                        rpc_url.to_standard_url(),
+                        rpc_url,
                     ))
                     .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -510,8 +510,10 @@ where
                 handlers::starknet_verify_msg::Handler::new(
                     verifier.clone(),
                     cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(HttpTransport::new(rpc_url))
-                        .change_context(Error::Connection)?,
+                    starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
+                        rpc_url.to_standard_url(),
+                    ))
+                    .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),
                 ),
                 event_processor_config.clone(),
@@ -524,8 +526,10 @@ where
                 handlers::starknet_verify_verifier_set::Handler::new(
                     verifier.clone(),
                     cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(HttpTransport::new(rpc_url))
-                        .change_context(Error::Connection)?,
+                    starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
+                        rpc_url.to_standard_url(),
+                    ))
+                    .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),
                 ),
                 event_processor_config.clone(),
@@ -718,7 +722,6 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
 
     use super::*;
     use crate::url::Url;
@@ -727,7 +730,7 @@ mod tests {
     fn test_invalid_url_parsing_returns_error() {
         // Test that invalid URLs are properly detected
         let invalid_url = "http://definitely-does-not-exist-12345.invalid";
-        let result = Url::from_str(invalid_url);
+        let result = Url::new_non_sensitive(invalid_url);
 
         // Should be able to parse the URL (syntax is valid)
         assert!(
@@ -747,7 +750,7 @@ mod tests {
     fn test_handler_config_creation_with_invalid_url() {
         // Test URL creation with invalid host - this should succeed syntactically
         let invalid_url = "http://invalid-nonexistent-host:8545";
-        let parsed_url = Url::from_str(invalid_url);
+        let parsed_url = Url::new_non_sensitive(invalid_url);
 
         // URL parsing should succeed for syntactically valid URLs
         assert!(

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -294,7 +294,7 @@ where
                 rpc_timeout,
             } => {
                 let rpc_client = json_rpc::Client::new_http(
-                    &chain.rpc_url,
+                    chain.rpc_url.clone(),
                     reqwest::ClientBuilder::new()
                         .connect_timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
                         .timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
@@ -323,7 +323,7 @@ where
                 rpc_timeout,
             } => {
                 let rpc_client = json_rpc::Client::new_http(
-                    &chain.rpc_url,
+                    chain.rpc_url.clone(),
                     reqwest::ClientBuilder::new()
                         .connect_timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
                         .timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
@@ -370,7 +370,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     json_rpc::Client::new_http(
-                        rpc_url,
+                        rpc_url.clone(),
                         reqwest::ClientBuilder::new()
                             .connect_timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
                             .timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
@@ -433,7 +433,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     json_rpc::Client::new_http(
-                        rpc_url,
+                        rpc_url.clone(),
                         reqwest::ClientBuilder::new()
                             .connect_timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
                             .timeout(rpc_timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
@@ -511,7 +511,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
-                        rpc_url,
+                        rpc_url.clone(),
                     ))
                     .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),
@@ -527,7 +527,7 @@ where
                     verifier.clone(),
                     cosmwasm_contract.clone(),
                     starknet::json_rpc::Client::new_with_transport(HttpTransport::new(
-                        rpc_url,
+                        rpc_url.clone(),
                     ))
                     .change_context(Error::Connection)?,
                     self.block_height_monitor.latest_block_height(),

--- a/ampd/src/tofnd/mod.rs
+++ b/ampd/src/tofnd/mod.rs
@@ -17,6 +17,7 @@ pub use proto::Algorithm;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct Config {
+    #[serde(deserialize_with = "Url::deserialize_sensitive")]
     pub url: Url,
     pub party_uid: String,
     pub key_uid: String,
@@ -26,7 +27,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            url: "http://localhost:50051/".parse().unwrap(),
+            url: Url::new_non_sensitive("http://localhost:50051/").unwrap(),
             party_uid: "ampd".into(),
             key_uid: "axelar".into(),
             timeout: Duration::from_secs(3),

--- a/ampd/src/url.rs
+++ b/ampd/src/url.rs
@@ -134,7 +134,6 @@ mod tests {
         }
         let toml_str = r#"url = "https://sensitive.test""#;
         let config: TestConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.url.is_sensitive);
         assert_eq!(format!("{}", config.url), REDACTED_VALUE);
         assert_eq!(config.url.as_str(), "https://sensitive.test/");
     }
@@ -148,7 +147,6 @@ mod tests {
         }
         let toml_str = r#"url = "https://non-sensitive.test""#;
         let config: TestConfig = toml::from_str(toml_str).unwrap();
-        assert!(!config.url.is_sensitive);
         assert_eq!(format!("{}", config.url), "https://non-sensitive.test/");
         assert_eq!(config.url.as_str(), "https://non-sensitive.test/");
     }

--- a/ampd/src/url.rs
+++ b/ampd/src/url.rs
@@ -50,10 +50,6 @@ impl Url {
             is_sensitive: false,
         })
     }
-
-    pub fn to_standard_url(&self) -> url::Url {
-        self.inner.clone()
-    }
 }
 
 impl Serialize for Url {
@@ -72,6 +68,12 @@ impl Display for Url {
         } else {
             f.write_str(self.inner.as_str())
         }
+    }
+}
+
+impl From<&Url> for url::Url {
+    fn from(value: &Url) -> Self {
+        value.inner.clone()
     }
 }
 
@@ -130,10 +132,10 @@ mod tests {
     }
 
     #[test]
-    fn test_to_standard_url_convert_to_url_sucessfully() {
+    fn test_from_trait_convert_to_url_sucessfully() {
         let original = "https://example.com";
         let url = Url::new_non_sensitive(original).unwrap();
-        let inner: url::Url = url.to_standard_url();
+        let inner: url::Url = url::Url::from(&url);
         assert_eq!(inner.as_str(), "https://example.com/");
     }
 

--- a/ampd/src/url.rs
+++ b/ampd/src/url.rs
@@ -93,7 +93,6 @@ mod tests {
     #[test]
     fn test_new_sensitive_and_display_debug() {
         let url = Url::new_sensitive("http://secret.api/key").unwrap();
-        assert!(url.is_sensitive);
         assert_eq!(format!("{}", url), REDACTED_VALUE);
         assert_eq!(format!("{:?}", url), REDACTED_VALUE);
     }
@@ -101,7 +100,6 @@ mod tests {
     #[test]
     fn test_new_non_sensitive_and_display_debug() {
         let url = Url::new_non_sensitive("http://public.api").unwrap();
-        assert!(!url.is_sensitive);
         assert_eq!(format!("{}", url), "http://public.api/");
         assert_eq!(format!("{:?}", url), "http://public.api/");
     }

--- a/ampd/src/url.rs
+++ b/ampd/src/url.rs
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_standard_url() {
+    fn test_to_standard_url_convert_to_url_sucessfully() {
         let original = "https://example.com";
         let url = Url::new_non_sensitive(original).unwrap();
         let inner: url::Url = url.to_standard_url();
@@ -138,14 +138,18 @@ mod tests {
     }
 
     #[test]
-    fn test_serialization() {
+    fn serialization_preserves_full_url_regardless_of_sensitivity() {
         let url = Url::new_non_sensitive("https://serialize.test").unwrap();
         let serialized = toml::to_string(&url).unwrap();
         assert!(serialized.contains("https://serialize.test"));
+
+        let sensitive_url = Url::new_sensitive("https://sensitive.serialize.test").unwrap();
+        let serialized = toml::to_string(&sensitive_url).unwrap();
+        assert!(serialized.contains("https://sensitive.serialize.test"));
     }
 
     #[test]
-    fn test_deserialize_sensitive() {
+    fn deserialize_sensitive_marks_url_as_sensitive_and_redacts_display() {
         #[derive(Deserialize)]
         struct TestConfig {
             #[serde(deserialize_with = "Url::deserialize_sensitive")]
@@ -159,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_non_sensitive() {
+    fn deserialize_non_sensitive_shows_full_url_in_display() {
         #[derive(Deserialize)]
         struct TestConfig {
             #[serde(deserialize_with = "Url::deserialize_non_sensitive")]


### PR DESCRIPTION
## Description

[AXE-9672](https://axelarnetwork.atlassian.net/browse/AXE-9672) (https://axelarnetwork.atlassian.net/browse/AXE-9672)

```
impl Debug for Config {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        f.debug_struct("Config")
            .field("tm_jsonrpc", &self.tm_jsonrpc)
            .field("tm_grpc", &self.tm_grpc)
            .field("tm_grpc_timeout", &self.tm_grpc_timeout)
            .field("broadcast", &self.broadcast)
            .field("handlers", &self.handlers)
            .field("tofnd_config", &self.tofnd_config)
            .field("event_processor", &self.event_processor)
            .field("service_registry", &self.service_registry)
            .field("rewards", &self.rewards)
            .field("health_check_bind_addr", &REDACTED_VALUE)
            // fmt::Debug is already redacted for field gprc
            // (@see: src/grpc/mod.rs)
            .field("grpc", &self.grpc)
            .finish()
    }
}
```
could be removed after the task **making_prometheus_client_configurable**, and turned the the health_track_server into a sensitive link

- **Removed** the `can_serialize_deserialize_config()` test, as it’s no longer valid in the sensitivity context — deserialization now produces Url instances marked as sensitive, which **redact** their contents in` Display` and `Debug` output, making them unsuitable for direct comparison with the original config.
- added unit tests in url 

- Replaced all `Url::from_str(...) `and `.parse() `calls with `new_non_sensitive()/ new_sensitive()`
- Split deserialization into two methods:

> deserialize_sensitive for redacted URLs.
> deserialize_non_sensitive for visible URLs.

- Changed from lifetime from` D: Deserializer<'a>` to` D: Deserializer<'de> `, using the standard lifetime parameter name
- all chain rpc_url, tonfnd, tm_jsonrpc, tm_grpc  URLs are also marked as `sensitive`,they will be turned to a sensitive url during deserialization, but the default value are marked as `non-sensitive` url 
## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes


[AXE-9672]: https://axelarnetwork.atlassian.net/browse/AXE-9672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ