### PR TITLE
Metrics/system2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "sui-gateway",
  "sui-json-rpc-types",
  "sui-types 0.1.0",
+ "sysinfo",
  "tendermint 0.35.0",
  "tendermint-proto 0.40.4",
  "tendermint-rpc",
@@ -5699,9 +5700,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -6707,6 +6708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6940,6 +6950,25 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -12054,6 +12083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13650,16 +13693,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.61.0"
+name = "windows"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -13686,9 +13762,19 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -13703,9 +13789,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -13721,9 +13807,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -13824,6 +13910,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -13,6 +13,7 @@ config = []
 url = []
 
 [dependencies]
+sysinfo = "0.36.1"
 ampd-proto = { workspace = true }
 async-trait = { workspace = true }
 axelar-solana-encoding = { workspace = true }

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -13,7 +13,6 @@ config = []
 url = []
 
 [dependencies]
-sysinfo = "0.36.1"
 ampd-proto = { workspace = true }
 async-trait = { workspace = true }
 axelar-solana-encoding = { workspace = true }
@@ -81,6 +80,7 @@ stellar-xdr = { workspace = true, features = ["serde_json"] }
 sui-gateway = { workspace = true }
 sui-json-rpc-types = { git = "https://github.com/mystenlabs/sui", tag = "testnet-v1.39.1" }
 sui-types = { git = "https://github.com/mystenlabs/sui", tag = "testnet-v1.39.1" }
+sysinfo = "0.36.1"
 tendermint = { workspace = true }
 tendermint-rpc = { version = "0.35.0", features = ["http-client"] }
 thiserror = { workspace = true }

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
 
 use axelar_wasm_std::voting::Vote;
 use axum::body::Body;
@@ -14,10 +14,8 @@ use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
-use std::sync::atomic::AtomicU64;
-use sysinfo::{get_current_pid, Pid, ProcessesToUpdate, ProcessRefreshKind};
-use sysinfo::System;
 use prometheus_client::registry::Registry;
+use sysinfo::{get_current_pid, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -44,7 +42,9 @@ pub enum Msg {
     VerificationVote {
         vote_status: Vote,
         chain_name: String,
-    },  
+    },
+    /// Update the system metrics
+    UpdateSystemMetrics { cpu_usage: f64, memory_usage: f64 },
 }
 
 /// Errors that can occur in metrics processing
@@ -113,8 +113,8 @@ impl Client {
 #[derive(Clone)]
 struct MetricsState {
     registry: Arc<Registry>,
+    client: Client,
     system_metrics_collector: SystemMetricsCollector,
-    metrics: Arc<Metrics>,
 }
 
 /// Creates a metrics endpoint with processor and client
@@ -140,33 +140,33 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
 
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
-    let metrics_arc = Arc::new(metrics);
+    let system_metrics_collector = SystemMetricsCollector::new();
 
+    let client = Client::WithChannel { sender: tx };
     let state = MetricsState {
         registry: Arc::new(registry),
-        system_metrics_collector: SystemMetricsCollector::new(),
-        metrics: metrics_arc.clone(),
+        client: client.clone(),
+        system_metrics_collector,
     };
 
     (
         get(serve_metrics).with_state(state),
-        Process::new(rx, Arc::clone(&metrics_arc)), // Use Arc::clone
-        Client::WithChannel { sender: tx },
+        Process::new(rx, metrics),
+        client,
     )
 }
-
 /// Background processor for handling metrics messages
 ///
 /// This processor runs in a separate task and updates metrics based on
 /// messages received from clients throughout the application.
 pub struct Process {
     stream: ReceiverStream<Msg>,
-    metrics: Arc<Metrics>, // Change to Arc<Metrics>
+    metrics: Metrics,
 }
 
 impl Process {
     /// Creates a new metrics processor
-    fn new(metrics_rx: mpsc::Receiver<Msg>, metrics: Arc<Metrics>) -> Self {
+    fn new(metrics_rx: mpsc::Receiver<Msg>, metrics: Metrics) -> Self {
         Self {
             stream: ReceiverStream::new(metrics_rx),
             metrics,
@@ -209,7 +209,11 @@ impl Process {
 async fn serve_metrics(
     State(state): State<MetricsState>,
 ) -> core::result::Result<Response<Body>, Error> {
-    state.metrics.update_system_metrics(&state.system_metrics_collector);
+    let system_metrics = state.system_metrics_collector.collect_metrics();
+    state.client.record_metric(Msg::UpdateSystemMetrics {
+        cpu_usage: system_metrics.cpu_usage,
+        memory_usage: system_metrics.memory_usage,
+    });
 
     let mut buffer = String::new();
     encode(&mut buffer, &state.registry)?;
@@ -281,15 +285,14 @@ impl Metrics {
                 self.verification_vote
                     .record_verification_vote(vote_status, chain_name);
             }
+            Msg::UpdateSystemMetrics {
+                cpu_usage,
+                memory_usage,
+            } => {
+                self.system_info.update_metrics(cpu_usage, memory_usage);
+            }
         }
     }
-
-    pub fn update_system_metrics(&self, collector: &SystemMetricsCollector) {
-        if let Some(metrics) = collector.collect_metrics() {
-            self.system_info.update_metrics(metrics);
-        }
-    }
-
 }
 
 impl BlockReceivedMetrics {
@@ -341,23 +344,31 @@ impl SystemInfoMetrics {
     fn new() -> Self {
         let cpu_usage = Gauge::<f64, AtomicU64>::default();
         let memory_usage = Gauge::<f64, AtomicU64>::default();
-        Self { cpu_usage, memory_usage }
+        Self {
+            cpu_usage,
+            memory_usage,
+        }
     }
 
     fn register(&self, registry: &mut Registry) {
-        registry.register("cpu_usage", "ampd cpu usage in percentage", self.cpu_usage.clone());
-        registry.register("memory_usage", "ampd memory usage in bytes", self.memory_usage.clone());
+        registry.register(
+            "cpu_usage",
+            "ampd cpu usage in percentage",
+            self.cpu_usage.clone(),
+        );
+        registry.register(
+            "memory_usage",
+            "ampd memory usage in bytes",
+            self.memory_usage.clone(),
+        );
     }
 
-    fn update_metrics(&self, metrics: ProcessMetrics) {
-        self.cpu_usage.set(metrics.cpu_usage);
-        self.memory_usage.set(metrics.memory_usage);
+    fn update_metrics(&self, cpu_usage: f64, memory_usage: f64) {
+        self.cpu_usage.set(cpu_usage);
+        self.memory_usage.set(memory_usage);
     }
 }
 
-
-
-// system metrics --------------------------------
 #[derive(Debug, Clone)]
 pub enum SystemMetricsCollector {
     Active(ActiveCollector),
@@ -376,16 +387,13 @@ pub struct ProcessMetrics {
     pub memory_usage: f64,
 }
 
-
 impl SystemMetricsCollector {
     pub fn new() -> Self {
         match get_current_pid() {
-            Ok(pid) => {
-                Self::Active(ActiveCollector {
-                    system: Arc::new(Mutex::new(System::new())),
-                    process_id: pid,
-                })
-            }
+            Ok(pid) => Self::Active(ActiveCollector {
+                system: Arc::new(Mutex::new(System::new())),
+                process_id: pid,
+            }),
             Err(e) => {
                 warn!("system metrics will not be available: {}", e);
                 Self::Dummy
@@ -393,47 +401,52 @@ impl SystemMetricsCollector {
         }
     }
 
-    pub fn collect_metrics(&self) -> Option<ProcessMetrics> {
+    pub fn collect_metrics(&self) -> ProcessMetrics {
         match self {
             Self::Active(collector) => collector.collect_metrics(),
-            Self::Dummy => Some(ProcessMetrics {
+            Self::Dummy => ProcessMetrics {
                 cpu_usage: 0.0,
                 memory_usage: 0.0,
-            }),
+            },
         }
     }
 }
 
 impl ActiveCollector {
-    pub fn collect_metrics(&self) -> Option<ProcessMetrics> {
+    pub fn collect_metrics(&self) -> ProcessMetrics {
         let mut system = self.system.lock().unwrap();
-        
+
         // First refresh to get initial state
         system.refresh_processes_specifics(
             ProcessesToUpdate::Some(&[self.process_id]),
             true,
-            ProcessRefreshKind::nothing().with_cpu().with_memory()
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
         );
-        
+
         // Wait for minimum interval and refresh again for accurate CPU usage
         std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
-        
+
         system.refresh_processes_specifics(
             ProcessesToUpdate::Some(&[self.process_id]),
             true,
-            ProcessRefreshKind::nothing().with_cpu().with_memory()
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
         );
-        
-        system.process(self.process_id).map(|process| {
-            ProcessMetrics {
+
+        match system.process(self.process_id) {
+            Some(process) => ProcessMetrics {
                 cpu_usage: process.cpu_usage() as f64,
                 memory_usage: process.memory() as f64,
+            },
+            None => {
+                warn!("system metrics is not available");
+                ProcessMetrics {
+                    cpu_usage: 0.0,
+                    memory_usage: 0.0,
+                }
             }
-        })
+        }
     }
 }
-
-    
 
 #[cfg(test)]
 mod tests {

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use axelar_wasm_std::voting::Vote;
 use axum::body::Body;
@@ -12,6 +13,10 @@ use prometheus_client::encoding::text::encode;
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use std::sync::atomic::AtomicU64;
+use sysinfo::{get_current_pid, Pid, ProcessesToUpdate, ProcessRefreshKind};
+use sysinfo::System;
 use prometheus_client::registry::Registry;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -39,7 +44,7 @@ pub enum Msg {
     VerificationVote {
         vote_status: Vote,
         chain_name: String,
-    },
+    },  
 }
 
 /// Errors that can occur in metrics processing
@@ -105,6 +110,13 @@ impl Client {
     }
 }
 
+#[derive(Clone)]
+struct MetricsState {
+    registry: Arc<Registry>,
+    system_metrics_collector: SystemMetricsCollector,
+    metrics: Arc<Metrics>,
+}
+
 /// Creates a metrics endpoint with processor and client
 ///
 /// This function sets up the complete metrics infrastructure:
@@ -128,10 +140,17 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
 
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
+    let metrics_arc = Arc::new(metrics);
+
+    let state = MetricsState {
+        registry: Arc::new(registry),
+        system_metrics_collector: SystemMetricsCollector::new(),
+        metrics: metrics_arc.clone(),
+    };
 
     (
-        get(serve_metrics).with_state(Arc::new(registry)),
-        Process::new(rx, metrics),
+        get(serve_metrics).with_state(state),
+        Process::new(rx, Arc::clone(&metrics_arc)), // Use Arc::clone
         Client::WithChannel { sender: tx },
     )
 }
@@ -142,12 +161,12 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
 /// messages received from clients throughout the application.
 pub struct Process {
     stream: ReceiverStream<Msg>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>, // Change to Arc<Metrics>
 }
 
 impl Process {
     /// Creates a new metrics processor
-    fn new(metrics_rx: mpsc::Receiver<Msg>, metrics: Metrics) -> Self {
+    fn new(metrics_rx: mpsc::Receiver<Msg>, metrics: Arc<Metrics>) -> Self {
         Self {
             stream: ReceiverStream::new(metrics_rx),
             metrics,
@@ -188,10 +207,12 @@ impl Process {
 }
 
 async fn serve_metrics(
-    State(registry): State<Arc<Registry>>,
+    State(state): State<MetricsState>,
 ) -> core::result::Result<Response<Body>, Error> {
+    state.metrics.update_system_metrics(&state.system_metrics_collector);
+
     let mut buffer = String::new();
-    encode(&mut buffer, &registry)?;
+    encode(&mut buffer, &state.registry)?;
     let response = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, OPENMETRICS_CONTENT_TYPE)
@@ -202,6 +223,12 @@ async fn serve_metrics(
 struct Metrics {
     block_received: BlockReceivedMetrics,
     verification_vote: VerificationVoteMetrics,
+    system_info: SystemInfoMetrics,
+}
+
+struct SystemInfoMetrics {
+    cpu_usage: Gauge<f64, AtomicU64>,
+    memory_usage: Gauge<f64, AtomicU64>,
 }
 
 struct BlockReceivedMetrics {
@@ -228,13 +255,16 @@ impl Metrics {
     pub fn new(registry: &mut Registry) -> Self {
         let block_received = BlockReceivedMetrics::new();
         let verification_vote = VerificationVoteMetrics::new();
+        let system_info = SystemInfoMetrics::new();
 
         block_received.register(registry);
         verification_vote.register(registry);
+        system_info.register(registry);
 
         Self {
             block_received,
             verification_vote,
+            system_info,
         }
     }
 
@@ -253,6 +283,13 @@ impl Metrics {
             }
         }
     }
+
+    pub fn update_system_metrics(&self, collector: &SystemMetricsCollector) {
+        if let Some(metrics) = collector.collect_metrics() {
+            self.system_info.update_metrics(metrics);
+        }
+    }
+
 }
 
 impl BlockReceivedMetrics {
@@ -299,6 +336,104 @@ impl VerificationVoteMetrics {
         self.total.get_or_create(&label).inc();
     }
 }
+
+impl SystemInfoMetrics {
+    fn new() -> Self {
+        let cpu_usage = Gauge::<f64, AtomicU64>::default();
+        let memory_usage = Gauge::<f64, AtomicU64>::default();
+        Self { cpu_usage, memory_usage }
+    }
+
+    fn register(&self, registry: &mut Registry) {
+        registry.register("cpu_usage", "ampd cpu usage in percentage", self.cpu_usage.clone());
+        registry.register("memory_usage", "ampd memory usage in bytes", self.memory_usage.clone());
+    }
+
+    fn update_metrics(&self, metrics: ProcessMetrics) {
+        self.cpu_usage.set(metrics.cpu_usage);
+        self.memory_usage.set(metrics.memory_usage);
+    }
+}
+
+
+
+// system metrics --------------------------------
+#[derive(Debug, Clone)]
+pub enum SystemMetricsCollector {
+    Active(ActiveCollector),
+    Dummy,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActiveCollector {
+    system: Arc<Mutex<System>>,
+    process_id: Pid,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcessMetrics {
+    pub cpu_usage: f64,
+    pub memory_usage: f64,
+}
+
+
+impl SystemMetricsCollector {
+    pub fn new() -> Self {
+        match get_current_pid() {
+            Ok(pid) => {
+                Self::Active(ActiveCollector {
+                    system: Arc::new(Mutex::new(System::new())),
+                    process_id: pid,
+                })
+            }
+            Err(e) => {
+                warn!("system metrics will not be available: {}", e);
+                Self::Dummy
+            }
+        }
+    }
+
+    pub fn collect_metrics(&self) -> Option<ProcessMetrics> {
+        match self {
+            Self::Active(collector) => collector.collect_metrics(),
+            Self::Dummy => Some(ProcessMetrics {
+                cpu_usage: 0.0,
+                memory_usage: 0.0,
+            }),
+        }
+    }
+}
+
+impl ActiveCollector {
+    pub fn collect_metrics(&self) -> Option<ProcessMetrics> {
+        let mut system = self.system.lock().unwrap();
+        
+        // First refresh to get initial state
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[self.process_id]),
+            true,
+            ProcessRefreshKind::nothing().with_cpu().with_memory()
+        );
+        
+        // Wait for minimum interval and refresh again for accurate CPU usage
+        std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+        
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[self.process_id]),
+            true,
+            ProcessRefreshKind::nothing().with_cpu().with_memory()
+        );
+        
+        system.process(self.process_id).map(|process| {
+            ProcessMetrics {
+                cpu_usage: process.cpu_usage() as f64,
+                memory_usage: process.memory() as f64,
+            }
+        })
+    }
+}
+
+    
 
 #[cfg(test)]
 mod tests {

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -141,8 +141,9 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
     let system_metrics_collector = SystemMetricsCollector::new();
-
+    
     let client = Client::WithChannel { sender: tx };
+
     let state = MetricsState {
         registry: Arc::new(registry),
         client: client.clone(),
@@ -369,6 +370,14 @@ impl SystemInfoMetrics {
     }
 }
 
+/// System metrics collector
+///
+/// This collector provides on-demand collection of CPU and memory metrics
+/// for the current AMPD process. It gracefully handles platform limitations
+/// and permission issues by falling back to dummy metrics when necessary.
+///
+/// `Active` - Can collect real system metrics from the OS
+/// `Dummy` - Returns zero metrics when system access is unavailable
 #[derive(Debug, Clone)]
 pub enum SystemMetricsCollector {
     Active(ActiveCollector),
@@ -390,10 +399,15 @@ pub struct ProcessMetrics {
 impl SystemMetricsCollector {
     pub fn new() -> Self {
         match get_current_pid() {
-            Ok(pid) => Self::Active(ActiveCollector {
-                system: Arc::new(Mutex::new(System::new())),
-                process_id: pid,
-            }),
+            Ok(pid) => {
+                let mut system = System::new();
+                refresh_process_metrics(&mut system, pid);
+                
+                Self::Active(ActiveCollector {
+                    system: Arc::new(Mutex::new(system)),
+                    process_id: pid,
+                })
+            },
             Err(e) => {
                 warn!("system metrics will not be available: {}", e);
                 Self::Dummy
@@ -412,31 +426,22 @@ impl SystemMetricsCollector {
     }
 }
 
+/// Collects system metrics by querying the OS for process information.
+/// CPU usage calculation requires two measurements over time - since this is called
+/// on-demand during Prometheus scraping, the measurement interval matches the scrape period.
+
 impl ActiveCollector {
     pub fn collect_metrics(&self) -> ProcessMetrics {
         let mut system = self.system.lock().unwrap();
-
-        // First refresh to get initial state
-        system.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&[self.process_id]),
-            true,
-            ProcessRefreshKind::nothing().with_cpu().with_memory(),
-        );
-
-        // Wait for minimum interval and refresh again for accurate CPU usage
-        std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
-
-        system.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&[self.process_id]),
-            true,
-            ProcessRefreshKind::nothing().with_cpu().with_memory(),
-        );
+        refresh_process_metrics(&mut system, self.process_id);
 
         match system.process(self.process_id) {
             Some(process) => ProcessMetrics {
                 cpu_usage: process.cpu_usage() as f64,
                 memory_usage: process.memory() as f64,
             },
+            // if the process is not found, return zero metrics and log a warning
+            // this may happens because of permission issues, process termination, or platform limitations
             None => {
                 warn!("system metrics is not available");
                 ProcessMetrics {
@@ -448,6 +453,15 @@ impl ActiveCollector {
     }
 }
 
+
+fn refresh_process_metrics(system: &mut System, process_id: Pid) {
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[process_id]),
+        true,
+        ProcessRefreshKind::nothing().with_cpu().with_memory(),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -455,6 +469,7 @@ mod tests {
     use axum::Router;
     use axum_test::TestServer;
     use tokio::time;
+    use super::test_utils::filter_system_metrics_output;
 
     use super::*;
 
@@ -482,7 +497,7 @@ mod tests {
         final_metrics.assert_status_ok();
 
         // Ensure the final metrics are in the expected format
-        goldie::assert!(final_metrics.text())
+        goldie::assert!(filter_system_metrics_output(&final_metrics.text()))
     }
 
     #[tokio::test(start_paused = true)]
@@ -517,9 +532,7 @@ mod tests {
         let final_metrics = server.get("/test").await;
         final_metrics.assert_status_ok();
 
-        println!("{}", final_metrics.text());
-
-        goldie::assert!(sort_metrics_output(&final_metrics.text()))
+        goldie::assert!(sort_metrics_output(&filter_system_metrics_output(&final_metrics.text())))
     }
 
     #[test]
@@ -534,6 +547,37 @@ mod tests {
 
         assert_eq!(sorted_data1, sorted_data2);
         goldie::assert!(sorted_data1);
+    }
+   
+    #[tokio::test(start_paused = true)]
+    async fn should_include_system_metrics_in_prometheus_output() {
+        let (router, process, _client) = create_endpoint();
+        _ = process.run(CancellationToken::new());
+
+        let router = Router::new().route("/test", router);
+        let server = TestServer::new(router).unwrap();
+
+        let initial_metrics = server.get("/test").await;
+        initial_metrics.assert_status_ok();
+        time::sleep(Duration::from_secs(1)).await;   
+
+        let final_metrics = server.get("/test").await;
+        final_metrics.assert_status_ok();
+
+        assert!(metric_value(&final_metrics.text(), "cpu_usage")    > 0.0);
+        assert!(metric_value(&final_metrics.text(), "memory_usage") > 0.0);
+    }
+
+    /// Extracts the numeric value of a Prometheus metric from text output
+    /// 
+    /// panic if the metric is not found or not a number
+    /// used when asserting system metrics
+    fn metric_value(text: &str, name: &str) -> f64 {
+        text.lines()
+            .find(|l| l.starts_with(name))
+            .and_then(|line| line.split_whitespace().nth(1))  
+            .and_then(|num| num.parse::<f64>().ok())
+            .expect(&format!("metric `{}` not found or not a number", name))
     }
 
     /// Sort metrics text alphabetically by line for consistent output
@@ -566,6 +610,24 @@ mod tests {
             }
         }
 
+        result.join("\n") + "\n"
+    }
+}
+
+/// Filters out dynamic system metrics from Prometheus output for stable golden file tests
+/// System metrics like CPU and memory usage are inherently dynamic and change between test runs
+/// This function removes these metrics to create stable, predictable output for testing.
+#[cfg(test)]
+pub mod test_utils {
+    pub fn filter_system_metrics_output(text: &str) -> String {
+        let mut result = Vec::new();    
+        for line in text.lines() {
+            if line.contains("cpu_usage") || line.contains("memory_usage") {
+                continue;
+            }
+            result.push(line.to_string());
+        }
+    
         result.join("\n") + "\n"
     }
 }

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -43,7 +43,7 @@ pub enum Msg {
         vote_status: Vote,
         chain_name: String,
     },
-    /// Update the system metrics
+    /// Update the system metrics for ampd process
     UpdateSystemMetrics { cpu_usage: f64, memory_usage: f64 },
 }
 
@@ -141,7 +141,7 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
     let system_metrics_collector = SystemMetricsCollector::new();
-    
+
     let client = Client::WithChannel { sender: tx };
 
     let state = MetricsState {
@@ -151,7 +151,7 @@ pub fn create_endpoint() -> (MethodRouter, Process, Client) {
     };
 
     (
-        get(serve_metrics).with_state(state),
+        get(handle_metrics_request).with_state(state),
         Process::new(rx, metrics),
         client,
     )
@@ -207,14 +207,10 @@ impl Process {
     }
 }
 
-async fn serve_metrics(
+async fn handle_metrics_request(
     State(state): State<MetricsState>,
 ) -> core::result::Result<Response<Body>, Error> {
-    let system_metrics = state.system_metrics_collector.collect_metrics();
-    state.client.record_metric(Msg::UpdateSystemMetrics {
-        cpu_usage: system_metrics.cpu_usage,
-        memory_usage: system_metrics.memory_usage,
-    });
+    update_system_metrics(&state);
 
     let mut buffer = String::new();
     encode(&mut buffer, &state.registry)?;
@@ -223,6 +219,17 @@ async fn serve_metrics(
         .header(CONTENT_TYPE, OPENMETRICS_CONTENT_TYPE)
         .body(Body::from(buffer))?;
     Ok(response)
+}
+
+fn update_system_metrics(state: &MetricsState) {
+    let ProcessMetrics {
+        cpu_usage,
+        memory_usage,
+    } = state.system_metrics_collector.collect_metrics();
+    state.client.record_metric(Msg::UpdateSystemMetrics {
+        cpu_usage,
+        memory_usage,
+    });
 }
 
 struct Metrics {
@@ -376,16 +383,16 @@ impl SystemInfoMetrics {
 /// for the current AMPD process. It gracefully handles platform limitations
 /// and permission issues by falling back to dummy metrics when necessary.
 ///
-/// `Active` - Can collect real system metrics from the OS
-/// `Dummy` - Returns zero metrics when system access is unavailable
+/// `Available` - collect real system metrics from the OS
+/// `Unavailable` - Returns zero metrics when system access is unavailable
 #[derive(Debug, Clone)]
 pub enum SystemMetricsCollector {
-    Active(ActiveCollector),
-    Dummy,
+    Available(SysInfoCollector),
+    Unavailable,
 }
 
 #[derive(Debug, Clone)]
-pub struct ActiveCollector {
+pub struct SysInfoCollector {
     system: Arc<Mutex<System>>,
     process_id: Pid,
 }
@@ -402,23 +409,23 @@ impl SystemMetricsCollector {
             Ok(pid) => {
                 let mut system = System::new();
                 refresh_process_metrics(&mut system, pid);
-                
-                Self::Active(ActiveCollector {
+
+                Self::Available(SysInfoCollector {
                     system: Arc::new(Mutex::new(system)),
                     process_id: pid,
                 })
-            },
+            }
             Err(e) => {
                 warn!("system metrics will not be available: {}", e);
-                Self::Dummy
+                Self::Unavailable
             }
         }
     }
 
     pub fn collect_metrics(&self) -> ProcessMetrics {
         match self {
-            Self::Active(collector) => collector.collect_metrics(),
-            Self::Dummy => ProcessMetrics {
+            Self::Available(collector) => collector.collect_metrics(),
+            Self::Unavailable => ProcessMetrics {
                 cpu_usage: 0.0,
                 memory_usage: 0.0,
             },
@@ -430,7 +437,7 @@ impl SystemMetricsCollector {
 /// CPU usage calculation requires two measurements over time - since this is called
 /// on-demand during Prometheus scraping, the measurement interval matches the scrape period.
 
-impl ActiveCollector {
+impl SysInfoCollector {
     pub fn collect_metrics(&self) -> ProcessMetrics {
         let mut system = self.system.lock().unwrap();
         refresh_process_metrics(&mut system, self.process_id);
@@ -440,7 +447,7 @@ impl ActiveCollector {
                 cpu_usage: process.cpu_usage() as f64,
                 memory_usage: process.memory() as f64,
             },
-            // if the process is not found, return zero metrics and log a warning
+            // if the process info is not found, return zero metrics and log a warning
             // this may happens because of permission issues, process termination, or platform limitations
             None => {
                 warn!("system metrics is not available");
@@ -452,7 +459,6 @@ impl ActiveCollector {
         }
     }
 }
-
 
 fn refresh_process_metrics(system: &mut System, process_id: Pid) {
     system.refresh_processes_specifics(
@@ -469,8 +475,8 @@ mod tests {
     use axum::Router;
     use axum_test::TestServer;
     use tokio::time;
-    use super::test_utils::filter_system_metrics_output;
 
+    use super::test_utils::filter_system_metrics_output;
     use super::*;
 
     #[tokio::test(start_paused = true)]
@@ -532,7 +538,9 @@ mod tests {
         let final_metrics = server.get("/test").await;
         final_metrics.assert_status_ok();
 
-        goldie::assert!(sort_metrics_output(&filter_system_metrics_output(&final_metrics.text())))
+        goldie::assert!(sort_metrics_output(&filter_system_metrics_output(
+            &final_metrics.text()
+        )))
     }
 
     #[test]
@@ -548,7 +556,7 @@ mod tests {
         assert_eq!(sorted_data1, sorted_data2);
         goldie::assert!(sorted_data1);
     }
-   
+
     #[tokio::test(start_paused = true)]
     async fn should_include_system_metrics_in_prometheus_output() {
         let (router, process, _client) = create_endpoint();
@@ -559,23 +567,23 @@ mod tests {
 
         let initial_metrics = server.get("/test").await;
         initial_metrics.assert_status_ok();
-        time::sleep(Duration::from_secs(1)).await;   
+        time::sleep(Duration::from_secs(1)).await;
 
         let final_metrics = server.get("/test").await;
         final_metrics.assert_status_ok();
 
-        assert!(metric_value(&final_metrics.text(), "cpu_usage")    > 0.0);
+        assert!(metric_value(&final_metrics.text(), "cpu_usage") > 0.0);
         assert!(metric_value(&final_metrics.text(), "memory_usage") > 0.0);
     }
 
     /// Extracts the numeric value of a Prometheus metric from text output
-    /// 
+    ///
     /// panic if the metric is not found or not a number
     /// used when asserting system metrics
     fn metric_value(text: &str, name: &str) -> f64 {
         text.lines()
             .find(|l| l.starts_with(name))
-            .and_then(|line| line.split_whitespace().nth(1))  
+            .and_then(|line| line.split_whitespace().nth(1))
             .and_then(|num| num.parse::<f64>().ok())
             .expect(&format!("metric `{}` not found or not a number", name))
     }
@@ -620,14 +628,14 @@ mod tests {
 #[cfg(test)]
 pub mod test_utils {
     pub fn filter_system_metrics_output(text: &str) -> String {
-        let mut result = Vec::new();    
+        let mut result = Vec::new();
         for line in text.lines() {
             if line.contains("cpu_usage") || line.contains("memory_usage") {
                 continue;
             }
             result.push(line.to_string());
         }
-    
+
         result.join("\n") + "\n"
     }
 }

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -327,6 +327,7 @@ mod tests {
 
     use super::*;
     use crate::monitoring::endpoints::status::Status;
+    use crate::monitoring::endpoints::metrics::test_utils::filter_system_metrics_output;
 
     #[test]
     fn ensure_correct_default_config() {
@@ -530,7 +531,7 @@ mod tests {
             initial_text, updated_text
         );
 
-        goldie::assert!(output);
+        goldie::assert!(filter_system_metrics_output(&output));
         cancel.cancel();
         _ = server_handle.await;
     }

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -326,8 +326,8 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::monitoring::endpoints::status::Status;
     use crate::monitoring::endpoints::metrics::test_utils::filter_system_metrics_output;
+    use crate::monitoring::endpoints::status::Status;
 
     #[test]
     fn ensure_correct_default_config() {


### PR DESCRIPTION
Tracked:
`Current CPU usage percentage of the ampd process`
`Current memory usage in bytes of the ampd process`
https://github.com/GuillaumeGomez/sysinfo
The metrics are collected using the `sysinfo` library, which provides cross-platform access to` process` and `system information`.

 platform limitation, missing permission, or other failure will default the system metric to `0`.

The sysinfo crate supports the following platforms:
https://docs.rs/crate/sysinfo/latest?
Linux
macOS
Windows
Android
iOS
FreeBSD
Raspberry Pi

On unsupported platforms or restricted permissions, process system metrics may not be available. metrics will fallback with values of 0.
(such as android or sandboxed macOS/iOS)
https://docs.rs/sysinfo/latest/sysinfo/struct.Process.html?utm_source=chatgpt.com

