### PR TITLE
reformat: rename EnsurePermission and external_execute macros

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 ## Convention Checklist
 - [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
 - [ ] Derive macros
-  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
+  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
   - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
   - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
   - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function

--- a/contracts/axelarnet-gateway/src/msg.rs
+++ b/contracts/axelarnet-gateway/src/msg.rs
@@ -1,7 +1,7 @@
 use axelar_core_std::nexus;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::HexBinary;
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::{Address, ChainName, CrossChainId, Message};
 
 pub use crate::contract::MigrateMsg;
@@ -25,7 +25,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Forward the given messages to the next step of the routing layer.
     /// Messages initiated via `CallContract` can be forwarded again to the router.

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -6,7 +6,7 @@ use axelar_wasm_std::msg_id::MessageIdFormat;
 use axelar_wasm_std::{nonempty, MajorityThreshold};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Binary};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use multisig::key::KeyType;
 use multisig_prover_api::encoding::Encoder;
 use router_api::ChainName;
@@ -24,7 +24,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// After the contract is instantiated, this should be the first call to execute
     #[permission(Governance)]

--- a/contracts/interchain-token-service/src/msg.rs
+++ b/contracts/interchain-token-service/src/msg.rs
@@ -4,7 +4,7 @@ use axelar_wasm_std::nonempty;
 use axelarnet_gateway::AxelarExecutableMsg;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint256;
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::{Address, ChainNameRaw};
 
 pub use crate::contract::MigrateMsg;
@@ -48,7 +48,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Execute a cross-chain message received by the axelarnet-gateway from another chain
     #[permission(Specific(gateway))]

--- a/contracts/multisig-prover/src/msg.rs
+++ b/contracts/multisig-prover/src/msg.rs
@@ -1,7 +1,7 @@
 use axelar_wasm_std::MajorityThreshold;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{HexBinary, Uint64};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 pub use multisig_prover_api::msg::InstantiateMsg;
 use router_api::CrossChainId;
 
@@ -9,7 +9,7 @@ pub use crate::contract::MigrateMsg;
 use crate::Payload;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     // Start building a proof that includes specified messages
     // Queries the gateway for actual message contents

--- a/contracts/multisig/src/msg.rs
+++ b/contracts/multisig/src/msg.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use axelar_wasm_std::nonempty;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, HexBinary, Uint128, Uint64};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::ChainName;
 
 pub use crate::contract::MigrateMsg;
@@ -23,7 +23,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Can only be called by an authorized contract.
     #[permission(Specific(authorized))]

--- a/contracts/rewards/src/msg.rs
+++ b/contracts/rewards/src/msg.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use axelar_wasm_std::{nonempty, Threshold};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128, Uint64};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::{Address, ChainName};
 
 pub use crate::contract::MigrateMsg;
@@ -43,7 +43,7 @@ pub struct Params {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Log a specific verifier as participating in a specific event. Verifier weights are ignored
     /// This call will error if the pool does not yet exist.

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, Storage,
 };
 use error_stack::ResultExt;
-use msgs_derive::external_execute;
+use msgs_derive::ensure_permissions;
 use router_api::error::Error;
 
 use crate::events::RouterInstantiated;
@@ -55,7 +55,7 @@ pub fn instantiate(
     }))
 }
 
-#[external_execute(allow_execution_from_contracts(coordinator = find_coordinator_address), allow_execution_from_addresses(gateway = find_gateway_address(&info.sender)))]
+#[ensure_permissions(allow_execution_from_contracts(coordinator = find_coordinator_address), allow_execution_from_addresses(gateway = find_gateway_address(&info.sender)))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,

--- a/contracts/voting-verifier/src/msg.rs
+++ b/contracts/voting-verifier/src/msg.rs
@@ -1,7 +1,7 @@
 use axelar_wasm_std::voting::{PollId, PollStatus, Vote, WeightedPoll};
 use axelar_wasm_std::{nonempty, MajorityThreshold, VerificationStatus};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use multisig::verifier_set::VerifierSet;
 use router_api::Message;
 pub use voting_verifier_api::msg::InstantiateMsg;
@@ -9,7 +9,7 @@ pub use voting_verifier_api::msg::InstantiateMsg;
 pub use crate::contract::MigrateMsg;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     // Computes the results of a poll
     // For all verified messages, calls MessagesVerified on the verifier

--- a/packages/gateway-api/src/msg.rs
+++ b/packages/gateway-api/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::{CrossChainId, Message};
 
 #[cw_serde]
@@ -11,7 +11,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Before messages that are unknown to the system can be routed, they need to be verified.
     /// Use this call to trigger verification for any of the given messages that is still unverified.

--- a/packages/msgs-derive/src/lib.rs
+++ b/packages/msgs-derive/src/lib.rs
@@ -31,10 +31,10 @@ use syn::{parse_quote, Expr, ExprCall, Ident, ItemEnum, ItemFn, Meta, Path, Toke
 /// use cosmwasm_std::{Addr, Deps, Env, MessageInfo};
 /// use cosmwasm_std::testing::MockApi;
 /// use axelar_wasm_std::permission_control::Permission;
-/// use msgs_derive::EnsurePermissions;
+/// use msgs_derive::Permissions;
 ///
 /// #[cw_serde]
-/// #[derive(EnsurePermissions)]
+/// #[derive(Permissions)]
 /// pub enum ExecuteMsg {
 ///     #[permission(NoPrivilege, Admin)]
 ///     AnyoneButGovernanceCanCallThis,
@@ -83,7 +83,7 @@ use syn::{parse_quote, Expr, ExprCall, Ident, ItemEnum, ItemFn, Meta, Path, Toke
 /// assert!(execute(deps, env, info, ExecuteMsg::OnlyGatewayCanCallThis).is_err());
 /// # }
 /// ```
-#[proc_macro_derive(EnsurePermissions, attributes(permission, allow_contract_executors))]
+#[proc_macro_derive(Permissions, attributes(permission, allow_contract_executors))]
 pub fn derive_ensure_permissions(input: TokenStream) -> TokenStream {
     // This will trigger a compile time error if the parse failed. In other words,
     // this macro can only be used on an enum.
@@ -484,10 +484,10 @@ fn external_execute_msg_ident(execute_msg_ident: Ident) -> Ident {
     format_ident!("{}FromContract", execute_msg_ident.clone())
 }
 
-/// AllPermissions is a custom struct used to parse the attributes for the external_execute macro
-/// The external_execute macro must be defined as follows:
+/// AllPermissions is a custom struct used to parse the attributes for the ensure_permissions macro
+/// The ensure_permissions macro must be defined as follows:
 ///
-/// #[external_execute(allow_execution_from_contracts(coordinator = find_coordinator_address), allow_execution_from_addresses(verifier = find_varifier_address))]
+/// #[ensure_permissions(allow_execution_from_contracts(coordinator = find_coordinator_address), allow_execution_from_addresses(verifier = find_varifier_address))]
 ///
 /// ContractPermission is a vector of tuples, where the first element is the contract name, and the second
 /// is the authorization function.
@@ -654,7 +654,7 @@ fn validate_external_contract_function(
 ///
 /// This macro takes arguments of the form:
 ///
-/// #\[external_execute(allow_execution_from_contracts(contract = find_contract_address), allow_execution_from_addresses(sender = find_sender_address))\]
+/// #\[ensure_permissions(allow_execution_from_contracts(contract = find_contract_address), allow_execution_from_addresses(sender = find_sender_address))\]
 ///
 /// 'allow_execution_from_contracts' handles case 1, and allow_execution_from_addresses handles
 /// case 2. In both scenarios, the left hand side of the assignment is the identifier for the
@@ -664,10 +664,10 @@ fn validate_external_contract_function(
 ///
 /// The right hand side can be an expression that returns a function with that signature.
 #[proc_macro_attribute]
-pub fn external_execute(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn ensure_permissions(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut execute_fn = syn::parse_macro_input!(item as ItemFn);
     if execute_fn.sig.ident != format_ident!("execute") {
-        panic!("external_execute macro can only be used with execute endpoint")
+        panic!("ensure_permissions macro can only be used with execute endpoint")
     }
 
     let all_permissions = syn::parse_macro_input!(attr as AllPermissions);

--- a/packages/msgs-derive/tests/macro.rs
+++ b/packages/msgs-derive/tests/macro.rs
@@ -5,10 +5,10 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::testing::{MockApi, MockStorage};
 use cosmwasm_std::{Addr, Storage};
 use error_stack::{report, Report};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 #[allow(dead_code)] // the msg fields are only defined to make sure the derive attribute can handle fields correctly
 enum TestMsg {
     #[permission(NoPrivilege)]
@@ -26,7 +26,7 @@ enum TestMsg {
 }
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 enum TestMsg2 {
     #[permission(Any)]
     Any,
@@ -159,7 +159,7 @@ fn ensure_specific_permissions() {
         Ok::<Addr, Report<Error>>(MockApi::default().addr_make("gateway3"))
     };
 
-    // Given a set of specific permissions, the EnsurePermissions macro will now determine
+    // Given a set of specific permissions, the Permissions macro will now determine
     // a deterministic order of how the permission checking functions should appear as
     // arguments in 'ensure_permissions'. Previously, the developer was responsible for
     // calling ensure_permissions. Since the call to ensure premissions is now generated,

--- a/packages/router-api/src/msg.rs
+++ b/packages/router-api/src/msg.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 
 use axelar_wasm_std::msg_id::MessageIdFormat;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 
 use crate::primitives::*;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Registers a new chain with the router
     #[permission(Governance)]

--- a/packages/service-registry-api/src/msg.rs
+++ b/packages/service-registry-api/src/msg.rs
@@ -1,6 +1,6 @@
 use axelar_wasm_std::nonempty;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use msgs_derive::EnsurePermissions;
+use msgs_derive::Permissions;
 use router_api::ChainName;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::primitives::*;
 
 #[cw_serde]
-#[derive(EnsurePermissions)]
+#[derive(Permissions)]
 pub enum ExecuteMsg {
     /// Can only be called by governance account
     #[permission(Governance)]


### PR DESCRIPTION
…d ensure_permissions

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
