### PR TITLE
chore(lints): integrate axelar-lints into amplifier

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -182,6 +182,29 @@ jobs:
           command: fmt
           args: --all -- --check
 
+      - name: Install latest stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-dylint
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-dylint
+
+      - name: Install dylint-lint
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: dylint-link
+
+      - name: Run custom lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: dylint
+          args: --all
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ rust-version = "1.81.0" # be sure there is an optimizer release supporting this 
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[workspace.metadata.dylint]
+
+[[workspace.metadata.dylint.libraries]]
+git = "https://github.com/axelarnetwork/axelar-lints"
+pattern = "amplifier-lints" 
+
 [workspace.metadata.scripts]
 optimize = """docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
@@ -130,6 +136,10 @@ xrpl-types = { version = "^1.0.0", path = "packages/xrpl-types" }
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"
 cast_possible_truncation = "deny"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(dylint_lib, values(any()))"]
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
- Configured a [custom linter for amplifier using dylint](https://github.com/axelarnetwork/axelar-lints). Can run all lints using `cargo dylint --all`.
- Configured the basic workflow to test using custom lints. Lints that warn and do not deny are allowed by default.

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
