### PR TITLE
fix(service-registry): default chain name to None in service query

### DIFF
--- a/packages/service-registry-api/src/msg.rs
+++ b/packages/service-registry-api/src/msg.rs
@@ -96,6 +96,7 @@ pub enum QueryMsg {
     #[returns(Service)]
     Service {
         service_name: String,
+        #[serde(default)]
         chain_name: Option<ChainName>,
     },
 


### PR DESCRIPTION
the Service query was changed to include a chain name. This however breaks backwards compatibility. Specifically, the XRPL integration uses this query, so deploying the new version of the service registry would break that integration. This change defaults the chain name to None when not passed, preserving backwards compatability.