### PR TITLE
refactor(coordinator): remove usage of register prover contract message

### DIFF
--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -241,15 +241,20 @@ mod tests {
     fn add_prover_from_governance_succeeds() {
         let mut test_setup = setup();
         let new_prover = test_setup.app.api().addr_make("new_eth_prover");
+        let new_gateway = test_setup.app.api().addr_make("new_eth_gateway");
+        let new_verifier = test_setup.app.api().addr_make("new_eth_verifier");
+
 
         assert!(test_setup
             .app
             .execute_contract(
                 test_setup.admin_addr.clone(),
                 test_setup.coordinator_addr.clone(),
-                &ExecuteMsg::RegisterProverContract {
+                &ExecuteMsg::RegisterChain {
                     chain_name: test_setup.chain_name.clone(),
-                    new_prover_addr: new_prover.to_string(),
+                    prover_address: new_prover.to_string(),
+                    gateway_address: new_gateway.to_string(),
+                    voting_verifier_address: new_verifier.to_string(),
                 },
                 &[]
             )
@@ -270,14 +275,18 @@ mod tests {
     fn add_prover_from_random_address_fails() {
         let mut test_setup = setup();
         let new_prover = test_setup.app.api().addr_make("new_eth_prover");
+        let new_gateway = test_setup.app.api().addr_make("new_eth_gateway");
+        let new_verifier = test_setup.app.api().addr_make("new_eth_verifier");
         let random_addr = test_setup.app.api().addr_make("random_address");
 
         let res = test_setup.app.execute_contract(
             random_addr.clone(),
             test_setup.coordinator_addr.clone(),
-            &ExecuteMsg::RegisterProverContract {
+            &ExecuteMsg::RegisterChain {
                 chain_name: test_setup.chain_name.clone(),
-                new_prover_addr: new_prover.to_string(),
+                prover_address: new_prover.to_string(),
+                gateway_address: new_gateway.to_string(),
+                voting_verifier_address: new_verifier.to_string(),
             },
             &[],
         );

--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -244,7 +244,6 @@ mod tests {
         let new_gateway = test_setup.app.api().addr_make("new_eth_gateway");
         let new_verifier = test_setup.app.api().addr_make("new_eth_verifier");
 
-
         assert!(test_setup
             .app
             .execute_contract(

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -47,11 +47,15 @@ pub fn register_chain(
     state::save_chain_contracts(
         deps.storage,
         chain_name.clone(),
-        prover_addr,
+        prover_addr.clone(),
         gateway_addr,
         voting_verifier_address,
     )
-    .change_context(Error::ChainNotRegistered(chain_name))?;
+    .change_context(Error::ChainNotRegistered(chain_name.clone()))?;
+
+    state::save_prover_for_chain(deps.storage, chain_name, prover_addr.clone())
+        .change_context(Error::ProverNotRegistered(prover_addr))?;
+
     Ok(Response::new())
 }
 

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -53,9 +53,6 @@ pub fn register_chain(
     )
     .change_context(Error::ChainNotRegistered(chain_name.clone()))?;
 
-    state::save_prover_for_chain(deps.storage, chain_name, prover_addr.clone())
-        .change_context(Error::ProverNotRegistered(prover_addr))?;
-
     Ok(Response::new())
 }
 

--- a/contracts/coordinator/src/state.rs
+++ b/contracts/coordinator/src/state.rs
@@ -250,10 +250,8 @@ pub fn is_prover_registered(
     match contracts_by_prover(storage, prover_address) {
         Ok(..) => Ok(true),
         Err(e)
-            if e.downcast_ref::<Error>().is_some_and(|e| match e {
-                Error::ProverNotRegistered(..) => true,
-                _ => false,
-            }) =>
+            if e.downcast_ref::<Error>()
+                .is_some_and(|e| matches!(e, Error::ProverNotRegistered(..))) =>
         {
             Ok(false)
         }

--- a/integration-tests/tests/coordinator_one_click_deployment.rs
+++ b/integration-tests/tests/coordinator_one_click_deployment.rs
@@ -136,10 +136,24 @@ fn deploy_chains(
     let response = protocol.coordinator.execute(
         &mut protocol.app,
         protocol.governance_address.clone(),
-        &coordinator::msg::ExecuteMsg::RegisterProverContract {
+        &coordinator::msg::ExecuteMsg::RegisterChain {
             chain_name: chain_name.parse().unwrap(),
-            new_prover_addr: contracts
+            prover_address: contracts
                 .multisig_prover
+                .contract_addr
+                .to_string()
+                .trim_matches(|c| c == '"' || c == '/')
+                .parse()
+                .unwrap(),
+            gateway_address: contracts
+                .gateway
+                .contract_addr
+                .to_string()
+                .trim_matches(|c| c == '"' || c == '/')
+                .parse()
+                .unwrap(),
+            voting_verifier_address: contracts
+                .voting_verifier
                 .contract_addr
                 .to_string()
                 .trim_matches(|c| c == '"' || c == '/')

--- a/integration-tests/tests/only_prover_updates_verifiers.rs
+++ b/integration-tests/tests/only_prover_updates_verifiers.rs
@@ -41,9 +41,11 @@ fn only_prover_can_update_verifier_set_with_coordinator() {
     let response = protocol.coordinator.execute(
         &mut protocol.app,
         protocol.governance_address.clone(),
-        &CoordinatorExecuteMsg::RegisterProverContract {
+        &CoordinatorExecuteMsg::RegisterChain {
             chain_name: chain_name.clone(),
-            new_prover_addr: MockApi::default().addr_make("random_address").to_string(),
+            prover_address: MockApi::default().addr_make("random_address").to_string(),
+            gateway_address: MockApi::default().addr_make("random_address").to_string(),
+            voting_verifier_address: MockApi::default().addr_make("random_address").to_string(),
         },
     );
     assert!(response.is_ok());

--- a/integration-tests/tests/test_utils/mod.rs
+++ b/integration-tests/tests/test_utils/mod.rs
@@ -737,16 +737,6 @@ pub fn setup_chain(protocol: &mut Protocol, chain_name: ChainName) -> Chain {
     let response = protocol.coordinator.execute(
         &mut protocol.app,
         protocol.governance_address.clone(),
-        &CoordinatorExecuteMsg::RegisterProverContract {
-            chain_name: chain_name.clone(),
-            new_prover_addr: multisig_prover.contract_addr.to_string(),
-        },
-    );
-    assert!(response.is_ok());
-
-    let response = protocol.coordinator.execute(
-        &mut protocol.app,
-        protocol.governance_address.clone(),
         &CoordinatorExecuteMsg::RegisterChain {
             chain_name: chain_name.clone(),
             prover_address: multisig_prover.contract_addr.to_string(),


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes

In this PR, I remove all internal usage of RegisterProverContract. The RegisterProverContract endpoint is kept, however, since external processes still depend on it. It will be removed later.