### PR TITLE
fix: pin the github actions being used in the workflows

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -40,7 +40,7 @@ runs:
 
     - name: Determine next semantic version
       id: semantic-version
-      uses: paulhatch/semantic-version@v5.3.0
+      uses: paulhatch/semantic-version@8d3552d38408b608e90e76237a2a5ac9fe524d04 # v5.3.0
       with:
         major_pattern: ${{ inputs.major-pattern }}
         minor_pattern: ${{ inputs.minor-pattern }}
@@ -244,7 +244,7 @@ runs:
       if:
         inputs.dry-run == 'false' &&
         steps.semantic-version.outputs.changed == 'true'
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # branch master latest commit
       with:
         github_token: ${{ inputs.github_token }}
         branch: ${{ github.ref }}

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -244,7 +244,7 @@ runs:
       if:
         inputs.dry-run == 'false' &&
         steps.semantic-version.outputs.changed == 'true'
-      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # branch master 
+      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # branch master
       with:
         github_token: ${{ inputs.github_token }}
         branch: ${{ github.ref }}

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -244,7 +244,7 @@ runs:
       if:
         inputs.dry-run == 'false' &&
         steps.semantic-version.outputs.changed == 'true'
-      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # branch master latest commit
+      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # branch master 
       with:
         github_token: ${{ inputs.github_token }}
         branch: ${{ github.ref }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Setup Rust toolchain
       id: rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
       with:
         # Use Blacksmith cache instead of default Swatinem
         cache: false
@@ -19,7 +19,7 @@ runs:
         rustflags: ""
 
     - name: Cache Rust dependencies
-      uses: useblacksmith/rust-cache@v3.0.1
+      uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1
       id: cache
       with:
         # Automatic toolchain-based separation

--- a/.github/workflows/ampd-handlers-docker-ecr.yaml
+++ b/.github/workflows/ampd-handlers-docker-ecr.yaml
@@ -17,7 +17,7 @@ jobs:
       IMAGE_TAG: ${{ github.sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -26,14 +26,14 @@ jobs:
           git fetch --unshallow
           
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
       - name: check if an image already build on same commit hash
         id: image-tag-check
@@ -41,10 +41,10 @@ jobs:
           image_tag_exists=$(aws ecr batch-get-image --repository-name ${REPOSITORY} --image-ids "imageTag=${IMAGE_TAG}" | jq '.images | length')
           echo "image_tag_exists=${image_tag_exists}" >> $GITHUB_OUTPUT
           
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         if: steps.image-tag-check.outputs.image_tag_exists == 0
 
-      - uses: useblacksmith/build-push-action@v1
+      - uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1
         if: steps.image-tag-check.outputs.image_tag_exists == 0
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Test Suite
     runs-on: blacksmith-32vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -26,7 +26,7 @@ jobs:
           cache-key: "cache-tests"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,7 +39,7 @@ jobs:
     name: Cosmwasm Compilation
     runs-on: blacksmith-32vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -66,7 +66,7 @@ jobs:
     name: Ampd Release Compilation
     runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -76,7 +76,7 @@ jobs:
           cache-key: "cache-ampd-compilation"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -88,7 +88,7 @@ jobs:
     name: Lints
     runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -103,12 +103,12 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt --profile minimal
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-sort
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
         with:
           crate: cargo-sort
 

--- a/.github/workflows/build-ampd-main.yaml
+++ b/.github/workflows/build-ampd-main.yaml
@@ -17,7 +17,7 @@ jobs:
       IMAGE_TAG: ${{ github.sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -26,14 +26,14 @@ jobs:
           git fetch --unshallow
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
       - name: check if an image already build on same commit hash
         id: image-tag-check
@@ -41,10 +41,10 @@ jobs:
           image_tag_exists=$(aws ecr batch-get-image --repository-name ${REPOSITORY} --image-ids "imageTag=${IMAGE_TAG}" | jq '.images | length')
           echo "image_tag_exists=${image_tag_exists}" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         if: steps.image-tag-check.outputs.image_tag_exists == 0
 
-      - uses: useblacksmith/build-push-action@v1
+      - uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1
         if: steps.image-tag-check.outputs.image_tag_exists == 0
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-ampd-release.yaml
+++ b/.github/workflows/build-ampd-release.yaml
@@ -56,13 +56,13 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ghwf-${{ github.event.repository.name }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload binaries to release
         if: github.event.inputs.dry-run == 'false'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./ampdbin/*
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload to R2
         if: github.event.inputs.dry-run == 'false'
-        uses: ryand56/r2-upload-action@v1.3.2
+        uses: ryand56/r2-upload-action@31453780fdaaf43c8eff7231dd521f8669b48621 # v1.3.2
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CF }}
@@ -221,21 +221,21 @@ jobs:
     if: github.event.inputs.dry-run == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -257,12 +257,12 @@ jobs:
     if: github.event.inputs.dry-run == 'false'
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # 3.3.0
         with:
           cosign-release: 'v2.2.2'
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/build-contracts-and-push-to-r2.yaml
+++ b/.github/workflows/build-contracts-and-push-to-r2.yaml
@@ -90,7 +90,7 @@ jobs:
 
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           fetch-depth: "0"
           path: axelar-amplifier
@@ -101,7 +101,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@e00cb83a68c1158b29afc5217dd0582cada6d172 # v4
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -149,7 +149,7 @@ jobs:
           echo "r2-destination-dir=./releases/cosmwasm/${crate_name}" >> $GITHUB_OUTPUT
 
 
-      - uses: ryand56/r2-upload-action@v1.3.2
+      - uses: ryand56/r2-upload-action@31453780fdaaf43c8eff7231dd521f8669b48621 # v1.3.2
         if: steps.check-release.outputs.is-release == 'true'
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
@@ -160,7 +160,7 @@ jobs:
           destination-dir: ${{ steps.prepare-release.outputs.r2-destination-dir }}
 
 
-      - uses: ryand56/r2-upload-action@v1.3.2
+      - uses: ryand56/r2-upload-action@31453780fdaaf43c8eff7231dd521f8669b48621 # v1.3.2
         if: steps.check-release.outputs.is-release != 'true'
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libclang-dev
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@d411fc90b6227faf782d40f921b31b725fe5cb1d # cargo-llvm-cov branch (v2.58.3)
+        uses: taiki-e/install-action@1fd1160ee1f4387ce162a5a4f9c26ea274278b7f # cargo-llvm-cov branch (v2.58.7)
 
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -27,7 +27,7 @@ jobs:
           cache-key: "cache-codecov"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libclang-dev
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@d411fc90b6227faf782d40f921b31b725fe5cb1d # cargo-llvm-cov branch v 2.58.3
 
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
@@ -43,7 +43,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libclang-dev
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@d411fc90b6227faf782d40f921b31b725fe5cb1d # cargo-llvm-cov branch v 2.58.3
+        uses: taiki-e/install-action@d411fc90b6227faf782d40f921b31b725fe5cb1d # cargo-llvm-cov branch (v2.58.3)
 
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@1fd1160ee1f4387ce162a5a4f9c26ea274278b7f # cargo-llvm-cov branch (v2.58.7)
+        with:
+          tool: cargo-llvm-cov
 
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@v3.2.6
+        uses: amannn/action-semantic-pull-request@81acd1c603cf23bd6f6fbe16be9e882cd25cd4e6 #v3.2.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dependabot-vulns-to-slack.yaml
+++ b/.github/workflows/dependabot-vulns-to-slack.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Vulnerabilities
-        uses: kunalnagarco/action-cve@v1.7.15
+        uses: kunalnagarco/action-cve@05d3c64f3f7792562f9054940c5340db3be8aa0b # v1.7.15
         with:
           token: ${{ secrets.SLACK_PERSONAL_ACCESS_TOKEN }}
           slack_webhook: ${{ secrets.SLACK_TEAM_PROTOCOL_CHANNEL_WEBHOOK }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
         with:
           # only need ~/.cargo for mdBook tools and no build artifacts, so forego built-in cache and set up caching manually
           cache: false
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache cargo and tools
         id: cache-cargo
-        uses: "actions/cache@v4"
+        uses: "actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809" # v4
         with:
           path: |
             ~/.cargo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout repository including submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
 
       # Install cargo-audit explicitly because available github actions don't support Cargo.lock v4 yet
       - name: Install cargo-audit
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
         with:
           crate: cargo-audit
           version: 0.21.2


### PR DESCRIPTION
make sure we pin specific version in when using github marketplace actions or external tools 
(more details [here](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash)).