### PR TITLE
refactor(ampd): Replace prometheus crate with official prometheus_client crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
  "num-traits",
  "openssl",
  "pin-project-lite",
- "prometheus",
+ "prometheus-client",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand 0.8.5",
@@ -3078,6 +3078,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dunce"
@@ -7759,6 +7765,29 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -53,7 +53,7 @@ openssl = { version = "0.10.72", features = [
   "vendored",
 ] } # Needed to make arm compilation work by forcing vendoring
 pin-project-lite = "0.2.16"
-prometheus = "0.13"
+prometheus-client = "0.23.1"
 prost = "0.13.5"
 prost-types = "0.13.5"
 report = { workspace = true }

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -566,7 +566,7 @@ mod tests {
         let metrics_url = base_url.join("metrics").unwrap();
         let response = reqwest::get(metrics_url).await.unwrap();
         let metrics_text = response.text().await.unwrap();
-        assert!(metrics_text.contains(&format!("blocks_received {}", num_block_ends)));
+        assert!(metrics_text.contains(&format!("blocks_received_total {}", num_block_ends)));
 
         cancel_token.cancel();
     }

--- a/ampd/src/monitoring/endpoints/testdata/metrics_handle_message_increments_counter_successfully.golden
+++ b/ampd/src/monitoring/endpoints/testdata/metrics_handle_message_increments_counter_successfully.golden
@@ -1,3 +1,4 @@
-# HELP blocks_received number of blocks received
+# HELP blocks_received number of blocks received.
 # TYPE blocks_received counter
-blocks_received 3
+blocks_received_total 3
+# EOF

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -533,7 +533,7 @@ mod tests {
 
         let response = reqwest::get(metrics_url).await.unwrap();
         let metrics_text = response.text().await.unwrap();
-        assert!(metrics_text.contains("blocks_received 15"));
+        assert!(metrics_text.contains("blocks_received_total 15"));
 
         cancel.cancel();
         _ = server_handle.await;

--- a/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
+++ b/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
@@ -1,10 +1,12 @@
 Initial Metrics:
-# HELP blocks_received number of blocks received
+# HELP blocks_received number of blocks received.
 # TYPE blocks_received counter
-blocks_received 0
+blocks_received_total 0
+# EOF
 
 
 Updated Metrics:
-# HELP blocks_received number of blocks received
+# HELP blocks_received number of blocks received.
 # TYPE blocks_received counter
-blocks_received 3
+blocks_received_total 3
+# EOF


### PR DESCRIPTION
- replaced the older` prometheus crate` with `prometheus-client`
- response use `OpenMetrics` format 
- source: 
https://docs.rs/prometheus-client/latest/prometheus_client/ 
 https://github.com/prometheus/client_rust
