### PR TITLE
feat(coordinator): add query endpoint for deployments

### DIFF
--- a/contracts/coordinator/src/client.rs
+++ b/contracts/coordinator/src/client.rs
@@ -255,6 +255,24 @@ mod test {
                         .into())
                         .into()
                     }
+                    QueryMsg::Deployments => Ok(to_json_binary(&vec![ChainContractsResponse {
+                        chain_name: chain_name!("axelar"),
+                        prover_address: Addr::unchecked("prover"),
+                        verifier_address: Addr::unchecked("verifier"),
+                        gateway_address: Addr::unchecked("gateway"),
+                    }])
+                    .into())
+                    .into(),
+                    QueryMsg::Deployment { deployment_name: _ } => {
+                        Ok(to_json_binary(&ChainContractsResponse {
+                            chain_name: chain_name!("axelar"),
+                            prover_address: Addr::unchecked("prover"),
+                            verifier_address: Addr::unchecked("verifier"),
+                            gateway_address: Addr::unchecked("gateway"),
+                        })
+                        .into())
+                        .into()
+                    }
                 }
             }
             _ => panic!("unexpected query: {:?}", msg),

--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -4,7 +4,7 @@ mod migrations;
 mod query;
 
 use axelar_wasm_std::error::ContractError;
-use axelar_wasm_std::{address, nonempty, permission_control, FnExt};
+use axelar_wasm_std::{address, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -141,13 +141,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
             &query::chain_contracts_info(deps, chain_contracts_key)?,
         )?),
         QueryMsg::Deployments => Ok(to_json_binary(&query::deployments(deps)?)?),
-        QueryMsg::Deployment { deployment_name } => {
-            Ok(to_json_binary(&query::deployed_contracts(
-                deps,
-                nonempty::String::try_from(deployment_name)
-                    .change_context(Error::ParseDeploymentName)?,
-            )?)?)
-        }
+        QueryMsg::Deployment { deployment_name } => Ok(to_json_binary(
+            &query::deployed_contracts(deps, deployment_name)?,
+        )?),
     }
 }
 
@@ -159,7 +155,7 @@ mod tests {
     use router_api::{chain_name, cosmos_addr, ChainName};
 
     use super::*;
-    use crate::msg::ChainContractsKey;
+    use crate::msg::{ChainContractsKey, ChainContractsResponse};
     use crate::state::{contracts_by_chain, ChainContractsRecord};
 
     struct TestSetup {

--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -4,7 +4,7 @@ mod migrations;
 mod query;
 
 use axelar_wasm_std::error::ContractError;
-use axelar_wasm_std::{address, permission_control, FnExt};
+use axelar_wasm_std::{address, nonempty, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -140,6 +140,14 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::ChainContractsInfo(chain_contracts_key) => Ok(to_json_binary(
             &query::chain_contracts_info(deps, chain_contracts_key)?,
         )?),
+        QueryMsg::Deployments => Ok(to_json_binary(&query::deployments(deps)?)?),
+        QueryMsg::Deployment { deployment_name } => {
+            Ok(to_json_binary(&query::deployed_contracts(
+                deps,
+                nonempty::String::try_from(deployment_name)
+                    .change_context(Error::ParseDeploymentName)?,
+            )?)?)
+        }
     }
 }
 

--- a/contracts/coordinator/src/contract/errors.rs
+++ b/contracts/coordinator/src/contract/errors.rs
@@ -51,4 +51,6 @@ pub enum Error {
     RouterClient,
     #[error("address {0} has incorrect format")]
     InvalidAddress(String),
+    #[error("failed to parse deployment name")]
+    ParseDeploymentName,
 }

--- a/contracts/coordinator/src/contract/query.rs
+++ b/contracts/coordinator/src/contract/query.rs
@@ -1,3 +1,4 @@
+use axelar_wasm_std::nonempty;
 use cosmwasm_std::{Addr, Deps, Order, StdError};
 use error_stack::{Result, ResultExt};
 use itertools::Itertools;
@@ -93,4 +94,31 @@ pub fn chain_contracts_info(
     }
     .change_context(Error::ChainContractsInfo)
     .map(ChainContractsResponse::from)
+}
+
+pub fn deployments(deps: Deps) -> Result<Vec<ChainContractsResponse>, Error> {
+    Ok(state::deployments(deps.storage)
+        .change_context(Error::ChainContractsInfo)?
+        .into_iter()
+        .map(|chains| ChainContractsResponse {
+            chain_name: chains.chain_name,
+            prover_address: chains.multisig_prover,
+            verifier_address: chains.voting_verifier,
+            gateway_address: chains.gateway,
+        })
+        .collect())
+}
+
+pub fn deployed_contracts(
+    deps: Deps,
+    deployment_name: nonempty::String,
+) -> Result<ChainContractsResponse, Error> {
+    state::deployed_contracts(deps.storage, deployment_name)
+        .map(|chains| ChainContractsResponse {
+            chain_name: chains.chain_name,
+            prover_address: chains.multisig_prover,
+            verifier_address: chains.voting_verifier,
+            gateway_address: chains.gateway,
+        })
+        .change_context(Error::ChainContractsInfo)
 }

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -130,7 +130,7 @@ pub enum QueryMsg {
     Deployments,
 
     #[returns(ChainContractsResponse)]
-    Deployment { deployment_name: String },
+    Deployment { deployment_name: nonempty::String },
 }
 
 #[cw_serde]

--- a/contracts/coordinator/src/msg.rs
+++ b/contracts/coordinator/src/msg.rs
@@ -125,6 +125,12 @@ pub enum QueryMsg {
 
     #[returns(ChainContractsResponse)]
     ChainContractsInfo(ChainContractsKey),
+
+    #[returns(Vec<ChainContractsResponse>)]
+    Deployments,
+
+    #[returns(ChainContractsResponse)]
+    Deployment { deployment_name: String },
 }
 
 #[cw_serde]

--- a/contracts/coordinator/src/state.rs
+++ b/contracts/coordinator/src/state.rs
@@ -228,6 +228,16 @@ pub fn deployed_contracts(
         .ok_or(report!(Error::DeploymentNameNotFound(deployment_name)))
 }
 
+pub fn deployments(storage: &dyn Storage) -> Result<Vec<ChainContracts>, Error> {
+    Ok(DEPLOYED_CHAINS
+        .range(storage, None, None, Order::Ascending)
+        .filter_map(|entry| match entry {
+            Ok((_, contracts)) => Some(contracts),
+            Err(..) => None,
+        })
+        .collect())
+}
+
 pub fn is_prover_registered(
     storage: &dyn Storage,
     prover_address: ProverAddress,


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
