### PR TITLE
ci: fix rust toolchain conflicts in GitHub Actions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,6 +9,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
+
+    - name: Show installed versions
+      id: versions
+      run: |
+        echo "rustc --version: $(rustc --version)"
+        echo "cargo --version: $(cargo --version)"
+        echo "rustup --version: $(rustup --version)"
+        echo "cachekey=$(rustc --version | sed -E 's/[^0-9]+([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\2\3a/' )" >> $GITHUB_OUTPUT
+        echo "all installed toolchains:"
+        echo "---------------------"
+        rustup show
+        echo "---------------------"
+      shell: bash
+
     - name: Setup Rust toolchain
       id: rust
       uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
@@ -19,9 +33,9 @@ runs:
         rustflags: ""
 
     # The default fallback is "stable", independent of the rust-toolchain.toml, and could be outdated.
-    - name: Set active toolchain as default fallback
+    - name: Remove
       shell: bash
-      run: rustup default "$(rustup show active-toolchain | cut -d' ' -f1)"
+      run: rustup toolchain uninstall "$(rustup show active-toolchain | cut -d' ' -f1)"
 
     - name: Show installed versions
       id: versions

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,7 +17,11 @@ runs:
         cache: false
         # Preserve RUSTFLAGS from .cargo/config.toml
         rustflags: ""
-        override: 'true'
+
+    # The default fallback is "stable", independent of the rust-toolchain.toml, and could be outdated.
+    - name: Set active toolchain as default fallback
+      shell: bash
+      run: rustup default "$(rustup show active-toolchain | cut -d' ' -f1)"
 
     - name: Show installed versions
       id: versions

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -12,7 +12,10 @@ runs:
 
     - name: show installed toolchains
       shell: bash
-      run: rustup show
+      run: |
+        rustup show
+        rustup toolchain list
+
 
     - name: Setup Rust toolchain
       id: rust
@@ -30,7 +33,10 @@ runs:
 
     - name: show installed toolchains
       shell: bash
-      run: rustup show
+      run: |
+        rustup show
+        rustup toolchain list
+
 
     - name: Cache Rust dependencies
       uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,6 +16,10 @@ runs:
         rustup show
         rustup toolchain list
 
+    # The default fallback is "stable", independent of the rust-toolchain.toml, and could be outdated.
+    - name: Remove
+      shell: bash
+      run: rustup toolchain uninstall "stable"
 
     - name: Setup Rust toolchain
       id: rust
@@ -25,11 +29,6 @@ runs:
         cache: false
         # Preserve RUSTFLAGS from .cargo/config.toml
         rustflags: ""
-
-    # The default fallback is "stable", independent of the rust-toolchain.toml, and could be outdated.
-    - name: Remove
-      shell: bash
-      run: rustup toolchain uninstall "$(rustup show active-toolchain | cut -d' ' -f1)"
 
     - name: show installed toolchains
       shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,13 +10,7 @@ runs:
   using: 'composite'
   steps:
 
-    - name: show installed toolchains
-      shell: bash
-      run: |
-        rustup show
-        rustup toolchain list
-
-    # The default fallback is "stable", independent of the rust-toolchain.toml, and could be outdated.
+    # In case there is a "stable" default toolchain cached, we need to uninstall that to ensure all steps use the expected toolchain
     - name: Remove
       shell: bash
       run: rustup toolchain uninstall "stable"
@@ -29,13 +23,6 @@ runs:
         cache: false
         # Preserve RUSTFLAGS from .cargo/config.toml
         rustflags: ""
-
-    - name: show installed toolchains
-      shell: bash
-      run: |
-        rustup show
-        rustup toolchain list
-
 
     - name: Cache Rust dependencies
       uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,6 +18,15 @@ runs:
         # Preserve RUSTFLAGS from .cargo/config.toml
         rustflags: ""
 
+    - name: Show installed versions
+      id: versions
+      run: |
+        echo "rustc --version: $(rustc --version)"
+        echo "cargo --version: $(cargo --version)"
+        echo "rustup --version: $(rustup --version)"
+        echo "cachekey=$(rustc --version | sed -E 's/[^0-9]+([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\2\3a/' )" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Cache Rust dependencies
       uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1
       id: cache

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -25,6 +25,10 @@ runs:
         echo "cargo --version: $(cargo --version)"
         echo "rustup --version: $(rustup --version)"
         echo "cachekey=$(rustc --version | sed -E 's/[^0-9]+([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\2\3a/' )" >> $GITHUB_OUTPUT
+        echo "all installed toolchains:"
+        echo "---------------------"
+        rustup show
+        echo "---------------------"
       shell: bash
 
     - name: Cache Rust dependencies

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,18 +10,9 @@ runs:
   using: 'composite'
   steps:
 
-    - name: Show installed versions
-      id: versions
-      run: |
-        echo "rustc --version: $(rustc --version)"
-        echo "cargo --version: $(cargo --version)"
-        echo "rustup --version: $(rustup --version)"
-        echo "cachekey=$(rustc --version | sed -E 's/[^0-9]+([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\2\3a/' )" >> $GITHUB_OUTPUT
-        echo "all installed toolchains:"
-        echo "---------------------"
-        rustup show
-        echo "---------------------"
+    - name: show installed toolchains
       shell: bash
+      run: rustup show
 
     - name: Setup Rust toolchain
       id: rust
@@ -37,18 +28,9 @@ runs:
       shell: bash
       run: rustup toolchain uninstall "$(rustup show active-toolchain | cut -d' ' -f1)"
 
-    - name: Show installed versions
-      id: versions
-      run: |
-        echo "rustc --version: $(rustc --version)"
-        echo "cargo --version: $(cargo --version)"
-        echo "rustup --version: $(rustup --version)"
-        echo "cachekey=$(rustc --version | sed -E 's/[^0-9]+([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\2\3a/' )" >> $GITHUB_OUTPUT
-        echo "all installed toolchains:"
-        echo "---------------------"
-        rustup show
-        echo "---------------------"
+    - name: show installed toolchains
       shell: bash
+      run: rustup show
 
     - name: Cache Rust dependencies
       uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,6 +17,7 @@ runs:
         cache: false
         # Preserve RUSTFLAGS from .cargo/config.toml
         rustflags: ""
+        override: 'true'
 
     - name: Show installed versions
       id: versions

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -103,6 +103,9 @@ jobs:
       - name: Uninstall stable & nightly rust versions
         run: rustup uninstall stable && rustup uninstall nightly
 
+      - name: show installed toolchains
+        run: rustup show
+
       # Install nightly toolchain for formatting (as per justfile)
       - name: Install nightly for rustfmt
         run: rustup toolchain install nightly --component rustfmt --profile minimal

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -133,14 +133,14 @@ jobs:
         with:
           crate: dylint-link
 
-      - name: Run cargo fmt
-        run: cargo +nightly fmt-check # alias
-
-      - name: Run cargo sort
-        run: cargo sort-check # alias
-
-      - name: Run cargo clippy
-        run: cargo clippy-check # alias
+#      - name: Run cargo fmt
+#        run: cargo +nightly fmt-check # alias
+#
+#      - name: Run cargo sort
+#        run: cargo sort-check # alias
+#
+#      - name: Run cargo clippy
+#        run: cargo clippy-check # alias
 
       - name: Run custom lints
         run: cargo dylint --all

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -104,7 +104,10 @@ jobs:
         run: rustup uninstall stable
 
       - name: show installed toolchains
-        run: rustup show
+        run: |
+          rustup show
+          rustup toolchain list
+
 
       # Install nightly toolchain for formatting (as per justfile)
       - name: Install nightly for rustfmt
@@ -121,7 +124,10 @@ jobs:
           crate: cargo-sort
 
       - name: show installed toolchains
-        run: rustup show
+        run: |
+          rustup show
+          rustup toolchain list
+
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -98,10 +98,10 @@ jobs:
         with:
           cache-key: "cache-lints"
 
-      # Currently a workaround for running custom lints.
-      # For some reason, the custom lints seem to use cargo version 1.80.0, causing that step to fail.
-      - name: Uninstall stable & nightly rust versions
-        run: rustup uninstall stable && rustup uninstall nightly
+#      # Currently a workaround for running custom lints.
+#      # For some reason, the custom lints seem to use cargo version 1.80.0, causing that step to fail.
+#      - name: Uninstall stable & nightly rust versions
+#        run: rustup uninstall stable && rustup uninstall nightly
 
       - name: show installed toolchains
         run: rustup show
@@ -119,6 +119,9 @@ jobs:
         uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
         with:
           crate: cargo-sort
+
+      - name: show installed toolchains
+        run: rustup show
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -98,12 +98,6 @@ jobs:
         with:
           cache-key: "cache-lints"
 
-      - name: show installed toolchains
-        run: |
-          rustup show
-          rustup toolchain list
-
-
       # Install nightly toolchain for formatting (as per justfile)
       - name: Install nightly for rustfmt
         run: rustup toolchain install nightly --component rustfmt --profile minimal
@@ -118,12 +112,6 @@ jobs:
         with:
           crate: cargo-sort
 
-      - name: show installed toolchains
-        run: |
-          rustup show
-          rustup toolchain list
-
-
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
         with:
@@ -134,14 +122,14 @@ jobs:
         with:
           crate: dylint-link
 
-#      - name: Run cargo fmt
-#        run: cargo +nightly fmt-check # alias
-#
-#      - name: Run cargo sort
-#        run: cargo sort-check # alias
-#
-#      - name: Run cargo clippy
-#        run: cargo clippy-check # alias
+      - name: Run cargo fmt
+        run: cargo +nightly fmt-check # alias
+
+      - name: Run cargo sort
+        run: cargo sort-check # alias
+
+      - name: Run cargo clippy
+        run: cargo clippy-check # alias
 
       - name: Run custom lints
         run: cargo dylint --all

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -98,10 +98,10 @@ jobs:
         with:
           cache-key: "cache-lints"
 
-#      # Currently a workaround for running custom lints.
-#      # For some reason, the custom lints seem to use cargo version 1.80.0, causing that step to fail.
-#      - name: Uninstall stable & nightly rust versions
-#        run: rustup uninstall stable && rustup uninstall nightly
+      # Currently a workaround for running custom lints.
+      # For some reason, the custom lints seem to use cargo version 1.80.0, causing that step to fail.
+      - name: Uninstall stable & nightly rust versions
+        run: rustup uninstall stable
 
       - name: show installed toolchains
         run: rustup show

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -98,11 +98,6 @@ jobs:
         with:
           cache-key: "cache-lints"
 
-      # Currently a workaround for running custom lints.
-      # For some reason, the custom lints seem to use cargo version 1.80.0, causing that step to fail.
-      - name: Uninstall stable & nightly rust versions
-        run: rustup uninstall stable
-
       - name: show installed toolchains
         run: |
           rustup show


### PR DESCRIPTION
## Fix Rust Toolchain Conflicts in CI

### Problem
The CI was experiencing toolchain version conflicts where a cached or default `stable` toolchain was interfering with the version specified in `rust-toolchain.toml` (1.86.0). This caused inconsistent behavior and failures in CI jobs.

### Solution
- Remove the default `stable` toolchain before setting up the project-specific toolchain
- This ensures all CI steps consistently use the Rust version defined in `rust-toolchain.toml`

### Changes
- **`.github/actions/setup-rust/action.yml`**: Added step to uninstall `stable` toolchain before setup
- **`.github/workflows/basic.yaml`**: Removed workaround that was uninstalling stable/nightly versions

### Testing
The changes have been tested through multiple CI runs to ensure the toolchain setup works correctly without conflicts.

### Impact
- ✅ Ensures consistent Rust version across all CI jobs
- ✅ Eliminates toolchain-related CI failures
- ✅ Simplifies the CI configuration by removing workarounds
