### PR TITLE
refactor(ampd): move hardcoded values into config 

### DIFF
--- a/ampd/README.md
+++ b/ampd/README.md
@@ -64,7 +64,7 @@ from Avalanche testnet, Sui testnet and Stacks testnet.
 
 ```yaml
 tm_jsonrpc="http://localhost:26657"
-tm_grpc="tcp://localhost:9090"'
+tm_grpc="tcp://localhost:9090"
 
 event_buffer_cap=10000
 

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -27,8 +27,9 @@ gas_price=[gas price with denom, i.e. "0.007uaxl"]
 queue_cap=[max messages to queue when broadcasting]
 tx_fetch_interval=[how often to query for transaction inclusion in a block]
 tx_fetch_max_retries=[how many times to query for transaction inclusion in a block before failing]
-tx_confirmation_buffer_size=[maximum number of transaction confirmations to process concurrently]
-tx_confirmation_queue_cap=[how many transactions can be queued for confirmation before backpressure]
+tx_confirmation_buffer_size=[maximum concurrent transaction confirmations (higher values improve throughput, lower values reduce resource usage; tune based on network and system capacity)]
+tx_confirmation_queue_cap=[maximum size of the confirmation queue (larger values buffer more transactions during spikes but use more memory; smaller values risk dropping requests under load)]
+
 
 [tofnd_config]
 key_uid=[uid of key used for signing transactions]

--- a/ampd/README.md
+++ b/ampd/README.md
@@ -27,6 +27,8 @@ gas_price=[gas price with denom, i.e. "0.007uaxl"]
 queue_cap=[max messages to queue when broadcasting]
 tx_fetch_interval=[how often to query for transaction inclusion in a block]
 tx_fetch_max_retries=[how many times to query for transaction inclusion in a block before failing]
+tx_confirmation_buffer_size=[maximum number of transaction confirmations to process concurrently]
+tx_confirmation_queue_cap=[how many transactions can be queued for confirmation before backpressure]
 
 [tofnd_config]
 key_uid=[uid of key used for signing transactions]
@@ -62,7 +64,8 @@ from Avalanche testnet, Sui testnet and Stacks testnet.
 
 ```yaml
 tm_jsonrpc="http://localhost:26657"
-tm_grpc="tcp://localhost:9090"
+tm_grpc="tcp://localhost:9090"'
+
 event_buffer_cap=10000
 
 [service_registry]
@@ -77,6 +80,8 @@ gas_price="0.00005uamplifier"
 queue_cap="1000"
 tx_fetch_interval="600ms"
 tx_fetch_max_retries="10"
+tx_confirmation_buffer_size = 10
+tx_confirmation_queue_cap = 1000
 
 [tofnd_config]
 key_uid="axelar"

--- a/ampd/src/broadcast/config.rs
+++ b/ampd/src/broadcast/config.rs
@@ -18,6 +18,10 @@ pub struct Config {
     pub queue_cap: usize,
     #[serde(with = "humantime_serde")]
     pub broadcast_interval: Duration,
+    #[serde(default)]
+    pub tx_confirmation_buffer_size: usize,
+    #[serde(default)]
+    pub tx_confirmation_queue_cap: usize,
 }
 
 impl Default for Config {
@@ -33,6 +37,8 @@ impl Default for Config {
             batch_gas_limit: 1000000,
             queue_cap: 1000,
             broadcast_interval: Duration::from_secs(5),
+            tx_confirmation_buffer_size: 10,
+            tx_confirmation_queue_cap: 1000,
         }
     }
 }

--- a/ampd/src/broadcast/config.rs
+++ b/ampd/src/broadcast/config.rs
@@ -18,7 +18,17 @@ pub struct Config {
     pub queue_cap: usize,
     #[serde(with = "humantime_serde")]
     pub broadcast_interval: Duration,
+    // Maximum number of transaction confirmations to process concurrently.
+    // - Controls parallelism when confirming transactions
+    // - Higher values increase throughput for confirming many transactions
+    // - Lower values reduce resource consumption
+    // - Balance based on network capacity and system resources
     pub tx_confirmation_buffer_size: usize,
+    // Maximum capacity of the transaction confirmation queue.
+    // - Determines how many transactions can be queued for confirmation before backpressure
+    // - Larger values provide more buffering for high-volume transaction periods
+    // - Too small may cause confirmation requests to be dropped during traffic spikes
+    // - Too large may consume excessive memory if confirmations become backlogged
     pub tx_confirmation_queue_cap: usize,
 }
 

--- a/ampd/src/broadcast/config.rs
+++ b/ampd/src/broadcast/config.rs
@@ -18,9 +18,7 @@ pub struct Config {
     pub queue_cap: usize,
     #[serde(with = "humantime_serde")]
     pub broadcast_interval: Duration,
-    #[serde(default)]
     pub tx_confirmation_buffer_size: usize,
-    #[serde(default)]
     pub tx_confirmation_queue_cap: usize,
 }
 

--- a/ampd/src/broadcast/confirmer.rs
+++ b/ampd/src/broadcast/confirmer.rs
@@ -13,20 +13,6 @@ use crate::monitoring::metrics;
 use crate::monitoring::metrics::{Msg, Stage};
 use crate::{cosmos, monitoring};
 
-// TODO: move these constants to the config. In the meantime, these were chosen as reasonable heuristics.
-// Maximum number of transaction confirmations to process concurrently.
-// - Controls parallelism when confirming transactions
-// - Higher values increase throughput for confirming many transactions
-// - Lower values reduce resource consumption
-// - Balance based on network capacity and system resources
-const TX_CONFIRMATION_BUFFER_SIZE: usize = 10;
-// Maximum capacity of the transaction confirmation queue.
-// - Determines how many transactions can be queued for confirmation before backpressure
-// - Larger values provide more buffering for high-volume transaction periods
-// - Too small may cause confirmation requests to be dropped during traffic spikes
-// - Too large may consume excessive memory if confirmations become backlogged
-const TX_CONFIRMATION_QUEUE_CAP: usize = 1000;
-
 type Result<T> = error_stack::Result<T, Error>;
 
 #[derive(Debug, Error)]
@@ -56,6 +42,7 @@ where
     rx: mpsc::Receiver<String>,
     client: T,
     retry_policy: RetryPolicy,
+    buffer_size: usize,
     monitoring_client: monitoring::Client,
 }
 
@@ -74,13 +61,16 @@ where
     pub fn new_confirmer_and_client(
         client: T,
         retry_policy: RetryPolicy,
+        buffer_size: usize,
+        queue_cap: usize,
         monitoring_client: monitoring::Client,
     ) -> (Self, TxConfirmerClient) {
-        let (tx, rx) = mpsc::channel(TX_CONFIRMATION_QUEUE_CAP);
+        let (tx, rx) = mpsc::channel(queue_cap);
         let confirmer = Self {
             rx,
             client,
             retry_policy,
+            buffer_size,
             monitoring_client,
         };
 
@@ -103,6 +93,7 @@ where
             client,
             retry_policy,
             monitoring_client,
+            buffer_size,
         } = self;
         let mut stream = ReceiverStream::new(rx)
             .inspect(|tx_hash| info!(tx_hash, "received tx hash to confirm"))
@@ -119,7 +110,7 @@ where
 
                 res
             })
-            .buffer_unordered(TX_CONFIRMATION_BUFFER_SIZE);
+            .buffer_unordered(buffer_size);
 
         while let Some(result) = stream.next().await {
             log_confirm_tx_result(result);
@@ -205,6 +196,8 @@ mod tests {
     async fn tx_confirmer_should_confirm_tx_that_succeed_on_chain() {
         let tx_hash = "tx_hash";
         let retry_policy = RetryPolicy::repeat_constant(Duration::from_millis(500), 3);
+        let buffer_size = 10;
+        let queue_cap = 1000;
 
         let mut client = cosmos::MockCosmosClient::default();
         client.expect_clone().return_once(|| {
@@ -230,8 +223,13 @@ mod tests {
 
         let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
-        let (confirmer, confirmer_client) =
-            super::TxConfirmer::new_confirmer_and_client(client, retry_policy, monitoring_client);
+        let (confirmer, confirmer_client) = super::TxConfirmer::new_confirmer_and_client(
+            client,
+            retry_policy,
+            buffer_size,
+            queue_cap,
+            monitoring_client,
+        );
         confirmer_client.send(tx_hash.to_string()).await.unwrap();
         drop(confirmer_client);
         confirmer.run().await.unwrap();
@@ -255,6 +253,8 @@ mod tests {
     async fn tx_confirmer_should_confirm_tx_that_failed_on_chain() {
         let tx_hash = "tx_hash";
         let retry_policy = RetryPolicy::repeat_constant(Duration::from_millis(500), 3);
+        let buffer_size = 10;
+        let queue_cap = 1000;
 
         let mut client = cosmos::MockCosmosClient::default();
         client.expect_clone().return_once(|| {
@@ -280,8 +280,13 @@ mod tests {
 
         let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
-        let (confirmer, confirmer_client) =
-            super::TxConfirmer::new_confirmer_and_client(client, retry_policy, monitoring_client);
+        let (confirmer, confirmer_client) = super::TxConfirmer::new_confirmer_and_client(
+            client,
+            retry_policy,
+            buffer_size,
+            queue_cap,
+            monitoring_client,
+        );
         confirmer_client.send(tx_hash.to_string()).await.unwrap();
         drop(confirmer_client);
         confirmer.run().await.unwrap();
@@ -305,6 +310,8 @@ mod tests {
     async fn tx_confirmer_should_not_confirm_tx_that_cannot_be_found_on_chain() {
         let tx_hash = "tx_hash";
         let retry_policy = RetryPolicy::repeat_constant(Duration::from_millis(500), 3);
+        let buffer_size = 10;
+        let queue_cap = 1000;
 
         let mut client = cosmos::MockCosmosClient::default();
         client.expect_clone().times(3).returning(|| {
@@ -321,8 +328,13 @@ mod tests {
 
         let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
-        let (confirmer, confirmer_client) =
-            super::TxConfirmer::new_confirmer_and_client(client, retry_policy, monitoring_client);
+        let (confirmer, confirmer_client) = super::TxConfirmer::new_confirmer_and_client(
+            client,
+            retry_policy,
+            buffer_size,
+            queue_cap,
+            monitoring_client,
+        );
         confirmer_client.send(tx_hash.to_string()).await.unwrap();
         drop(confirmer_client);
         confirmer.run().await.unwrap();
@@ -346,6 +358,8 @@ mod tests {
     async fn tx_confirmer_should_not_confirm_tx_that_cannot_be_queried() {
         let tx_hash = "tx_hash";
         let retry_policy = RetryPolicy::repeat_constant(Duration::from_millis(500), 3);
+        let buffer_size = 10;
+        let queue_cap = 1000;
 
         let mut client = cosmos::MockCosmosClient::default();
         client.expect_clone().times(3).returning(|| {
@@ -362,8 +376,13 @@ mod tests {
 
         let (monitoring_client, mut receiver) = test_utils::monitoring_client();
 
-        let (confirmer, confirmer_client) =
-            super::TxConfirmer::new_confirmer_and_client(client, retry_policy, monitoring_client);
+        let (confirmer, confirmer_client) = super::TxConfirmer::new_confirmer_and_client(
+            client,
+            retry_policy,
+            buffer_size,
+            queue_cap,
+            monitoring_client,
+        );
         confirmer_client.send(tx_hash.to_string()).await.unwrap();
         drop(confirmer_client);
         confirmer.run().await.unwrap();

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::pin::Pin;
 
 use clap::Subcommand;
@@ -165,7 +164,7 @@ async fn instantiate_broadcaster(
         .await
         .change_context(Error::Broadcaster)?;
 
-    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>, None)
+    let (_, monitoring_client) = monitoring::Server::new(monitoring::Config::Disabled)
         .expect("should never fail to create dummy monitoring client");
 
     let (msg_queue, _) = broadcast::MsgQueue::new_msg_queue_and_client(

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -165,7 +165,7 @@ async fn instantiate_broadcaster(
         .await
         .change_context(Error::Broadcaster)?;
 
-    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>)
+    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>, None)
         .expect("should never fail to create dummy monitoring client");
 
     let (msg_queue, _) = broadcast::MsgQueue::new_msg_queue_and_client(

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -7,7 +7,7 @@ use crate::handlers::config::deserialize_handler_configs;
 use crate::handlers::{self};
 use crate::tofnd::Config as TofndConfig;
 use crate::url::Url;
-use crate::{broadcast, event_processor, grpc, monitoring};
+use crate::{broadcast, event_processor, event_sub, grpc, monitoring, tm_client};
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(default)]
@@ -27,6 +27,8 @@ pub struct Config {
     #[serde(deserialize_with = "grpc::deserialize_config")]
     pub grpc: grpc::Config,
     pub monitoring_server: monitoring::Config,
+    pub event_sub: event_sub::Config,
+    pub tm_client: tm_client::Config,
 }
 
 impl Default for Config {
@@ -45,6 +47,8 @@ impl Default for Config {
             rewards: RewardsConfig::default(),
             grpc: grpc::Config::default(),
             monitoring_server: monitoring::Config::default(),
+            event_sub: event_sub::Config::default(),
+            tm_client: tm_client::Config::default(),
         }
     }
 }

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -44,7 +44,6 @@ pub struct Config {
     pub stream_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub delay: Duration,
-    #[serde(default)]
     pub tx_broadcast_buffer_size: usize,
 }
 

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -19,13 +19,6 @@ use crate::monitoring::metrics;
 use crate::monitoring::metrics::{Msg, Stage};
 use crate::{broadcast, cosmos, event_sub, monitoring};
 
-// Maximum number of messages to enqueue for broadcasting concurrently.
-// - Controls parallelism when enqueueing messages to the broadcast queue
-// - Higher values increase throughput for processing many messages at once
-// - Lower values reduce resource consumption
-// - Setting is balanced based on network capacity and system resources
-const TX_BROADCAST_BUFFER_SIZE: usize = 10;
-
 #[async_trait]
 pub trait EventHandler {
     type Err: Context;
@@ -51,6 +44,8 @@ pub struct Config {
     pub stream_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub delay: Duration,
+    #[serde(default)]
+    pub tx_broadcast_buffer_size: usize,
 }
 
 impl Default for Config {
@@ -61,6 +56,7 @@ impl Default for Config {
             stream_timeout: Duration::from_secs(15),
             stream_buffer_size: 100000,
             delay: Duration::from_secs(1),
+            tx_broadcast_buffer_size: 10,
         }
     }
 }
@@ -87,6 +83,7 @@ where
         retry_delay,
         retry_max_attempts,
         stream_timeout,
+        tx_broadcast_buffer_size,
         ..
     } = event_processor_config;
     let handler_retry = RetryPolicy::repeat_constant(retry_delay, retry_max_attempts);
@@ -111,6 +108,7 @@ where
                     &msg_queue_client,
                     &event,
                     handler_retry,
+                    tx_broadcast_buffer_size,
                     &monitoring_client,
                 )
                 .await?;
@@ -134,6 +132,7 @@ async fn handle_event<H, C>(
     msg_queue_client: &broadcast::MsgQueueClient<C>,
     event: &Event,
     retry_policy: RetryPolicy,
+    tx_broadcast_buffer_size: usize,
     monitoring_client: &monitoring::Client,
 ) -> Result<(), Error>
 where
@@ -153,7 +152,7 @@ where
         Ok(msgs) => {
             tokio_stream::iter(msgs)
                 .map(|msg| async { msg_queue_client.clone().enqueue_and_forget(msg).await })
-                .buffered(TX_BROADCAST_BUFFER_SIZE)
+                .buffered(tx_broadcast_buffer_size)
                 .inspect_err(|err| {
                     warn!(
                         err = LoggableError::from(err).as_value(),
@@ -274,6 +273,7 @@ mod tests {
             stream_timeout: stream_timeout_value,
             stream_buffer_size: 100000,
             delay,
+            tx_broadcast_buffer_size: 10,
         }
     }
 

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -44,6 +44,11 @@ pub struct Config {
     pub stream_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub delay: Duration,
+    // Maximum number of messages to enqueue for broadcasting concurrently.
+    // - Controls parallelism when enqueueing messages to the broadcast queue
+    // - Higher values increase throughput for processing many messages at once
+    // - Lower values reduce resource consumption
+    // - Setting is balanced based on network capacity and system resources
     pub tx_broadcast_buffer_size: usize,
 }
 

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -38,6 +38,14 @@ pub enum Error {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Config {
     // The maximum number of blocks to process concurrently.
+    // - A value of 1 ensures sequential processing, preventing the event sub
+    //   from downloading events from multiple blocks simultaneously. This minimizes
+    //   memory usage but may slow down event processing.
+    // - Higher values enable parallel block processing, improving throughput but
+    //   increasing memory usage and potential resource contention.
+    // - Setting this too high may cause excessive memory consumption, while setting
+    //   it too low may lead to slower processing and underutilization of downstream
+    //   consumers.
     pub block_processing_buffer: usize,
     // Interval to poll for new blocks
     #[serde(with = "humantime_serde")]

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -50,7 +50,7 @@ impl Default for Config {
         Self {
             block_processing_buffer: 10,
             poll_interval: Duration::from_secs(5),
-            retry_delay: Duration::from_secs(1),
+            retry_delay: Duration::from_secs(3),
             retry_max_attempts: 3,
         }
     }

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -37,9 +37,13 @@ pub enum Error {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Config {
+    // The maximum number of blocks to process concurrently.
     pub block_processing_buffer: usize,
+    // Interval to poll for new blocks
     #[serde(with = "humantime_serde")]
     pub poll_interval: Duration,
+
+    // Retry policy for block processing and event retrival
     #[serde(with = "humantime_serde")]
     pub retry_delay: Duration,
     pub retry_max_attempts: u64,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -102,7 +102,7 @@ async fn prepare_app(cfg: Config) -> Result<App, Error> {
 
     let tm_client = tm_client::TendermintClient::new(
         tendermint_rpc::HttpClient::new(tm_jsonrpc.as_str())
-        .change_context(Error::Connection)
+            .change_context(Error::Connection)
             .attach_printable(tm_jsonrpc.clone())?,
         tm_client.max_retries,
         tm_client.retry_delay,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -102,7 +102,7 @@ async fn prepare_app(cfg: Config) -> Result<App, Error> {
 
     let tm_client = tm_client::TendermintClient::new(
         tendermint_rpc::HttpClient::new(tm_jsonrpc.as_str())
-            .change_context(Error::Connection)
+        .change_context(Error::Connection)
             .attach_printable(tm_jsonrpc.clone())?,
         tm_client.max_retries,
         tm_client.retry_delay,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -94,11 +94,8 @@ async fn prepare_app(cfg: Config) -> Result<App, Error> {
         tm_client,
     } = cfg;
 
-    let (monitoring_server, monitoring_client) = monitoring::Server::new(
-        monitoring_server.bind_address,
-        monitoring_server.channel_size,
-    )
-    .change_context(Error::Monitor)?;
+    let (monitoring_server, monitoring_client) =
+        monitoring::Server::new(monitoring_server).change_context(Error::Monitor)?;
 
     let tm_client = tm_client::TendermintClient::new(
         tendermint_rpc::HttpClient::new(tm_jsonrpc.as_str())

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -27,10 +27,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-// safe upper bound for expected metric throughput;
-// shouldn't exceed 1000 message
-const CHANNEL_SIZE: usize = 1000;
-
 /// content-Type for Prometheus/OpenMetrics text format responses.
 const OPENMETRICS_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -152,8 +152,8 @@ impl Client {
 ///
 /// Panics if the Prometheus registry cannot be created or
 /// if metrics cannot be registered. This should never happen in normal operation.
-pub fn create_endpoint() -> (MethodRouter, Process, Client) {
-    let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
+pub fn create_endpoint(channel_size: usize) -> (MethodRouter, Process, Client) {
+    let (tx, rx) = mpsc::channel(channel_size);
 
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
@@ -636,7 +636,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn should_update_all_metrics_successfully() {
-        let (router, process, client) = create_endpoint();
+        let channel_size = 1000;
+        let (router, process, client) = create_endpoint(channel_size);
         _ = process.run(CancellationToken::new());
 
         let router = Router::new().route("/test", router);

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -375,6 +375,7 @@ mod tests {
         // Test parsing enabled config from environment variable
         env::set_var("TEST_MONITORING_ENABLED", "true");
         env::set_var("TEST_MONITORING_BIND_ADDRESS", "127.0.0.1:4000");
+        env::set_var("TEST_MONITORING_CHANNEL_SIZE", "500");
 
         let enabled_config: Config = cfg::builder()
             .add_source(Environment::with_prefix("TEST_MONITORING"))
@@ -386,6 +387,7 @@ mod tests {
             enabled_config.bind_address,
             Some(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4000))
         );
+        assert_eq!(enabled_config.channel_size, Some(500));
 
         // Test parsing disabled config from environment variable
         env::set_var("TEST_MONITORING_ENABLED", "false");
@@ -400,6 +402,7 @@ mod tests {
         // Clean up
         env::remove_var("TEST_MONITORING_ENABLED");
         env::remove_var("TEST_MONITORING_BIND_ADDRESS");
+        env::remove_var("TEST_MONITORING_CHANNEL_SIZE");
     }
 
     #[test]

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -36,7 +36,7 @@ pub enum Config {
     Disabled,
     Enabled {
         bind_address: SocketAddrV4,
-        // Safe upper bound for expected metric throughput. 
+        // Safe upper bound for expected metric throughput.
         channel_size: usize,
     },
 }

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -36,6 +36,7 @@ pub enum Config {
     Disabled,
     Enabled {
         bind_address: SocketAddrV4,
+        // Safe upper bound for expected metric throughput. 
         channel_size: usize,
     },
 }

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -55,18 +55,18 @@ impl Config {
     /// The default channel size is `1000`.
     pub fn enabled() -> Self {
         Self::Enabled {
-            bind_address: default_bind_addr(),
-            channel_size: default_channel_size(),
+            bind_address: Self::default_bind_addr(),
+            channel_size: Self::default_channel_size(),
         }
     }
-}
 
-fn default_bind_addr() -> SocketAddrV4 {
-    SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000)
-}
+    fn default_bind_addr() -> SocketAddrV4 {
+        SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000)
+    }
 
-fn default_channel_size() -> usize {
-    1000
+    fn default_channel_size() -> usize {
+        1000
+    }
 }
 
 // Custom serialization to make the state of the monitoring server more explicit in a config file
@@ -85,8 +85,8 @@ impl Serialize for Config {
         let compat = match self {
             Config::Disabled => ConfigCompat {
                 enabled: false,
-                bind_address: default_bind_addr(),
-                channel_size: default_channel_size(),
+                bind_address: Self::default_bind_addr(),
+                channel_size: Self::default_channel_size(),
             },
             Config::Enabled {
                 bind_address,
@@ -112,9 +112,9 @@ impl<'de> Deserialize<'de> for Config {
         struct ConfigCompat {
             #[serde(default)]
             enabled: bool,
-            #[serde(default = "default_bind_addr")]
+            #[serde(default = "Config::default_bind_addr")]
             bind_address: SocketAddrV4,
-            #[serde(default = "default_channel_size")]
+            #[serde(default = "Config::default_channel_size")]
             channel_size: usize,
         }
 

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -28,34 +28,44 @@ pub enum Error {
 
 /// Configuration for the monitoring server
 ///
-/// Controls whether the monitoring server is enabled and on which address it binds.
-/// When `bind_address` is `None`, the server is disabled.
-#[derive(Clone, PartialEq, Debug, Default)]
-pub struct Config {
-    /// The address to bind the monitoring server to.
-    /// When `None`, the server is disabled.
-    pub bind_address: Option<SocketAddrV4>,
-    pub channel_size: Option<usize>,
+/// This enum ensures that the logical relationship between fields is maintained:
+/// - When monitoring is disabled, no fields are required
+/// - When monitoring is enabled, bind_address and channel_size are optional and will use sensible defaults if not specified
+#[derive(Clone, PartialEq, Debug)]
+pub enum Config {
+    Disabled,
+    Enabled {
+        bind_address: SocketAddrV4,
+        channel_size: usize,
+    },
+}
+
+/// The default configuration of the monitoring server is disabled.
+impl Default for Config {
+    fn default() -> Self {
+        Self::Disabled
+    }
 }
 
 impl Config {
     /// Creates a new configuration with monitoring enabled using the default bind address
     ///
     /// The default bind address is `127.0.0.1:3000`.
+    /// The default channel size is `1000`.
     pub fn enabled() -> Self {
-        Self {
-            bind_address: Some(Self::default_bind_addr()),
-            channel_size: Some(Self::default_channel_size()),
+        Self::Enabled {
+            bind_address: default_bind_addr(),
+            channel_size: default_channel_size(),
         }
     }
+}
 
-    fn default_bind_addr() -> SocketAddrV4 {
-        SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000)
-    }
+fn default_bind_addr() -> SocketAddrV4 {
+    SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000)
+}
 
-    fn default_channel_size() -> usize {
-        1000
-    }
+fn default_channel_size() -> usize {
+    1000
 }
 
 // Custom serialization to make the state of the monitoring server more explicit in a config file
@@ -71,10 +81,20 @@ impl Serialize for Config {
             channel_size: usize,
         }
 
-        let compat = ConfigCompat {
-            enabled: self.bind_address.is_some(),
-            bind_address: self.bind_address.unwrap_or_else(Self::default_bind_addr),
-            channel_size: self.channel_size.unwrap_or_else(Self::default_channel_size),
+        let compat = match self {
+            Config::Disabled => ConfigCompat {
+                enabled: false,
+                bind_address: default_bind_addr(),
+                channel_size: default_channel_size(),
+            },
+            Config::Enabled {
+                bind_address,
+                channel_size,
+            } => ConfigCompat {
+                enabled: true,
+                bind_address: *bind_address,
+                channel_size: *channel_size,
+            },
         };
 
         compat.serialize(serializer)
@@ -91,17 +111,21 @@ impl<'de> Deserialize<'de> for Config {
         struct ConfigCompat {
             #[serde(default)]
             enabled: bool,
-            #[serde(default = "Config::default_bind_addr")]
+            #[serde(default = "default_bind_addr")]
             bind_address: SocketAddrV4,
-            #[serde(default = "Config::default_channel_size")]
+            #[serde(default = "default_channel_size")]
             channel_size: usize,
         }
 
         let compat = ConfigCompat::deserialize(deserializer)?;
 
-        Ok(Config {
-            bind_address: compat.enabled.then_some(compat.bind_address),
-            channel_size: compat.enabled.then_some(compat.channel_size),
+        Ok(if compat.enabled {
+            Config::Enabled {
+                bind_address: compat.bind_address,
+                channel_size: compat.channel_size,
+            }
+        } else {
+            Config::Disabled
         })
     }
 }
@@ -149,17 +173,14 @@ impl Server {
     ///
     /// Returns an error if the server cannot be created or if metrics endpoints
     /// cannot be initialized.
-    pub fn new(
-        connector: Option<impl Into<TcpConnector>>,
-        channel_size: Option<usize>,
-    ) -> Result<(Server, Client), Error> {
-        match connector {
-            Some(connector) => Self::create_server_with_client(
-                connector.into(),
-                channel_size
-                    .expect("if monitoring server is enabled, channel size must be a value"),
-            ),
-            None => {
+    pub fn new(config: Config) -> Result<(Server, Client), Error> {
+        match config {
+            Config::Enabled {
+                bind_address,
+                channel_size,
+            } => Self::create_server_with_client(TcpConnector::from(bind_address), channel_size),
+
+            Config::Disabled => {
                 info!("monitoring server is disabled");
                 Ok((
                     Server::Disabled,
@@ -383,11 +404,14 @@ mod tests {
             .unwrap()
             .try_deserialize()
             .unwrap();
+
         assert_eq!(
-            enabled_config.bind_address,
-            Some(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4000))
+            enabled_config,
+            Config::Enabled {
+                bind_address: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4000),
+                channel_size: 500,
+            }
         );
-        assert_eq!(enabled_config.channel_size, Some(500));
 
         // Test parsing disabled config from environment variable
         env::set_var("TEST_MONITORING_ENABLED", "false");
@@ -397,7 +421,7 @@ mod tests {
             .unwrap()
             .try_deserialize()
             .unwrap();
-        assert_eq!(disabled_config.bind_address, None);
+        assert_eq!(disabled_config, Config::Disabled);
 
         // Clean up
         env::remove_var("TEST_MONITORING_ENABLED");
@@ -408,7 +432,7 @@ mod tests {
     #[test]
     #[traced_test]
     fn disabled_client_discards_messages_without_error() {
-        let (_, client) = Server::new(None::<SocketAddr>, None).unwrap(); // Creates disabled server and client
+        let (_, client) = Server::new(Config::Disabled).unwrap(); // Creates disabled server and client
 
         // Should succeed without doing anything
         client.metrics().record_metric(metrics::Msg::BlockReceived);
@@ -429,7 +453,7 @@ mod tests {
 
     #[async_test]
     async fn disabled_server_shuts_down_when_cancelled() {
-        let (server, _) = Server::new(None::<SocketAddr>, None).unwrap(); // Creates disabled server
+        let (server, _) = Server::new(Config::Disabled).unwrap(); // Creates disabled server
         let cancel = CancellationToken::new();
 
         let handle = tokio::spawn(server.run(cancel.clone()));
@@ -450,10 +474,14 @@ mod tests {
     async fn server_startup_fails_when_address_unavailable() {
         // First, bind to a specific port to make it unavailable
         let listener = listener().await.connect().await.unwrap();
-        let blocked_addr = listener.local_addr().unwrap();
+        let blocked_addr = convert_to_socketaddrv4(listener.local_addr().unwrap());
 
         // Create a server on the same address - creation should succeed
-        let (server, _) = Server::new(Some(blocked_addr), Some(1000)).unwrap();
+        let (server, _) = Server::new(Config::Enabled {
+            bind_address: blocked_addr,
+            channel_size: 1000,
+        })
+        .unwrap();
 
         // But running the server should fail
         let cancel = CancellationToken::new();
@@ -471,11 +499,15 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_responds_to_status_endpoint_and_shuts_down_gracefully() {
-        let connector = listener().await;
+        let bind_address = listener().await.bind_address().unwrap();
         let channel_size = 1000;
-        let status_url = create_endpoint_url(connector.bind_address().ok(), "status");
+        let status_url = create_endpoint_url(bind_address, "status");
 
-        let (server, _) = Server::new(Some(connector), Some(channel_size)).unwrap();
+        let (server, _) = Server::new(Config::Enabled {
+            bind_address: convert_to_socketaddrv4(bind_address),
+            channel_size,
+        })
+        .unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -499,11 +531,15 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_continues_serving_after_all_metrics_clients_dropped() {
-        let connector = listener().await;
+        let bind_address = listener().await.bind_address().unwrap();
         let channel_size = 1000;
-        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
+        let metrics_url = create_endpoint_url(bind_address, "metrics");
 
-        let (server, monitoring_client) = Server::new(Some(connector), Some(channel_size)).unwrap();
+        let (server, monitoring_client) = Server::new(Config::Enabled {
+            bind_address: convert_to_socketaddrv4(bind_address),
+            channel_size,
+        })
+        .unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -532,11 +568,15 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn metrics_endpoint_increments_counters_when_messages_sent() {
-        let connector = listener().await;
+        let bind_address = listener().await.bind_address().unwrap();
         let channel_size = 1000;
-        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
+        let metrics_url = create_endpoint_url(bind_address, "metrics");
 
-        let (server, monitoring_client) = Server::new(Some(connector), Some(channel_size)).unwrap();
+        let (server, monitoring_client) = Server::new(Config::Enabled {
+            bind_address: convert_to_socketaddrv4(bind_address),
+            channel_size,
+        })
+        .unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -568,8 +608,12 @@ mod tests {
     #[traced_test]
     async fn enabled_server_shuts_down_gracefully_when_cancellation_token_triggered() {
         let channel_size = 1000;
-        let (server, monitoring_client) =
-            Server::new(Some(listener().await), Some(channel_size)).unwrap();
+        let bind_address = convert_to_socketaddrv4(listener().await.bind_address().unwrap());
+        let (server, monitoring_client) = Server::new(Config::Enabled {
+            bind_address,
+            channel_size,
+        })
+        .unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -610,11 +654,15 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_handles_concurrent_metrics_requests_correctly() {
-        let connector = listener().await;
+        let bind_address = listener().await.bind_address().unwrap();
         let channel_size = 1000;
-        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
+        let metrics_url = create_endpoint_url(bind_address, "metrics");
 
-        let (server, original_client) = Server::new(Some(connector), Some(channel_size)).unwrap();
+        let (server, original_client) = Server::new(Config::Enabled {
+            bind_address: convert_to_socketaddrv4(bind_address),
+            channel_size,
+        })
+        .unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -656,8 +704,15 @@ mod tests {
             .into()
     }
 
-    fn create_endpoint_url(bind_address: Option<SocketAddr>, endpoint: &str) -> String {
-        format!("http://{}/{endpoint}", bind_address.unwrap())
+    fn create_endpoint_url(bind_address: SocketAddr, endpoint: &str) -> String {
+        format!("http://{}/{endpoint}", bind_address)
+    }
+
+    fn convert_to_socketaddrv4(addr: SocketAddr) -> SocketAddrV4 {
+        match addr {
+            SocketAddr::V4(v4) => v4,
+            SocketAddr::V6(_) => panic!("expected IPv4 address in this test"),
+        }
     }
 
     fn send_multiple_metrics(

--- a/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
+++ b/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
@@ -1,8 +1,8 @@
 Enabled Config:
-Config { bind_address: Some(127.0.0.1:3000), channel_size: Some(1000) }
+Enabled { bind_address: 127.0.0.1:3000, channel_size: 1000 }
 
 Disabled Config:
-Config { bind_address: None, channel_size: None }
+Disabled
 
 Enabled Serialized:
 enabled = true

--- a/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
+++ b/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
@@ -1,14 +1,16 @@
 Enabled Config:
-Config { bind_address: Some(127.0.0.1:3000) }
+Config { bind_address: Some(127.0.0.1:3000), channel_size: Some(1000) }
 
 Disabled Config:
-Config { bind_address: None }
+Config { bind_address: None, channel_size: None }
 
 Enabled Serialized:
 enabled = true
 bind_address = "127.0.0.1:3000"
+channel_size = 1000
 
 
 Disabled Serialized:
 enabled = false
 bind_address = "127.0.0.1:3000"
+channel_size = 1000

--- a/ampd/src/testdata/deserialize_valid_grpc_config.golden
+++ b/ampd/src/testdata/deserialize_valid_grpc_config.golden
@@ -1,6 +1,7 @@
 {
   "tm_jsonrpc": "http://localhost:26657/",
   "tm_grpc": "tcp://localhost:9090",
+  "default_rpc_timeout": "3s",
   "tm_grpc_timeout": {
     "secs": 5,
     "nanos": 0

--- a/ampd/src/testdata/deserialize_valid_grpc_config.golden
+++ b/ampd/src/testdata/deserialize_valid_grpc_config.golden
@@ -10,7 +10,8 @@
     "retry_max_attempts": 3,
     "stream_timeout": "15s",
     "stream_buffer_size": 100000,
-    "delay": "1s"
+    "delay": "1s",
+    "tx_broadcast_buffer_size": 10
   },
   "broadcast": {
     "chain_id": "axelar-dojo-1",
@@ -20,7 +21,9 @@
     "gas_price": "0.00005uaxl",
     "batch_gas_limit": 1000000,
     "queue_cap": 1000,
-    "broadcast_interval": "5s"
+    "broadcast_interval": "5s",
+    "tx_confirmation_buffer_size": 10,
+    "tx_confirmation_queue_cap": 1000
   },
   "handlers": [],
   "tofnd_config": {
@@ -47,6 +50,17 @@
   },
   "monitoring_server": {
     "enabled": false,
-    "bind_address": "127.0.0.1:3000"
+    "bind_address": "127.0.0.1:3000",
+    "channel_size": 1000
+  },
+  "event_sub": {
+    "block_processing_buffer": 10,
+    "poll_interval": "5s",
+    "retry_delay": "1s",
+    "retry_max_attempts": 3
+  },
+  "tm_client": {
+    "max_retries": 15,
+    "retry_delay": "1s"
   }
 }

--- a/ampd/src/testdata/deserialize_valid_grpc_config.golden
+++ b/ampd/src/testdata/deserialize_valid_grpc_config.golden
@@ -57,7 +57,7 @@
   "event_sub": {
     "block_processing_buffer": 10,
     "poll_interval": "5s",
-    "retry_delay": "1s",
+    "retry_delay": "3s",
     "retry_max_attempts": 3
   },
   "tm_client": {

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -11,6 +11,7 @@ retry_max_attempts = 3
 stream_timeout = '15s'
 stream_buffer_size = 100000
 delay = '1s'
+tx_broadcast_buffer_size = 10
 
 [broadcast]
 chain_id = 'axelar-dojo-1'
@@ -21,6 +22,8 @@ gas_price = '0.00005uaxl'
 batch_gas_limit = 1000000
 queue_cap = 1000
 broadcast_interval = '5s'
+tx_confirmation_buffer_size = 10
+tx_confirmation_queue_cap = 1000
 
 [[handlers]]
 type = 'EvmMsgVerifier'
@@ -162,3 +165,14 @@ request_timeout = '30s'
 [monitoring_server]
 enabled = false
 bind_address = '127.0.0.1:3000'
+channel_size = 1000
+
+[event_sub]
+block_processing_buffer = 10
+poll_interval = '5s'
+retry_delay = '1s'
+retry_max_attempts = 3
+
+[tm_client]
+max_retries = 15
+retry_delay = '1s'

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -1,5 +1,6 @@
 tm_jsonrpc = 'http://localhost:26657/'
 tm_grpc = 'tcp://localhost:9090'
+default_rpc_timeout = '3s'
 
 [tm_grpc_timeout]
 secs = 5

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -171,7 +171,7 @@ channel_size = 1000
 [event_sub]
 block_processing_buffer = 10
 poll_interval = '5s'
-retry_delay = '1s'
+retry_delay = '3s'
 retry_max_attempts = 3
 
 [tm_client]

--- a/ampd/src/tm_client.rs
+++ b/ampd/src/tm_client.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use error_stack::{Report, Result};
 use mockall::automock;
+use serde::{Deserialize, Serialize};
 use tendermint::block::Height;
 use tendermint_rpc::{Client, HttpClient};
 
@@ -12,8 +13,37 @@ pub type BlockResultsResponse = tendermint_rpc::endpoint::block_results::Respons
 pub type BlockResponse = tendermint_rpc::endpoint::block::Response;
 pub type Error = tendermint_rpc::Error;
 
-const MAX_RETRIES: u64 = 15;
-const RETRY_DELAY: Duration = Duration::from_secs(1);
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct Config {
+    pub max_retries: u64,
+    #[serde(with = "humantime_serde")]
+    pub retry_delay: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_retries: 15,
+            retry_delay: Duration::from_secs(1),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TendermintClient {
+    client: HttpClient,
+    retry_policy: RetryPolicy,
+}
+
+impl TendermintClient {
+    pub fn new(client: HttpClient, max_retries: u64, retry_delay: Duration) -> Self {
+        let retry_policy = RetryPolicy::repeat_constant(retry_delay, max_retries);
+        Self {
+            client,
+            retry_policy,
+        }
+    }
+}
 
 #[automock]
 #[async_trait]
@@ -23,20 +53,17 @@ pub trait TmClient {
 }
 
 #[async_trait]
-impl TmClient for HttpClient {
+impl TmClient for TendermintClient {
     async fn latest_block(&self) -> Result<BlockResponse, Error> {
-        future::with_retry(
-            || Client::latest_block(self),
-            RetryPolicy::repeat_constant(RETRY_DELAY, MAX_RETRIES),
-        )
-        .await
-        .map_err(Report::from)
+        future::with_retry(|| Client::latest_block(&self.client), self.retry_policy)
+            .await
+            .map_err(Report::from)
     }
 
     async fn block_results(&self, height: Height) -> Result<BlockResultsResponse, Error> {
         future::with_retry(
-            || Client::block_results(self, height),
-            RetryPolicy::repeat_constant(RETRY_DELAY, MAX_RETRIES),
+            || Client::block_results(&self.client, height),
+            self.retry_policy,
         )
         .await
         .map_err(Report::from)


### PR DESCRIPTION
This PR refactors several previously hardcoded constants into configurable fields in ampd:
**Broadcast:** moved `TX_CONFIRMATION_BUFFER_SIZ`E and `TX_CONFIRMATION_QUEUE_CAP` into broadcast::Config.

**Event Processor:** moved `TX_BROADCAST_BUFFER_SIZE `into event_processor::Config.

**Event Sub**: creatse  `event_sub::Config`. and moved `BLOCK_PROCESSING_BUFFER`, `POLL_INTERVAL`, and `retry policy` into it

**Monitoring:** added `channel_size` field to` monitoring::Config `and updated server initialization accordingly.

**Tendermint Client**: added `tm_client::Config` for retry parameters (max_retries, retry_delay).

**lib**: moved` default_rpc_timeout` into config

