### PR TITLE
refactor(tests): use `chain_name_raw!` in tests instead of `ChainNameRaw::from_str`

### DIFF
--- a/ampd/src/xrpl/verifier.rs
+++ b/ampd/src/xrpl/verifier.rs
@@ -320,7 +320,7 @@ mod test {
 
     use axelar_wasm_std::msg_id::HexTxHash;
     use axelar_wasm_std::nonempty;
-    use router_api::ChainNameRaw;
+    use router_api::chain_name_raw;
     use xrpl_http_client::Memo;
     use xrpl_types::msg::XRPLInterchainTransferMessage;
     use xrpl_types::types::{XRPLAccountId, XRPLPaymentAmount};
@@ -363,7 +363,7 @@ mod test {
                 "592639c10223c4ec6c0ffc670e94d289a25dd1ad".to_string(),
             )
             .unwrap(),
-            destination_chain: ChainNameRaw::from_str("Ethereum").unwrap(),
+            destination_chain: chain_name_raw!("Ethereum"),
             payload_hash: Some(
                 hex::decode("40e7ed31929500a6a4945765612bac44a71fe18ef7a1bf3d904811558b41354f")
                     .unwrap()
@@ -417,7 +417,7 @@ mod test {
                 "592639c10223c4ec6c0ffc670e94d289a25dd1ad".to_string(),
             )
             .unwrap(),
-            destination_chain: ChainNameRaw::from_str("ethereum").unwrap(),
+            destination_chain: chain_name_raw!("ethereum"),
             payload_hash: None,
             transfer_amount: XRPLPaymentAmount::Drops(100000),
             gas_fee_amount: XRPLPaymentAmount::Drops(50000),

--- a/contracts/its-abi-translator/src/abi.rs
+++ b/contracts/its-abi-translator/src/abi.rs
@@ -306,15 +306,13 @@ fn from_vec(value: std::vec::Vec<u8>) -> Result<Option<nonempty::HexBinary>, Err
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use alloy_primitives::{FixedBytes, U256};
     use alloy_sol_types::SolValue;
     use assert_ok::assert_ok;
     use axelar_wasm_std::{assert_err_contains, nonempty};
     use cosmwasm_std::{HexBinary, Uint256};
     use interchain_token_service_std::HubMessage;
-    use router_api::ChainNameRaw;
+    use router_api::chain_name_raw;
 
     use super::{DeployInterchainToken, InterchainTransfer};
     use crate::abi::{
@@ -327,7 +325,7 @@ mod tests {
 
     #[test]
     fn interchain_transfer_encode_decode() {
-        let remote_chain = ChainNameRaw::from_str("chain").unwrap();
+        let remote_chain = chain_name_raw!("chain");
 
         let cases = vec![
             HubMessage::SendToHub {
@@ -455,7 +453,7 @@ mod tests {
 
     #[test]
     fn deploy_interchain_token_encode_decode() {
-        let remote_chain = ChainNameRaw::from_str("chain").unwrap();
+        let remote_chain = chain_name_raw!("chain");
 
         let cases = vec![
             HubMessage::SendToHub {
@@ -542,7 +540,7 @@ mod tests {
 
     #[test]
     fn link_token_encode_decode() {
-        let remote_chain = ChainNameRaw::from_str("chain").unwrap();
+        let remote_chain = chain_name_raw!("chain");
 
         let cases = vec![
             HubMessage::SendToHub {
@@ -706,7 +704,7 @@ mod tests {
     fn encode_decode_large_data() {
         let large_data = vec![0u8; 1024 * 1024]; // 1MB of data
         let original = HubMessage::SendToHub {
-            destination_chain: ChainNameRaw::from_str("large-data-chain").unwrap(),
+            destination_chain: chain_name_raw!("large-data-chain"),
             message: interchain_token_service_std::InterchainTransfer {
                 token_id: [0u8; 32].into(),
                 source_address: from_hex("1234"),
@@ -725,7 +723,7 @@ mod tests {
     #[test]
     fn encode_decode_unicode_strings() {
         let original = HubMessage::SendToHub {
-            destination_chain: ChainNameRaw::from_str("chain").unwrap(),
+            destination_chain: chain_name_raw!("chain"),
             message: interchain_token_service_std::DeployInterchainToken {
                 token_id: [0u8; 32].into(),
                 name: "Unicode Token 🪙".try_into().unwrap(),


### PR DESCRIPTION
## Description
- Replaced instances of `ChainNameRaw::from_str` using string literals with the macro `chain_name_raw!`.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
