### PR TITLE
refactor(tests): use `address!` macro instead of string conversion

### DIFF
--- a/ampd/src/handlers/stacks_verify_msg.rs
+++ b/ampd/src/handlers/stacks_verify_msg.rs
@@ -217,7 +217,7 @@ mod tests {
     use cosmwasm_std;
     use error_stack::Result;
     use ethers_core::types::H160;
-    use router_api::ChainName;
+    use router_api::{address, ChainName};
     use tokio::sync::watch;
     use tokio::test as async_test;
     use voting_verifier::events::{PollMetadata, PollStarted, TxEventConfirmation};
@@ -493,7 +493,7 @@ mod tests {
                 tx_id: msg_id.tx_hash_as_hex(),
                 event_index: u32::try_from(msg_id.event_index).unwrap(),
                 message_id: msg_id.to_string().parse().unwrap(),
-                source_address: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".parse().unwrap(),
+                source_address: address!("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"),
                 destination_chain: "ethereum".parse().unwrap(),
                 destination_address: format!("0x{:x}", H160::repeat_byte(2)).parse().unwrap(),
                 payload_hash: [1; 32],

--- a/ampd/src/handlers/starknet_verify_msg.rs
+++ b/ampd/src/handlers/starknet_verify_msg.rs
@@ -178,6 +178,7 @@ mod tests {
     use ethers_core::types::H256;
     use events::Event;
     use mockall::predicate::eq;
+    use router_api::address;
     use starknet_core::types::Felt;
     use tendermint::abci;
     use tokio::sync::watch;
@@ -525,7 +526,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: "destination-address".parse().unwrap(),
+                    destination_address: address!("destination-address"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123, 86,
@@ -548,7 +549,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum-1".parse().unwrap(),
-                    destination_address: "destination-address-1".parse().unwrap(),
+                    destination_address: address!("destination-address-1"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28u8, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123,
@@ -592,7 +593,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: "destination-address".parse().unwrap(),
+                    destination_address: address!("destination-address"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123, 86,
@@ -615,7 +616,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: "destination-address".parse().unwrap(),
+                    destination_address: address!("destination-address"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28u8, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123,
@@ -659,7 +660,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: "destination-address".parse().unwrap(),
+                    destination_address: address!("destination-address"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28u8, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123,
@@ -682,7 +683,7 @@ mod tests {
                             .parse()
                             .unwrap(),
                     destination_chain: "ethereum".parse().unwrap(),
-                    destination_address: "destination-address".parse().unwrap(),
+                    destination_address: address!("destination-address"),
                     payload_hash: H256::from_slice(&[
                         // keccak256("hello")
                         28u8, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123,

--- a/contracts/axelarnet-gateway/src/clients/external.rs
+++ b/contracts/axelarnet-gateway/src/clients/external.rs
@@ -44,7 +44,7 @@ impl<'a> Client<'a> {
 mod test {
     use cosmwasm_std::testing::{mock_dependencies, MockApi};
     use cosmwasm_std::{to_json_binary, HexBinary, WasmMsg};
-    use router_api::CrossChainId;
+    use router_api::{address, CrossChainId};
 
     use crate::clients::external;
 
@@ -55,7 +55,7 @@ mod test {
         let destination_addr = MockApi::default().addr_make("axelar-executable");
 
         let executable_msg = external::AxelarExecutableMsg {
-            source_address: "source-address".parse().unwrap(),
+            source_address: address!("source-address"),
             payload: HexBinary::from(vec![1, 2, 3]),
             cc_id: CrossChainId::new("source-chain", "message-id").unwrap(),
         };

--- a/contracts/axelarnet-gateway/src/clients/gateway.rs
+++ b/contracts/axelarnet-gateway/src/clients/gateway.rs
@@ -66,6 +66,7 @@ mod test {
 
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockQuerier};
     use cosmwasm_std::{from_json, to_json_binary, Addr, QuerierWrapper, WasmMsg, WasmQuery};
+    use router_api::address;
 
     use super::*;
     use crate::contract::{instantiate, query};
@@ -90,7 +91,7 @@ mod test {
             client::ContractClient::new(QuerierWrapper::new(&querier), &addr).into();
 
         let destination_chain: ChainName = "destination-chain".parse().unwrap();
-        let destination_address: Address = "destination-address".parse().unwrap();
+        let destination_address = address!("destination-address");
         let payload = HexBinary::from(vec![1, 2, 3]);
 
         let msg = client.call_contract(

--- a/contracts/axelarnet-gateway/tests/execute.rs
+++ b/contracts/axelarnet-gateway/tests/execute.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::testing::{message_info, mock_dependencies};
 use cosmwasm_std::HexBinary;
 use rand::RngCore;
 use router_api::msg::ExecuteMsg as RouterExecuteMsg;
-use router_api::{CrossChainId, Message};
+use router_api::{address, CrossChainId, Message};
 
 use crate::utils::{
     axelar_query_handler, messages, mock_axelar_dependencies, params, OwnedDepsExt,
@@ -170,7 +170,7 @@ fn route_from_router_multiple_times_with_data_mismatch_fails() {
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
     utils::route_from_router(deps.as_default_mut(), msgs.clone()).unwrap();
 
-    msgs[0].source_address = "wrong-address".parse().unwrap();
+    msgs[0].source_address = address!("wrong-address");
 
     assert_err_contains!(
         utils::route_from_router(deps.as_default_mut(), msgs),
@@ -267,7 +267,7 @@ fn route_to_router_after_contract_call_with_tempered_data_fails() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = "destination-chain".parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
@@ -309,7 +309,7 @@ fn route_to_router_after_contract_call_succeeds_multiple_times() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = "destination-chain".parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
@@ -350,7 +350,7 @@ fn route_to_router_after_contract_call_ignores_duplicates() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = "destination-chain".parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
@@ -393,7 +393,7 @@ fn contract_call_returns_correct_message() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = "destination-chain".parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
@@ -426,7 +426,7 @@ fn contract_call_returns_correct_events() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = "destination-chain".parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();
@@ -471,7 +471,7 @@ fn route_to_router_after_contract_call_to_self_succeeds_multiple_times() {
         .with_custom_handler(axelar_query_handler(tx_hash, nonce, false));
 
     let destination_chain = params::AXELARNET.parse().unwrap();
-    let destination_address = "destination-address".parse().unwrap();
+    let destination_address = address!("destination-address");
     let payload = vec![1, 2, 3].into();
 
     utils::instantiate_contract(deps.as_default_mut()).unwrap();

--- a/contracts/axelarnet-gateway/tests/query.rs
+++ b/contracts/axelarnet-gateway/tests/query.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::testing::{
 use cosmwasm_std::{from_json, ContractResult, Deps, OwnedDeps, SystemResult};
 use rand::RngCore;
 use router_api::msg::ExecuteMsg as RouterExecuteMsg;
-use router_api::{ChainName, CrossChainId, Message};
+use router_api::{address, ChainName, CrossChainId, Message};
 use serde_json::json;
 use sha3::{Digest, Keccak256};
 
@@ -120,7 +120,7 @@ fn populate_executable_messages(
     let msgs: Vec<_> = (0..10)
         .map(|i| Message {
             cc_id: CrossChainId::new("source-chain", format!("hash-index-{}", i)).unwrap(),
-            source_address: "source-address".parse().unwrap(),
+            source_address: address!("source-address"),
             destination_chain: params::AXELARNET.parse().unwrap(),
             destination_address: deps
                 .api

--- a/contracts/axelarnet-gateway/tests/utils/messages.rs
+++ b/contracts/axelarnet-gateway/tests/utils/messages.rs
@@ -1,6 +1,6 @@
 use axelar_core_std::nexus;
 use cosmwasm_std::testing::MockApi;
-use router_api::{CrossChainId, Message};
+use router_api::{address, CrossChainId, Message};
 use sha3::Digest;
 
 use crate::utils::params;
@@ -8,7 +8,7 @@ use crate::utils::params;
 pub fn dummy_from_router(payload: &impl AsRef<[u8]>) -> Message {
     Message {
         cc_id: CrossChainId::new("source-chain", "hash-index").unwrap(),
-        source_address: "source-address".parse().unwrap(),
+        source_address: address!("source-address"),
         destination_chain: params::AXELARNET.parse().unwrap(),
         destination_address: MockApi::default()
             .addr_make("destination-address")
@@ -24,7 +24,7 @@ pub fn dummy_to_router(payload: &impl AsRef<[u8]>) -> Message {
         cc_id: CrossChainId::new("source-chain", "hash-index").unwrap(),
         source_address: params::AXELARNET.parse().unwrap(),
         destination_chain: "destination-chain".parse().unwrap(),
-        destination_address: "destination-address".parse().unwrap(),
+        destination_address: address!("destination-address"),
         payload_hash: sha3::Keccak256::digest(payload).into(),
     }
 }
@@ -32,9 +32,9 @@ pub fn dummy_to_router(payload: &impl AsRef<[u8]>) -> Message {
 pub fn dummy_from_nexus(payload: &impl AsRef<[u8]>) -> nexus::execute::Message {
     nexus::execute::Message {
         source_chain: "Ethereum".parse().unwrap(),
-        source_address: "source-address".parse().unwrap(),
+        source_address: address!("source-address"),
         destination_chain: "destination-chain".parse().unwrap(),
-        destination_address: "destination-address".parse().unwrap(),
+        destination_address: address!("destination-address"),
         payload_hash: sha3::Keccak256::digest(payload).into(),
         source_tx_id: "source-chain".as_bytes().to_vec().try_into().unwrap(),
         source_tx_index: 0,

--- a/contracts/gateway/src/contract/execute.rs
+++ b/contracts/gateway/src/contract/execute.rs
@@ -180,7 +180,7 @@ fn messages_into_events(msgs: Vec<Message>, transform: fn(Message) -> GatewayEve
 mod tests {
     use axelar_wasm_std::err_contains;
     use cosmwasm_std::testing::mock_dependencies;
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
 
     use crate::contract::execute::route_outgoing_messages;
     use crate::state;
@@ -189,9 +189,9 @@ mod tests {
     fn reject_reroute_outgoing_message_with_different_contents() {
         let mut msg = Message {
             cc_id: CrossChainId::new("source-chain", "0x1234-1").unwrap(),
-            source_address: "source-address".parse().unwrap(),
+            source_address: address!("source-address"),
             destination_chain: "destination-chain".parse().unwrap(),
-            destination_address: "destination-address".parse().unwrap(),
+            destination_address: address!("destination-address"),
             payload_hash: [1; 32],
         };
 

--- a/contracts/gateway/src/contract/query.rs
+++ b/contracts/gateway/src/contract/query.rs
@@ -34,7 +34,7 @@ fn accumulate_errs(
 mod test {
     use cosmwasm_std::from_json;
     use cosmwasm_std::testing::mock_dependencies;
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
 
     use crate::state;
 
@@ -89,23 +89,23 @@ mod test {
         vec![
             Message {
                 cc_id: CrossChainId::new("chain1", "id1").unwrap(),
-                destination_address: "addr1".parse().unwrap(),
+                destination_address: address!("addr1"),
                 destination_chain: "chain2".parse().unwrap(),
-                source_address: "addr2".parse().unwrap(),
+                source_address: address!("addr2"),
                 payload_hash: [0; 32],
             },
             Message {
                 cc_id: CrossChainId::new("chain2", "id2").unwrap(),
-                destination_address: "addr3".parse().unwrap(),
+                destination_address: address!("addr3"),
                 destination_chain: "chain3".parse().unwrap(),
-                source_address: "addr4".parse().unwrap(),
+                source_address: address!("addr4"),
                 payload_hash: [1; 32],
             },
             Message {
                 cc_id: CrossChainId::new("chain3", "id3").unwrap(),
-                destination_address: "addr5".parse().unwrap(),
+                destination_address: address!("addr5"),
                 destination_chain: "chain4".parse().unwrap(),
-                source_address: "addr6".parse().unwrap(),
+                source_address: address!("addr6"),
                 payload_hash: [2; 32],
             },
         ]

--- a/contracts/gateway/src/state.rs
+++ b/contracts/gateway/src/state.rs
@@ -69,7 +69,7 @@ pub fn save_outgoing_message(
 #[cfg(test)]
 mod test {
     use cosmwasm_std::testing::mock_dependencies;
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
 
     use crate::state::OUTGOING_MESSAGES;
 
@@ -79,9 +79,9 @@ mod test {
 
         let message = Message {
             cc_id: CrossChainId::new("chain", "id").unwrap(),
-            source_address: "source-address".parse().unwrap(),
+            source_address: address!("source-address"),
             destination_chain: "destination".parse().unwrap(),
-            destination_address: "destination-address".parse().unwrap(),
+            destination_address: address!("destination-address"),
             payload_hash: [1; 32],
         };
 

--- a/contracts/gateway/tests/contract.rs
+++ b/contracts/gateway/tests/contract.rs
@@ -16,7 +16,7 @@ use gateway::msg::InstantiateMsg;
 use gateway_api::msg::{ExecuteMsg, QueryMsg};
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
-use router_api::{CrossChainId, Message};
+use router_api::{address, CrossChainId, Message};
 use serde::Serialize;
 use voting_verifier::msg::MessageStatus;
 
@@ -349,9 +349,9 @@ fn generate_msgs(namespace: impl Debug, count: u8) -> Vec<Message> {
     (0..count)
         .map(|i| Message {
             cc_id: CrossChainId::new("mock-chain", format!("{:?}{}", namespace, i)).unwrap(),
-            destination_address: "idc".parse().unwrap(),
+            destination_address: address!("idc"),
             destination_chain: "mock-chain-2".parse().unwrap(),
-            source_address: "idc".parse().unwrap(),
+            source_address: address!("idc"),
             payload_hash: [i; 32],
         })
         .collect()

--- a/contracts/interchain-token-service/tests/execute.rs
+++ b/contracts/interchain-token-service/tests/execute.rs
@@ -12,7 +12,7 @@ use interchain_token_service_std::{
     RegisterTokenMetadata, TokenId,
 };
 use its_abi_translator::abi::hub_message_abi_encode;
-use router_api::{cosmos_address, Address, ChainName, ChainNameRaw, CrossChainId};
+use router_api::{address, cosmos_address, Address, ChainName, ChainNameRaw, CrossChainId};
 use serde_json::json;
 use utils::{make_deps, params, TestMessage};
 
@@ -862,7 +862,7 @@ fn execute_its_when_not_gateway_sender_fails() {
         message_info(&api.addr_make("not-gateway"), &[]),
         ExecuteMsg::Execute(axelarnet_gateway::AxelarExecutableMsg {
             cc_id: CrossChainId::new("source", "hash").unwrap(),
-            source_address: "source".parse().unwrap(),
+            source_address: address!("source"),
             payload: HexBinary::from([]),
         }),
     );
@@ -895,7 +895,7 @@ fn execute_message_when_unknown_source_address_fails() {
     )
     .unwrap();
 
-    let unknown_address: Address = "unknown-address".parse().unwrap();
+    let unknown_address = address!("unknown-address");
     let result = utils::execute(
         deps.as_mut(),
         router_message.cc_id.clone(),

--- a/contracts/interchain-token-service/tests/query.rs
+++ b/contracts/interchain-token-service/tests/query.rs
@@ -8,7 +8,7 @@ use interchain_token_service::msg::{
     DEFAULT_PAGINATION_LIMIT,
 };
 use interchain_token_service_std::TokenId;
-use router_api::{Address, ChainNameRaw};
+use router_api::{address, Address, ChainNameRaw};
 
 mod utils;
 
@@ -25,18 +25,14 @@ impl ChainConfigTest {
 
         let eth = utils::ChainData {
             chain: "Ethereum".parse().unwrap(),
-            address: "0x1234567890123456789012345678901234567890"
-                .parse()
-                .unwrap(),
+            address: address!("0x1234567890123456789012345678901234567890"),
             max_uint_bits: 256.try_into().unwrap(),
             max_decimals: 18,
         };
 
         let polygon = utils::ChainData {
             chain: "Polygon".parse().unwrap(),
-            address: "0x1234567890123456789012345678901234567890"
-                .parse()
-                .unwrap(),
+            address: address!("0x1234567890123456789012345678901234567890"),
             max_uint_bits: 256.try_into().unwrap(),
             max_decimals: 18,
         };
@@ -128,15 +124,11 @@ fn query_all_its_contracts() {
     let its_contracts = vec![
         (
             "ethereum".parse::<ChainNameRaw>().unwrap(),
-            "0x1234567890123456789012345678901234567890"
-                .parse::<Address>()
-                .unwrap(),
+            address!("0x1234567890123456789012345678901234567890"),
         ),
         (
             "Optimism".parse().unwrap(),
-            "0x0987654321098765432109876543210987654321"
-                .parse()
-                .unwrap(),
+            address!("0x0987654321098765432109876543210987654321"),
         ),
     ]
     .into_iter()

--- a/contracts/interchain-token-service/tests/utils/messages.rs
+++ b/contracts/interchain-token-service/tests/utils/messages.rs
@@ -1,5 +1,5 @@
 use interchain_token_service_std::{DeployInterchainToken, HubMessage, Message, TokenId};
-use router_api::{Address, ChainNameRaw, CrossChainId};
+use router_api::{address, Address, ChainNameRaw, CrossChainId};
 
 pub fn dummy_message() -> Message {
     DeployInterchainToken {
@@ -24,9 +24,9 @@ pub struct TestMessage {
 impl TestMessage {
     pub fn dummy() -> Self {
         let source_its_chain: ChainNameRaw = "source-its-chain".parse().unwrap();
-        let source_its_contract: Address = "source-its-contract".parse().unwrap();
+        let source_its_contract = address!("source-its-contract");
         let destination_its_chain: ChainNameRaw = "dest-its-chain".parse().unwrap();
-        let destination_its_contract: Address = "dest-its-contract".parse().unwrap();
+        let destination_its_contract = address!("dest-its-contract");
 
         let hub_message = HubMessage::SendToHub {
             destination_chain: destination_its_chain.clone(),
@@ -36,7 +36,7 @@ impl TestMessage {
             cc_id: CrossChainId::new(source_its_chain.clone(), "message-id").unwrap(),
             source_address: source_its_contract.clone(),
             destination_chain: "its-hub-chain".parse().unwrap(),
-            destination_address: "its-hub-contract".parse().unwrap(),
+            destination_address: address!("its-hub-contract"),
             payload_hash: [1; 32],
         };
 

--- a/contracts/multisig-prover/src/events.rs
+++ b/contracts/multisig-prover/src/events.rs
@@ -16,7 +16,7 @@ pub enum Event {
 
 #[cfg(test)]
 mod tests {
-    use router_api::Message;
+    use router_api::{address, Message};
 
     use super::*;
     use crate::Payload;
@@ -26,16 +26,16 @@ mod tests {
         let payload = Payload::Messages(vec![
             Message {
                 cc_id: CrossChainId::new("ethereum", "some-id").unwrap(),
-                source_address: "0x1234".parse().unwrap(),
+                source_address: address!("0x1234"),
                 destination_chain: "avalanche".parse().unwrap(),
-                destination_address: "0x5678".parse().unwrap(),
+                destination_address: address!("0x5678"),
                 payload_hash: [0; 32],
             },
             Message {
                 cc_id: CrossChainId::new("fantom", "some-other-id").unwrap(),
-                source_address: "0x1234".parse().unwrap(),
+                source_address: address!("0x1234"),
                 destination_chain: "avalanche".parse().unwrap(),
-                destination_address: "0x5678".parse().unwrap(),
+                destination_address: address!("0x5678"),
                 payload_hash: [0; 32],
             },
         ]);

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -153,7 +153,7 @@ mod test {
     use permission_control::Permission;
     use router_api::error::Error;
     use router_api::{
-        ChainEndpoint, ChainName, CrossChainId, GatewayDirection, Message, FIELD_DELIMITER,
+        address, ChainEndpoint, ChainName, CrossChainId, GatewayDirection, Message, FIELD_DELIMITER,
     };
 
     use super::*;
@@ -232,9 +232,9 @@ mod test {
             .to_string();
             msgs.push(Message {
                 cc_id: CrossChainId::new(src_chain.chain_name.clone(), id).unwrap(),
-                destination_address: "idc".parse().unwrap(),
+                destination_address: address!("idc"),
                 destination_chain: dest_chain.chain_name.clone(),
-                source_address: "idc".parse().unwrap(),
+                source_address: address!("idc"),
                 payload_hash: [x as u8; 32],
             })
         }

--- a/contracts/voting-verifier/src/client.rs
+++ b/contracts/voting-verifier/src/client.rs
@@ -120,7 +120,7 @@ mod test {
         from_json, Addr, DepsMut, QuerierWrapper, SystemError, Uint128, Uint64, WasmQuery,
     };
     use multisig::verifier_set::VerifierSet;
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
 
     use crate::contract::{instantiate, query};
     use crate::msg::{InstantiateMsg, MessageStatus, QueryMsg};
@@ -143,8 +143,8 @@ mod test {
                 .as_str(),
             )
             .unwrap(),
-            source_address: "0x1234".parse().unwrap(),
-            destination_address: "0x5678".parse().unwrap(),
+            source_address: address!("0x1234"),
+            destination_address: address!("0x5678"),
             destination_chain: "eth".parse().unwrap(),
             payload_hash: [0; 32],
         };
@@ -159,8 +159,8 @@ mod test {
                 .as_str(),
             )
             .unwrap(),
-            source_address: "0x4321".parse().unwrap(),
-            destination_address: "0x8765".parse().unwrap(),
+            source_address: address!("0x4321"),
+            destination_address: address!("0x8765"),
             destination_chain: "eth".parse().unwrap(),
             payload_hash: [0; 32],
         };
@@ -238,8 +238,8 @@ mod test {
                 .as_str(),
             )
             .unwrap(),
-            source_address: "0x1234".parse().unwrap(),
-            destination_address: "0x5678".parse().unwrap(),
+            source_address: address!("0x1234"),
+            destination_address: address!("0x5678"),
             destination_chain: "eth".parse().unwrap(),
             payload_hash: [0; 32],
         }]);

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -126,7 +126,7 @@ mod test {
     use cosmwasm_std::{from_json, Empty, Fraction, OwnedDeps, Uint128, Uint64, WasmQuery};
     use multisig::key::KeyType;
     use multisig::test::common::{build_verifier_set, ecdsa_test_data};
-    use router_api::{ChainName, CrossChainId, Message};
+    use router_api::{address, ChainName, CrossChainId, Message};
     use service_registry::{AuthorizationState, BondingState, Verifier, WeightedVerifier};
     use sha3::{Digest, Keccak256, Keccak512};
     use starknet_checked_felt::CheckedFelt;
@@ -471,15 +471,15 @@ mod test {
                     .parse()
                     .unwrap(),
                 destination_chain: "destination-chain1".parse().unwrap(),
-                destination_address: "destination-address1".parse().unwrap(),
+                destination_address: address!("destination-address1"),
                 payload_hash: [0; 32],
             },
             Message {
                 cc_id: CrossChainId::new("other-chain", message_id("id", 2, &msg_id_format))
                     .unwrap(),
-                source_address: "source-address2".parse().unwrap(),
+                source_address: address!("source-address2"),
                 destination_chain: "destination-chain2".parse().unwrap(),
-                destination_address: "destination-address2".parse().unwrap(),
+                destination_address: address!("destination-address2"),
                 payload_hash: [0; 32],
             },
         ]);

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -349,7 +349,7 @@ mod test {
     use multisig::key::KeyType;
     use multisig::test::common::{build_verifier_set, ecdsa_test_data};
     use multisig::verifier_set::VerifierSet;
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
     use serde_json::json;
 
     use super::{TxEventConfirmation, VerifierSetConfirmation};
@@ -367,9 +367,9 @@ mod test {
     fn generate_msg(msg_id: nonempty::String) -> Message {
         Message {
             cc_id: CrossChainId::new("source-chain", msg_id).unwrap(),
-            source_address: "source-address".parse().unwrap(),
+            source_address: address!("source-address"),
             destination_chain: "destination-chain".parse().unwrap(),
-            destination_address: "destination-address".parse().unwrap(),
+            destination_address: address!("destination-address"),
             payload_hash: [0; 32],
         }
     }
@@ -559,18 +559,18 @@ mod test {
                     tx_id: "txId1".try_into().unwrap(),
                     event_index: 1,
                     message_id: "messageId".try_into().unwrap(),
-                    destination_address: "destinationAddress1".parse().unwrap(),
+                    destination_address: address!("destinationAddress1"),
                     destination_chain: "destinationChain".try_into().unwrap(),
-                    source_address: "sourceAddress1".parse().unwrap(),
+                    source_address: address!("sourceAddress1"),
                     payload_hash: [0; 32],
                 },
                 TxEventConfirmation {
                     tx_id: "txId2".try_into().unwrap(),
                     event_index: 2,
                     message_id: "messageId".try_into().unwrap(),
-                    destination_address: "destinationAddress2".parse().unwrap(),
+                    destination_address: address!("destinationAddress2"),
                     destination_chain: "destinationChain".try_into().unwrap(),
-                    source_address: "sourceAddress2".parse().unwrap(),
+                    source_address: address!("sourceAddress2"),
                     payload_hash: [1; 32],
                 },
             ],

--- a/packages/axelar-core-std/src/nexus/execute.rs
+++ b/packages/axelar-core-std/src/nexus/execute.rs
@@ -86,7 +86,7 @@ mod test {
     use std::vec;
 
     use axelar_wasm_std::msg_id::{Base58TxDigestAndEventIndex, HexTxHashAndEventIndex};
-    use router_api::CrossChainId;
+    use router_api::{address, CrossChainId};
 
     use super::Message;
 
@@ -98,9 +98,9 @@ mod test {
         };
         let msg = Message {
             source_chain: "ethereum".parse().unwrap(),
-            source_address: "something".parse().unwrap(),
+            source_address: address!("something"),
             destination_chain: "polygon".parse().unwrap(),
-            destination_address: "something else".parse().unwrap(),
+            destination_address: address!("something else"),
             payload_hash: [1; 32],
             source_tx_id: msg_id.tx_hash.to_vec().try_into().unwrap(),
             source_tx_index: msg_id.event_index,
@@ -128,9 +128,9 @@ mod test {
                 .as_str(),
             )
             .unwrap(),
-            source_address: "something".parse().unwrap(),
+            source_address: address!("something"),
             destination_chain: "polygon".parse().unwrap(),
-            destination_address: "something else".parse().unwrap(),
+            destination_address: address!("something else"),
             payload_hash: [1; 32],
         };
 
@@ -151,9 +151,9 @@ mod test {
                 .as_str(),
             )
             .unwrap(),
-            source_address: "something".parse().unwrap(),
+            source_address: address!("something"),
             destination_chain: "polygon".parse().unwrap(),
-            destination_address: "something else".parse().unwrap(),
+            destination_address: address!("something else"),
             payload_hash: [1; 32],
         };
 

--- a/packages/gateway-api/src/client.rs
+++ b/packages/gateway-api/src/client.rs
@@ -56,7 +56,7 @@ impl Client<'_> {
 mod tests {
     use cosmwasm_std::testing::{MockApi, MockQuerier};
     use cosmwasm_std::{from_json, to_json_binary, Addr, QuerierWrapper, SystemError, WasmQuery};
-    use router_api::{CrossChainId, Message};
+    use router_api::{address, CrossChainId, Message};
 
     use crate::client::Client;
     use crate::msg::QueryMsg;
@@ -127,9 +127,9 @@ mod tests {
                             .into_iter()
                             .map(|cc_id| Message {
                                 cc_id,
-                                source_address: "foobar".parse().unwrap(),
+                                source_address: address!("foobar"),
                                 destination_chain: "ethereum".parse().unwrap(),
-                                destination_address: "foobar".parse().unwrap(),
+                                destination_address: address!("foobar"),
                                 payload_hash: [0u8; 32],
                             })
                             .collect::<Vec<Message>>(),


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
