### PR TITLE
chore(ampd): add feature flags for url, config, and commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
 name = "ampd-sdk"
 version = "0.1.0"
 dependencies = [
+ "ampd",
  "ampd-proto",
  "async-trait",
  "axelar-wasm-std",

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -6,6 +6,12 @@ rust-version = { workspace = true }
 license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["commands", "config"]
+commands = []
+config = []
+url = []
+
 [dependencies]
 ampd-proto = { workspace = true }
 async-trait = { workspace = true }

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -57,6 +57,14 @@ mod types;
 mod url;
 mod xrpl;
 
+#[cfg(feature = "commands")]
+pub use commands::*;
+#[allow(unused_imports)]
+#[cfg(feature = "config")]
+pub use config::*;
+#[cfg(feature = "url")]
+pub use url::*;
+
 use crate::asyncutil::future::RetryPolicy;
 use crate::broadcaster::confirm_tx::TxConfirmer;
 

--- a/packages/ampd-sdk/Cargo.toml
+++ b/packages/ampd-sdk/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 edition = { workspace = true }
 
 [dependencies]
+ampd = { path = "../../ampd", default-features = false, features = ["url"] }
 ampd-proto = { workspace = true }
 async-trait = { workspace = true }
 axelar-wasm-std = { workspace = true }


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
