### PR TITLE
feat(minor-coordinator): coordinator can combine contract instantiation with deployment

### DIFF
--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -90,8 +90,17 @@ pub fn execute(
             deployment_name,
             salt,
             params,
-        } => execute::instantiate_chain_contracts(deps, env, info, deployment_name, salt, *params)
-            .change_context(Error::InstantiateChainContracts),
+            deploy_contracts,
+        } => execute::instantiate_chain_contracts(
+            deps,
+            env,
+            info,
+            deployment_name,
+            salt,
+            *params,
+            deploy_contracts,
+        )
+        .change_context(Error::InstantiateChainContracts),
         ExecuteMsg::RegisterDeployment { deployment_name } => {
             execute::register_deployment(deps, info.sender, deployment_name.clone())
                 .change_context(Error::RegisterDeployment(deployment_name))

--- a/contracts/coordinator/src/contract/execute.rs
+++ b/contracts/coordinator/src/contract/execute.rs
@@ -92,7 +92,7 @@ fn launch_contract(
             admin: Some(info.sender.to_string()),
             code_id,
             msg: instantiate_msg,
-            funds: info.funds.clone(),
+            funds: vec![],
             label,
             salt: salt.clone(),
         },

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -50,6 +50,7 @@ pub enum ExecuteMsg {
         // Make params a Box to avoid having a large discrepancy in variant sizes
         // Such an error will be flagged by "cargo clippy..."
         params: Box<DeploymentParams>,
+        deploy_contracts: bool,
     },
 
     /// `RegisterDeployment` calls the router using `ExecuteMsgFromProxy`.


### PR DESCRIPTION
## Description

It can be cumbersome to invoke two governance proposals to instantiate and deploy the gateway, verifier and prover contracts. This PR provides the option to combine both steps into one.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
