### PR TITLE
fix(ampd): add tx confirmation when executing commands 

### DIFF
--- a/ampd/src/broadcaster_v2/confirmer.rs
+++ b/ampd/src/broadcaster_v2/confirmer.rs
@@ -111,7 +111,11 @@ where
     }
 }
 
-async fn confirm_tx<T>(client: &T, tx_hash: String, retry_policy: RetryPolicy) -> Result<TxResponse>
+pub async fn confirm_tx<T>(
+    client: &T,
+    tx_hash: String,
+    retry_policy: RetryPolicy,
+) -> Result<TxResponse>
 where
     T: cosmos::CosmosClient + Clone,
 {

--- a/ampd/src/broadcaster_v2/mod.rs
+++ b/ampd/src/broadcaster_v2/mod.rs
@@ -30,7 +30,7 @@ mod tx;
 
 pub use broadcaster::Broadcaster;
 pub use config::Config;
-pub use confirmer::TxConfirmer;
+pub use confirmer::{confirm_tx, TxConfirmer};
 #[cfg(test)]
 pub use msg_queue::QueueMsg;
 pub use msg_queue::{MsgQueue, MsgQueueClient};

--- a/ampd/src/commands/bond_verifier.rs
+++ b/ampd/src/commands/bond_verifier.rs
@@ -7,24 +7,33 @@ use report::ResultCompatExt;
 use service_registry_api::msg::ExecuteMsg;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub service_name: nonempty::String,
-    pub amount: u128,
-    pub denom: String,
+    service_name: nonempty::String,
+    amount: u128,
+    denom: String,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
-    let coin = Coin::new(args.amount, args.denom.as_str()).change_context(Error::InvalidInput)?;
+    let Args {
+        denom,
+        amount,
+        service_name,
+        broadcast,
+    } = args;
+
+    let coin = Coin::new(amount, denom.as_str()).change_context(Error::InvalidInput)?;
 
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let msg = serde_json::to_vec(&ExecuteMsg::BondVerifier {
-        service_name: args.service_name.into(),
+        service_name: service_name.into(),
     })
     .expect("bond verifier msg should serialize");
 
@@ -37,7 +46,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast bond verifier transaction, tx hash: {}",

--- a/ampd/src/commands/claim_stake.rs
+++ b/ampd/src/commands/claim_stake.rs
@@ -6,20 +6,27 @@ use report::ResultCompatExt;
 use service_registry_api::msg::ExecuteMsg;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub service_name: nonempty::String,
+    service_name: nonempty::String,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
+    let Args {
+        service_name,
+        broadcast,
+    } = args;
+
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let msg = serde_json::to_vec(&ExecuteMsg::ClaimStake {
-        service_name: args.service_name.into(),
+        service_name: service_name.into(),
     })
     .expect("claim stake msg should be serializable");
 
@@ -32,7 +39,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast claim stake transaction, tx hash: {}",

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -111,7 +111,7 @@ async fn broadcast_tx(config: Config, tx: Any, pub_key: CosmosPublicKey) -> Resu
     broadcaster
         .broadcast(vec![tx].try_into().expect("must be non-empty"))
         .map_err(|err| err.change_context(Error::Broadcaster))
-        .and_then(|res| confirm_tx(broadcast, cosmos_client, res.txhash.clone()))
+        .and_then(|res| confirm_tx(broadcast, cosmos_client, res.txhash))
         .await
 }
 

--- a/ampd/src/commands/register_chain_support.rs
+++ b/ampd/src/commands/register_chain_support.rs
@@ -7,22 +7,30 @@ use router_api::ChainName;
 use service_registry_api::msg::ExecuteMsg;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub service_name: nonempty::String,
-    pub chain: ChainName,
+    service_name: nonempty::String,
+    chain: ChainName,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
+    let Args {
+        service_name,
+        chain,
+        broadcast,
+    } = args;
+
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let msg = serde_json::to_vec(&ExecuteMsg::RegisterChainSupport {
-        service_name: args.service_name.into(),
-        chains: vec![args.chain],
+        service_name: service_name.into(),
+        chains: vec![chain],
     })
     .expect("register chain support msg should serialize");
 
@@ -35,7 +43,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast register chain support transaction, tx hash: {}",

--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -10,7 +10,7 @@ use sha3::{Digest, Keccak256};
 use tracing::info;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::tofnd::{self, Multisig, MultisigClient};
 use crate::types::TMAddress;
@@ -43,9 +43,16 @@ impl From<KeyType> for multisig::key::KeyType {
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
     key_type: KeyType,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
+    let Args {
+        key_type,
+        broadcast,
+    } = args;
+
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let multisig_address = multisig_address(&config)?;
@@ -61,7 +68,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .change_context(Error::Connection)
     .attach_printable(tofnd_config.url)?;
     let multisig_key = multisig_client
-        .keygen(&multisig_address.to_string(), args.key_type.into())
+        .keygen(&multisig_address.to_string(), key_type.into())
         .await
         .change_context(Error::Tofnd)?;
 
@@ -75,14 +82,14 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
             &multisig_address.to_string(),
             address_hash,
             multisig_key,
-            args.key_type.into(),
+            key_type.into(),
         )
         .await
         .change_context(Error::Tofnd)?
         .into();
 
     let msg = serde_json::to_vec(&ExecuteMsg::RegisterPublicKey {
-        public_key: PublicKey::try_from((args.key_type.into(), multisig_key.to_bytes().into()))
+        public_key: PublicKey::try_from((key_type.into(), multisig_key.to_bytes().into()))
             .change_context(Error::Tofnd)?,
         signed_sender_address,
     })
@@ -97,7 +104,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast register public key transaction, tx hash: {}",

--- a/ampd/src/commands/send_tokens.rs
+++ b/ampd/src/commands/send_tokens.rs
@@ -6,24 +6,32 @@ use error_stack::Result;
 use report::ResultCompatExt;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub to_address: nonempty::String,
-    pub amount: u128,
-    pub denom: nonempty::String,
+    to_address: nonempty::String,
+    amount: u128,
+    denom: nonempty::String,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
-    let coin = Coin::new(args.amount, args.denom.as_str()).change_context(Error::InvalidInput)?;
+    let Args {
+        to_address,
+        amount,
+        denom,
+        broadcast,
+    } = args;
+
+    let coin = Coin::new(amount, denom.as_str()).change_context(Error::InvalidInput)?;
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let tx = MsgSend {
-        to_address: args
-            .to_address
+        to_address: to_address
             .parse::<AccountId>()
             .change_context(Error::InvalidInput)?,
         from_address: pub_key.account_id(PREFIX).change_context(Error::Tofnd)?,
@@ -32,7 +40,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast send transaction, tx hash: {}",

--- a/ampd/src/commands/set_rewards_proxy.rs
+++ b/ampd/src/commands/set_rewards_proxy.rs
@@ -6,22 +6,27 @@ use rewards::msg::ExecuteMsg;
 use router_api::Address;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub proxy_address: Address,
+    proxy_address: Address,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
+    let Args {
+        proxy_address,
+        broadcast,
+    } = args;
+
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
-    let msg = serde_json::to_vec(&ExecuteMsg::SetVerifierProxy {
-        proxy_address: args.proxy_address,
-    })
-    .expect("register chain support msg should serialize");
+    let msg = serde_json::to_vec(&ExecuteMsg::SetVerifierProxy { proxy_address })
+        .expect("register chain support msg should serialize");
 
     let tx = MsgExecuteContract {
         sender: pub_key.account_id(PREFIX).change_context(Error::Tofnd)?,
@@ -32,7 +37,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast set verifier proxy transaction, tx hash: {}",

--- a/ampd/src/commands/unbond_verifier.rs
+++ b/ampd/src/commands/unbond_verifier.rs
@@ -6,20 +6,27 @@ use report::ResultCompatExt;
 use service_registry_api::msg::ExecuteMsg;
 use valuable::Valuable;
 
-use crate::commands::{broadcast_tx, verifier_pub_key};
+use crate::commands::{broadcast_tx, verifier_pub_key, BroadcastArgs};
 use crate::config::Config;
 use crate::{Error, PREFIX};
 
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
-    pub service_name: nonempty::String,
+    service_name: nonempty::String,
+    #[clap(flatten)]
+    broadcast: BroadcastArgs,
 }
 
 pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
+    let Args {
+        service_name,
+        broadcast,
+    } = args;
+
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
     let msg = serde_json::to_vec(&ExecuteMsg::UnbondVerifier {
-        service_name: args.service_name.into(),
+        service_name: service_name.into(),
     })
     .expect("unbond verifier msg should be serializable");
 
@@ -32,7 +39,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    let tx_hash = broadcast_tx(config, tx, pub_key).await?;
+    let tx_hash = broadcast_tx(config, tx, pub_key, broadcast.skip_confirmation).await?;
 
     Ok(Some(format!(
         "successfully broadcast unbond verifier transaction, tx hash: {}",


### PR DESCRIPTION
## Description
Tries to fix this: https://github.com/axelarnetwork/axelarate/actions/runs/16352480999/job/46204604718

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
