### PR TITLE
feat(ampd): track ampd error in monitoring server

### DIFF
--- a/ampd/src/broadcast/msg_queue.rs
+++ b/ampd/src/broadcast/msg_queue.rs
@@ -1032,16 +1032,13 @@ mod tests {
         let gas_price_amount = 0.025;
         let gas_price_denom = "uaxl";
 
-        let mut cosmos_client = setup_client(&TMAddress::random(PREFIX));
-        cosmos_client.expect_simulate().once().returning(move |_| {
-            Ok(SimulateResponse {
-                gas_info: Some(GasInfo {
-                    gas_wanted: gas_cost,
-                    gas_used: gas_cost,
-                }),
-                result: None,
-            })
+        let gas_info = Some(GasInfo {
+            gas_wanted: gas_cost,
+            gas_used: gas_cost,
         });
+
+        let cosmos_client = setup_client_with_simulate(&TMAddress::random(PREFIX), gas_info, 1);
+
         let broadcaster = broadcaster::Broadcaster::builder()
             .client(cosmos_client)
             .chain_id("chain-id".parse().unwrap())

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -164,15 +164,17 @@ async fn instantiate_broadcaster(
         .build()
         .await
         .change_context(Error::Broadcaster)?;
+
+    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>)
+        .expect("should never fail to create dummy monitoring client");
+
     let (msg_queue, _) = broadcast::MsgQueue::new_msg_queue_and_client(
         broadcaster.clone(),
         broadcaster_config.queue_cap,
         broadcaster_config.batch_gas_limit,
         broadcaster_config.broadcast_interval,
+        monitoring_client.clone(),
     );
-
-    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>)
-        .expect("should never fail to create dummy monitoring client");
 
     let broadcaster_task = broadcast::BroadcasterTask::builder()
         .broadcaster(broadcaster)

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -118,6 +118,7 @@ where
             StreamStatus::Error(err) => return Err(err.change_context(Error::EventStream)),
             StreamStatus::TimedOut => {
                 warn!("event stream timed out");
+                monitoring_client.metrics().record_metric(Msg::EventTimeout);
             }
         }
     }
@@ -155,7 +156,8 @@ where
                     warn!(
                         err = LoggableError::from(err).as_value(),
                         "failed to enqueue message for broadcasting"
-                    )
+                    );
+                    monitoring_client.metrics().record_metric(Msg::MsgEnqueueError);
                 })
                 .collect::<Vec<_>>()
                 .await;

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -157,7 +157,9 @@ where
                         err = LoggableError::from(err).as_value(),
                         "failed to enqueue message for broadcasting"
                     );
-                    monitoring_client.metrics().record_metric(Msg::MsgEnqueueError);
+                    monitoring_client
+                        .metrics()
+                        .record_metric(Msg::MessageEnqueueError);
                 })
                 .collect::<Vec<_>>()
                 .await;
@@ -330,14 +332,16 @@ mod tests {
             .build()
             .await
             .unwrap();
+
+        let (monitoring_client, _) = test_utils::monitoring_client();
+
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let result = consume_events(
             "handler".to_string(),
@@ -384,14 +388,15 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
+
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let result = consume_events(
             "handler".to_string(),
@@ -438,14 +443,14 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let result = consume_events(
             "handler".to_string(),
@@ -512,14 +517,14 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (msg_queue, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let result = consume_events(
             "handler".to_string(),
@@ -584,14 +589,14 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (msg_queue, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let result = consume_events(
             "handler".to_string(),
@@ -647,15 +652,16 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
 
         token.cancel();
-        let (monitoring_client, _) = test_utils::monitoring_client();
         let result = consume_events(
             "handler".to_string(),
             handler,
@@ -695,15 +701,16 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
 
         token.cancel();
-        let (monitoring_client, _) = test_utils::monitoring_client();
         let result = consume_events(
             "handler".to_string(),
             MockEventHandler::new(),
@@ -753,14 +760,15 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
 
-        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
         let cancel_token = CancellationToken::new();
 
         let result_with_timeout = timeout(
@@ -851,15 +859,15 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             100,
             Duration::from_millis(500),
+            monitoring_client.clone(),
         );
-
-        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
         let _ = consume_events(
             "handler".to_string(),
@@ -897,6 +905,133 @@ mod tests {
         })
         .await
         .expect("Failed event handling metric not found");
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn should_record_event_timeout_metric() {
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+        let chain_id: chain::Id = "test-chain-id".parse().unwrap();
+        let gas_adjustment = 1.5;
+        let gas_price_amount = 0.025;
+        let gas_price_denom = "uaxl";
+        let token = CancellationToken::new();
+        let event_config = setup_event_config(
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+        );
+
+        let mock_client = setup_client(&address);
+
+        let broadcaster = broadcast::Broadcaster::builder()
+            .client(mock_client)
+            .chain_id(chain_id)
+            .pub_key(pub_key)
+            .gas_adjustment(gas_adjustment)
+            .gas_price(DecCoin::new(gas_price_amount, gas_price_denom).unwrap())
+            .build()
+            .await
+            .unwrap();
+        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
+        let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
+            broadcaster,
+            10,
+            100,
+            Duration::from_millis(500),
+            monitoring_client.clone(),
+        );
+
+        let task = tokio::spawn(consume_events(
+            "handler".to_string(),
+            MockEventHandler::new(),
+            stream::pending(),
+            event_config,
+            token.child_token(),
+            msg_queue_client,
+            monitoring_client,
+        ));
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        token.cancel();
+        let _ = task.await.unwrap();
+
+        let metric = receiver.recv().await.unwrap();
+        assert_eq!(metric, metrics::Msg::EventTimeout);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn record_msg_enqueue_error_when_msg_enqueue_failed() {
+        let pub_key = random_cosmos_public_key();
+        let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
+        let chain_id: chain::Id = "test-chain-id".parse().unwrap();
+        let gas_adjustment = 1.5;
+        let gas_price_amount = 0.025;
+        let gas_price_denom = "uaxl";
+        let event_config = setup_event_config(
+            Duration::from_secs(1),
+            Duration::from_secs(1000),
+            Duration::from_secs(1),
+        );
+        let events: Vec<Result<Event, event_sub::Error>> = vec![Ok(Event::BlockEnd(0_u32.into()))];
+
+        let mut handler = MockEventHandler::new();
+        handler
+            .expect_handle()
+            .return_once(|_| Ok(vec![dummy_msg()]));
+
+        let mut mock_client = setup_client(&address);
+        mock_client.expect_clone().times(1).returning(move || {
+            let base_account = create_base_account(&address);
+            let mut mock_client = cosmos::MockCosmosClient::new();
+            mock_client.expect_account().return_once(move |_| {
+                Ok(QueryAccountResponse {
+                    account: Some(Any::from_msg(&base_account).unwrap()),
+                })
+            });
+            mock_client
+                .expect_simulate()
+                .return_once(|_| Err(Status::internal("internal error").into_report()));
+            mock_client
+        });
+
+        let broadcaster = broadcast::Broadcaster::builder()
+            .client(mock_client)
+            .chain_id(chain_id)
+            .pub_key(pub_key)
+            .gas_adjustment(gas_adjustment)
+            .gas_price(DecCoin::new(gas_price_amount, gas_price_denom).unwrap())
+            .build()
+            .await
+            .unwrap();
+        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
+        let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
+            broadcaster,
+            10,
+            100,
+            Duration::from_millis(500),
+            monitoring_client.clone(),
+        );
+
+        let _ = consume_events(
+            "handler".to_string(),
+            handler,
+            stream::iter(events),
+            event_config,
+            CancellationToken::new(),
+            msg_queue_client,
+            monitoring_client,
+        )
+        .await;
+
+        let _ = find_msg_variant(&mut receiver, |m| {
+            matches!(m, metrics::Msg::MessageEnqueueError)
+        })
+        .await
+        .expect("MsgEnqueueError metric not found");
 
         assert!(receiver.try_recv().is_err());
     }

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -118,7 +118,9 @@ where
             StreamStatus::Error(err) => return Err(err.change_context(Error::EventStream)),
             StreamStatus::TimedOut => {
                 warn!("event stream timed out");
-                monitoring_client.metrics().record_metric(Msg::EventTimeout);
+                monitoring_client
+                    .metrics()
+                    .record_metric(Msg::EventPollingTimeout);
             }
         }
     }
@@ -910,7 +912,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn should_record_event_timeout_metric() {
+    async fn should_record_event_polling_timeout_metric() {
         let pub_key = random_cosmos_public_key();
         let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
         let chain_id: chain::Id = "test-chain-id".parse().unwrap();
@@ -960,11 +962,12 @@ mod tests {
         let _ = task.await.unwrap();
 
         let metric = receiver.recv().await.unwrap();
-        assert_eq!(metric, metrics::Msg::EventTimeout);
+        assert_eq!(metric, metrics::Msg::EventPollingTimeout);
+        assert!(receiver.try_recv().is_err());
     }
 
     #[tokio::test(start_paused = true)]
-    async fn record_msg_enqueue_error_when_msg_enqueue_failed() {
+    async fn should_record_msg_enqueue_error_when_msg_enqueue_failed() {
         let pub_key = random_cosmos_public_key();
         let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
         let chain_id: chain::Id = "test-chain-id".parse().unwrap();

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -16,6 +16,8 @@ use tracing::{error, info, instrument};
 use valuable::Valuable;
 
 use crate::asyncutil::future::RetryPolicy;
+use crate::monitoring;
+use crate::monitoring::metrics::Msg;
 use crate::tm_client::TmClient;
 
 pub mod stream;
@@ -78,17 +80,24 @@ pub struct EventPublisher<T: TmClient + Sync> {
     poll_interval: Duration,
     tx: Sender<std::result::Result<Event, Error>>,
     delay: Duration,
+    monitoring_client: monitoring::Client,
 }
 
 impl<T: TmClient + Sync + std::fmt::Debug> EventPublisher<T> {
     #[instrument]
-    pub fn new(client: T, capacity: usize, delay: Duration) -> (Self, EventSubscriber) {
+    pub fn new(
+        client: T,
+        capacity: usize,
+        delay: Duration,
+        monitoring_client: monitoring::Client,
+    ) -> (Self, EventSubscriber) {
         let (tx, _) = broadcast::channel(capacity);
         let publisher = EventPublisher {
             tm_client: client,
             poll_interval: POLL_INTERVAL,
             tx: tx.clone(),
             delay,
+            monitoring_client,
         };
         let subscriber = EventSubscriber { tx };
 
@@ -108,6 +117,9 @@ impl<T: TmClient + Sync + std::fmt::Debug> EventPublisher<T> {
             // error_stack::Report does not implement `Clone`, so we log the full error and pass on the latest context
             let event = event
                 .inspect_err(|err| {
+                    self.monitoring_client
+                        .metrics()
+                        .record_metric(Msg::EventPublisherError);
                     error!(
                         err = LoggableError::from(err).as_value(),
                         "failed to retrieve to events"
@@ -116,6 +128,9 @@ impl<T: TmClient + Sync + std::fmt::Debug> EventPublisher<T> {
                 .map_err(|err| err.current_context().clone());
 
             let _ = self.tx.send(event).map_err(Report::new).inspect_err(|err| {
+                self.monitoring_client
+                    .metrics()
+                    .record_metric(Msg::EventPublisherError);
                 error!(
                     err = LoggableError::from(err).as_value(),
                     "failed to send event to subscribers"
@@ -149,6 +164,8 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use crate::event_sub::{Error, EventPublisher, EventSub};
+    use crate::monitoring::metrics::Msg;
+    use crate::monitoring::test_utils;
     use crate::tm_client::{self, MockTmClient};
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -175,8 +192,9 @@ mod tests {
         tm_client.expect_block_results().never();
 
         let token = CancellationToken::new();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (event_publisher, _subscriber) =
-            EventPublisher::new(tm_client, 100, Duration::from_secs(1));
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
         let handle = tokio::spawn(event_publisher.run(token.child_token()));
 
         while *call_count.read().unwrap() < 10 {
@@ -237,8 +255,9 @@ mod tests {
         });
 
         let token = CancellationToken::new();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (event_publisher, subscriber) =
-            EventPublisher::new(tm_client, 100, Duration::from_secs(1));
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
         let mut stream = subscriber.subscribe();
         let handle = tokio::spawn(event_publisher.run(token.child_token()));
 
@@ -317,5 +336,67 @@ mod tests {
             app_hash: Default::default(),
             finalize_block_events: vec![],
         }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn should_record_event_publisher_err_successfully() {
+        let block: tendermint::Block =
+            serde_json::from_str(include_str!("../tests/axelar_block.json")).unwrap();
+        let initial_height = block.header().height;
+
+        let mut tm_client = MockTmClient::new();
+        let mut call_count = 0;
+        tm_client.expect_latest_block().returning(move || {
+            call_count += 1;
+
+            match call_count {
+                1 => Err(report!(tendermint_rpc::Error::server(
+                    "server error".to_string()
+                ))),
+                2 => Ok(tm_client::BlockResponse {
+                    block_id: Default::default(),
+                    block: block.clone(),
+                }),
+                _ => unreachable!("Should only have 2 calls"),
+            }
+        });
+        tm_client.expect_block_results().returning(move |height| {
+            if height == initial_height {
+                Ok(block_results_response(
+                    height,
+                    vec![random_event()],
+                    vec![random_event()],
+                    vec![random_event()],
+                ))
+            } else {
+                Ok(block_results_response(height, vec![], vec![], vec![]))
+            }
+        });
+
+        let token = CancellationToken::new();
+        let (monitoring_client, mut receiver) = test_utils::monitoring_client();
+        let (event_publisher, subscriber) =
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
+        let mut stream = subscriber.subscribe();
+        let handle = tokio::spawn(event_publisher.run(token.child_token()));
+
+        // 1st call return LatestBlockQuery error -> record metric
+        assert_err_contains!(stream.next().await.unwrap(), Error, Error::LatestBlockQuery);
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        // Second call should succeed and emit events
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Ok(Event::BlockBegin(_))
+        ));
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        token.cancel();
+        handle.await.unwrap().unwrap();
+
+        // only 1 error recorded
+        let metric = receiver.recv().await.unwrap();
+        assert_eq!(metric, Msg::EventPublisherError);
+        assert!(receiver.try_recv().is_err());
     }
 }

--- a/ampd/src/grpc/blockchain_service.rs
+++ b/ampd/src/grpc/blockchain_service.rs
@@ -150,6 +150,7 @@ mod tests {
     use crate::broadcast::DecCoin;
     use crate::cosmos::MockCosmosClient;
     use crate::event_sub::{self, MockEventSub};
+    use crate::monitoring::test_utils;
     use crate::types::{random_cosmos_public_key, TMAddress};
     use crate::PREFIX;
 
@@ -213,11 +214,13 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
         let (msg_queue, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             100,
             GAS_CAP,
             Duration::from_secs(1),
+            monitoring_client,
         );
         let service = Service::builder()
             .event_sub(mock_event_sub)
@@ -932,12 +935,14 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let (monitoring_client, _) = test_utils::monitoring_client();
 
         let (_, msg_queue_client) = broadcast::MsgQueue::new_msg_queue_and_client(
             broadcaster,
             10,
             1000u64,
             Duration::from_secs(1),
+            monitoring_client,
         );
 
         let service = Service::builder()

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -111,6 +111,7 @@ async fn prepare_app(cfg: Config) -> Result<App, Error> {
         tm_client.clone(),
         event_processor.stream_buffer_size,
         event_processor.delay,
+        monitoring_client.clone(),
     );
     let cosmos_client = cosmos::CosmosGrpcClient::new(tm_grpc.as_str(), tm_grpc_timeout)
         .await
@@ -130,6 +131,7 @@ async fn prepare_app(cfg: Config) -> Result<App, Error> {
         broadcast.queue_cap,
         broadcast.batch_gas_limit,
         broadcast.broadcast_interval,
+        monitoring_client.clone(),
     );
     let grpc_server = grpc::Server::builder()
         .config(grpc_config)

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -59,6 +59,10 @@ pub enum Msg {
         success: bool,
         duration: Duration,
     },
+    /// Record the number of messages enqueued error 
+    MsgEnqueueError,
+    /// Record the number of event timeout
+    EventTimeout,
 }
 
 /// Errors that can occur in metrics processing
@@ -220,6 +224,8 @@ struct Metrics {
     block_received: BlockReceivedMetrics,
     verification_vote: VerificationVoteMetrics,
     stage_result: EventStageMetrics,
+    msg_enqueue_error: MsgEnqueueErrorMetrics,
+    event_timeout: EventTimeoutMetrics,
 }
 
 impl Metrics {
@@ -227,15 +233,21 @@ impl Metrics {
         let block_received = BlockReceivedMetrics::new();
         let verification_vote = VerificationVoteMetrics::new();
         let stage_result = EventStageMetrics::new();
+        let msg_enqueue_error = MsgEnqueueErrorMetrics::new();
+        let event_timeout = EventTimeoutMetrics::new();
 
         block_received.register(registry);
         verification_vote.register(registry);
         stage_result.register(registry);
+        msg_enqueue_error.register(registry);
+        event_timeout.register(registry);
 
         Self {
             block_received,
             verification_vote,
             stage_result,
+            msg_enqueue_error,
+            event_timeout,
         }
     }
 
@@ -257,6 +269,12 @@ impl Metrics {
                 duration,
             } => {
                 self.stage_result.record(success, duration, stage);
+            }
+            Msg::MsgEnqueueError => {
+                self.msg_enqueue_error.increment();
+            }
+            Msg::EventTimeout => {
+                self.event_timeout.increment();
             }
         }
     }
@@ -390,6 +408,52 @@ impl EventStageMetrics {
         self.duration
             .get_or_create(&label)
             .inc_by(u64::try_from(duration.as_millis()).unwrap());
+    }
+}
+
+struct MsgEnqueueErrorMetrics {
+    total: Counter,
+}
+
+impl MsgEnqueueErrorMetrics {
+    fn new() -> Self {
+        let total = Counter::default();
+        Self { total }
+    }
+
+    fn register(&self, registry: &mut Registry) {
+        registry.register(
+            "msg_enqueue_error",
+            "number of messages enqueued error",
+            self.total.clone(),
+        );
+    }
+
+    fn increment(&self) {
+        self.total.inc();
+    }
+}
+
+struct EventTimeoutMetrics {
+    total: Counter,
+}
+
+impl EventTimeoutMetrics {
+    fn new() -> Self {
+        let total = Counter::default();
+        Self { total }
+    }
+
+    fn register(&self, registry: &mut Registry) {
+        registry.register(
+            "event_stream_timeout",
+            "number of timeouts while waiting for blockchain events",
+            self.total.clone(),
+        );
+    }
+
+    fn increment(&self) {
+        self.total.inc();
     }
 }
 
@@ -570,6 +634,14 @@ mod tests {
             success: false,
             duration: Duration::from_millis(600),
         });
+
+        // Msg Enqueue Error Metrics
+        client.record_metric(Msg::MsgEnqueueError);
+        client.record_metric(Msg::MsgEnqueueError);
+
+        // Event Timeout Metrics
+        client.record_metric(Msg::EventTimeout);
+        client.record_metric(Msg::EventTimeout);
 
         // Wait for the metrics to be updated
         time::sleep(Duration::from_secs(1)).await;

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -638,7 +638,7 @@ mod tests {
 
         // record error metrics
         for _ in 0..2 {
-            client.record_metric(Msg::MsgEnqueueError);
+            client.record_metric(Msg::MessageEnqueueError);
             client.record_metric(Msg::EventPollingTimeout);
             client.record_metric(Msg::EventPublisherError);
         }

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -61,8 +61,8 @@ pub enum Msg {
     },
     /// Record the number of error in msg enqueue
     MessageEnqueueError,
-    /// Record the number of event timeout
-    EventTimeout,
+    /// Record the number of event stream polling timeout
+    EventPollingTimeout,
     /// Record the number of error happens in event publisher
     EventPublisherError,
 }
@@ -226,7 +226,7 @@ struct Metrics {
     block_received: BlockReceivedMetrics,
     verification_vote: VerificationVoteMetrics,
     stage_result: EventStageMetrics,
-    error_metrics: ErrorMetricsCollection, // Single field
+    error_metrics: ErrorMetrics,
 }
 
 impl Metrics {
@@ -234,7 +234,7 @@ impl Metrics {
         let block_received = BlockReceivedMetrics::new();
         let verification_vote = VerificationVoteMetrics::new();
         let stage_result = EventStageMetrics::new();
-        let error_metrics = ErrorMetricsCollection::new();
+        let error_metrics = ErrorMetrics::new();
 
         block_received.register(registry);
         verification_vote.register(registry);
@@ -271,7 +271,7 @@ impl Metrics {
             Msg::MessageEnqueueError => {
                 self.error_metrics.record_msg_enqueue_error();
             }
-            Msg::EventTimeout => {
+            Msg::EventPollingTimeout => {
                 self.error_metrics.record_event_timeout();
             }
             Msg::EventPublisherError => {
@@ -413,69 +413,48 @@ impl EventStageMetrics {
 }
 
 struct ErrorMetrics {
-    total: Counter,
-    name: &'static str,
-    description: &'static str,
+    msg_enqueue_error: Counter,
+    event_timeout: Counter,
+    event_publisher_error: Counter,
 }
 
 impl ErrorMetrics {
-    fn new(name: &'static str, description: &'static str) -> Self {
-        Self {
-            total: Counter::default(),
-            name,
-            description,
-        }
-    }
-
-    fn register(&self, registry: &mut Registry) {
-        registry.register(self.name, self.description, self.total.clone());
-    }
-
-    fn increment(&self) {
-        self.total.inc();
-    }
-}
-
-struct ErrorMetricsCollection {
-    msg_enqueue_error: ErrorMetrics,
-    event_timeout: ErrorMetrics,
-    event_publisher_error: ErrorMetrics,
-}
-
-impl ErrorMetricsCollection {
     fn new() -> Self {
         Self {
-            msg_enqueue_error: ErrorMetrics::new(
-                "msg_enqueue_error",
-                "number of failures in message enqueue",
-            ),
-            event_timeout: ErrorMetrics::new(
-                "event_stream_timeout",
-                "number of timeouts while waiting for blockchain events",
-            ),
-            event_publisher_error: ErrorMetrics::new(
-                "event_publisher_error",
-                "number of failures in event publisher",
-            ),
+            msg_enqueue_error: Counter::default(),
+            event_timeout: Counter::default(),
+            event_publisher_error: Counter::default(),
         }
     }
 
     fn register_all(&self, registry: &mut Registry) {
-        self.msg_enqueue_error.register(registry);
-        self.event_timeout.register(registry);
-        self.event_publisher_error.register(registry);
+        registry.register(
+            "msg_enqueue_error",
+            "number of failures in message enqueue",
+            self.msg_enqueue_error.clone(),
+        );
+        registry.register(
+            "event_stream_timeout",
+            "number of timeouts while polling blockchain events",
+            self.event_timeout.clone(),
+        );
+        registry.register(
+            "event_publisher_error",
+            "number of failures in event publisher",
+            self.event_publisher_error.clone(),
+        );
     }
 
     fn record_msg_enqueue_error(&self) {
-        self.msg_enqueue_error.increment();
+        self.msg_enqueue_error.inc();
     }
 
     fn record_event_timeout(&self) {
-        self.event_timeout.increment();
+        self.event_timeout.inc();
     }
 
     fn record_event_publisher_error(&self) {
-        self.event_publisher_error.increment();
+        self.event_publisher_error.inc();
     }
 }
 
@@ -657,17 +636,12 @@ mod tests {
             duration: Duration::from_millis(600),
         });
 
-        // Msg Enqueue Error Metrics
-        client.record_metric(Msg::MessageEnqueueError);
-        client.record_metric(Msg::MessageEnqueueError);
-
-        // Event Timeout Metrics
-        client.record_metric(Msg::EventTimeout);
-        client.record_metric(Msg::EventTimeout);
-
-        // Event Publisher Error Metrics
-        client.record_metric(Msg::EventPublisherError);
-        client.record_metric(Msg::EventPublisherError);
+        // record error metrics
+        for _ in 0..2 {
+            client.record_metric(Msg::MsgEnqueueError);
+            client.record_metric(Msg::EventPollingTimeout);
+            client.record_metric(Msg::EventPublisherError);
+        }
 
         // Wait for the metrics to be updated
         time::sleep(Duration::from_secs(1)).await;

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -59,10 +59,12 @@ pub enum Msg {
         success: bool,
         duration: Duration,
     },
-    /// Record the number of messages enqueued error 
-    MsgEnqueueError,
+    /// Record the number of error in msg enqueue
+    MessageEnqueueError,
     /// Record the number of event timeout
     EventTimeout,
+    /// Record the number of error happens in event publisher
+    EventPublisherError,
 }
 
 /// Errors that can occur in metrics processing
@@ -224,8 +226,7 @@ struct Metrics {
     block_received: BlockReceivedMetrics,
     verification_vote: VerificationVoteMetrics,
     stage_result: EventStageMetrics,
-    msg_enqueue_error: MsgEnqueueErrorMetrics,
-    event_timeout: EventTimeoutMetrics,
+    error_metrics: ErrorMetricsCollection, // Single field
 }
 
 impl Metrics {
@@ -233,21 +234,18 @@ impl Metrics {
         let block_received = BlockReceivedMetrics::new();
         let verification_vote = VerificationVoteMetrics::new();
         let stage_result = EventStageMetrics::new();
-        let msg_enqueue_error = MsgEnqueueErrorMetrics::new();
-        let event_timeout = EventTimeoutMetrics::new();
+        let error_metrics = ErrorMetricsCollection::new();
 
         block_received.register(registry);
         verification_vote.register(registry);
         stage_result.register(registry);
-        msg_enqueue_error.register(registry);
-        event_timeout.register(registry);
+        error_metrics.register_all(registry);
 
         Self {
             block_received,
             verification_vote,
             stage_result,
-            msg_enqueue_error,
-            event_timeout,
+            error_metrics,
         }
     }
 
@@ -270,11 +268,14 @@ impl Metrics {
             } => {
                 self.stage_result.record(success, duration, stage);
             }
-            Msg::MsgEnqueueError => {
-                self.msg_enqueue_error.increment();
+            Msg::MessageEnqueueError => {
+                self.error_metrics.record_msg_enqueue_error();
             }
             Msg::EventTimeout => {
-                self.event_timeout.increment();
+                self.error_metrics.record_event_timeout();
+            }
+            Msg::EventPublisherError => {
+                self.error_metrics.record_event_publisher_error();
             }
         }
     }
@@ -411,22 +412,23 @@ impl EventStageMetrics {
     }
 }
 
-struct MsgEnqueueErrorMetrics {
+struct ErrorMetrics {
     total: Counter,
+    name: &'static str,
+    description: &'static str,
 }
 
-impl MsgEnqueueErrorMetrics {
-    fn new() -> Self {
-        let total = Counter::default();
-        Self { total }
+impl ErrorMetrics {
+    fn new(name: &'static str, description: &'static str) -> Self {
+        Self {
+            total: Counter::default(),
+            name,
+            description,
+        }
     }
 
     fn register(&self, registry: &mut Registry) {
-        registry.register(
-            "msg_enqueue_error",
-            "number of messages enqueued error",
-            self.total.clone(),
-        );
+        registry.register(self.name, self.description, self.total.clone());
     }
 
     fn increment(&self) {
@@ -434,26 +436,46 @@ impl MsgEnqueueErrorMetrics {
     }
 }
 
-struct EventTimeoutMetrics {
-    total: Counter,
+struct ErrorMetricsCollection {
+    msg_enqueue_error: ErrorMetrics,
+    event_timeout: ErrorMetrics,
+    event_publisher_error: ErrorMetrics,
 }
 
-impl EventTimeoutMetrics {
+impl ErrorMetricsCollection {
     fn new() -> Self {
-        let total = Counter::default();
-        Self { total }
+        Self {
+            msg_enqueue_error: ErrorMetrics::new(
+                "msg_enqueue_error",
+                "number of failures in message enqueue",
+            ),
+            event_timeout: ErrorMetrics::new(
+                "event_stream_timeout",
+                "number of timeouts while waiting for blockchain events",
+            ),
+            event_publisher_error: ErrorMetrics::new(
+                "event_publisher_error",
+                "number of failures in event publisher",
+            ),
+        }
     }
 
-    fn register(&self, registry: &mut Registry) {
-        registry.register(
-            "event_stream_timeout",
-            "number of timeouts while waiting for blockchain events",
-            self.total.clone(),
-        );
+    fn register_all(&self, registry: &mut Registry) {
+        self.msg_enqueue_error.register(registry);
+        self.event_timeout.register(registry);
+        self.event_publisher_error.register(registry);
     }
 
-    fn increment(&self) {
-        self.total.inc();
+    fn record_msg_enqueue_error(&self) {
+        self.msg_enqueue_error.increment();
+    }
+
+    fn record_event_timeout(&self) {
+        self.event_timeout.increment();
+    }
+
+    fn record_event_publisher_error(&self) {
+        self.event_publisher_error.increment();
     }
 }
 
@@ -636,12 +658,16 @@ mod tests {
         });
 
         // Msg Enqueue Error Metrics
-        client.record_metric(Msg::MsgEnqueueError);
-        client.record_metric(Msg::MsgEnqueueError);
+        client.record_metric(Msg::MessageEnqueueError);
+        client.record_metric(Msg::MessageEnqueueError);
 
         // Event Timeout Metrics
         client.record_metric(Msg::EventTimeout);
         client.record_metric(Msg::EventTimeout);
+
+        // Event Publisher Error Metrics
+        client.record_metric(Msg::EventPublisherError);
+        client.record_metric(Msg::EventPublisherError);
 
         // Wait for the metrics to be updated
         time::sleep(Duration::from_secs(1)).await;

--- a/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
+++ b/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
@@ -36,7 +36,7 @@ stage_duration_total{stage="TransactionConfirmation"} 1100
 # HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 2
-# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# HELP event_stream_timeout number of timeouts while polling blockchain events.
 # TYPE event_stream_timeout counter
 event_stream_timeout_total 2
 # HELP event_publisher_error number of failures in event publisher.

--- a/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
+++ b/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
@@ -33,9 +33,15 @@ stage_failed_total{stage="TransactionConfirmation"} 1
 stage_duration_total{stage="EventHandling"} 300
 stage_duration_total{stage="TransactionBroadcast"} 700
 stage_duration_total{stage="TransactionConfirmation"} 1100
-# HELP msg_enqueue_error number of messages enqueued error.
+# HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 2
+# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# TYPE event_stream_timeout counter
+event_stream_timeout_total 2
+# HELP event_publisher_error number of failures in event publisher.
+# TYPE event_publisher_error counter
+event_publisher_error_total 2
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent

--- a/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
+++ b/ampd/src/monitoring/endpoints/testdata/should_update_and_record_all_metrics_successfully.golden
@@ -33,6 +33,9 @@ stage_failed_total{stage="TransactionConfirmation"} 1
 stage_duration_total{stage="EventHandling"} 300
 stage_duration_total{stage="TransactionBroadcast"} 700
 stage_duration_total{stage="TransactionConfirmation"} 1100
+# HELP msg_enqueue_error number of messages enqueued error.
+# TYPE msg_enqueue_error counter
+msg_enqueue_error_total 2
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent

--- a/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
+++ b/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
@@ -10,9 +10,15 @@ blocks_received_total 0
 # TYPE stage_failed counter
 # HELP stage_duration duration of processing items per stage in milliseconds.
 # TYPE stage_duration counter
-# HELP msg_enqueue_error number of messages enqueued error.
+# HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 0
+# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# TYPE event_stream_timeout counter
+event_stream_timeout_total 0
+# HELP event_publisher_error number of failures in event publisher.
+# TYPE event_publisher_error counter
+event_publisher_error_total 0
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent
@@ -36,9 +42,15 @@ blocks_received_total 3
 # TYPE stage_failed counter
 # HELP stage_duration duration of processing items per stage in milliseconds.
 # TYPE stage_duration counter
-# HELP msg_enqueue_error number of messages enqueued error.
+# HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 0
+# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# TYPE event_stream_timeout counter
+event_stream_timeout_total 0
+# HELP event_publisher_error number of failures in event publisher.
+# TYPE event_publisher_error counter
+event_publisher_error_total 0
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent

--- a/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
+++ b/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
@@ -13,7 +13,7 @@ blocks_received_total 0
 # HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 0
-# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# HELP event_stream_timeout number of timeouts while polling blockchain events.
 # TYPE event_stream_timeout counter
 event_stream_timeout_total 0
 # HELP event_publisher_error number of failures in event publisher.
@@ -45,7 +45,7 @@ blocks_received_total 3
 # HELP msg_enqueue_error number of failures in message enqueue.
 # TYPE msg_enqueue_error counter
 msg_enqueue_error_total 0
-# HELP event_stream_timeout number of timeouts while waiting for blockchain events.
+# HELP event_stream_timeout number of timeouts while polling blockchain events.
 # TYPE event_stream_timeout counter
 event_stream_timeout_total 0
 # HELP event_publisher_error number of failures in event publisher.

--- a/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
+++ b/ampd/src/monitoring/testdata/metrics_endpoint_increments_counters_when_messages_sent.golden
@@ -10,6 +10,9 @@ blocks_received_total 0
 # TYPE stage_failed counter
 # HELP stage_duration duration of processing items per stage in milliseconds.
 # TYPE stage_duration counter
+# HELP msg_enqueue_error number of messages enqueued error.
+# TYPE msg_enqueue_error counter
+msg_enqueue_error_total 0
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent
@@ -33,6 +36,9 @@ blocks_received_total 3
 # TYPE stage_failed counter
 # HELP stage_duration duration of processing items per stage in milliseconds.
 # TYPE stage_duration counter
+# HELP msg_enqueue_error number of messages enqueued error.
+# TYPE msg_enqueue_error counter
+msg_enqueue_error_total 0
 # HELP ampd_cpu_usage_percent CPU usage of the ampd process in percentage
 # TYPE ampd_cpu_usage_percent gauge
 # UNIT ampd_cpu_usage_percent percent


### PR DESCRIPTION
While several AMPD errors are already covered by existing stage and flow metrics, this PR introduces three new metrics to track key failure points that were previously unobserved:
`event_stream_timeout_total`
Tracked when the event stream does not emit any events within the expected duration.

`msg_enqueue_error_total`
Tracked when a message fails to enqueue into the broadcast queue, i.e.exceeding the gas cap,failed simulation...

`event_publisher_error_total`
Tracked when the EventPublisher fails to query or send events 