### PR TITLE
fix(ampd): retry when there is a sequence mismatch error

### DIFF
--- a/ampd/src/broadcast/broadcaster.rs
+++ b/ampd/src/broadcast/broadcaster.rs
@@ -202,9 +202,7 @@ where
     ///
     /// * `Error::EstimateGas` - If the gas estimation fails
     pub async fn estimate_gas(&mut self, msgs: Vec<Any>) -> Result<Gas> {
-        let acc_sequence = self.acc_sequence.read().await;
-
-        cosmos::estimate_gas(&mut self.client, msgs, self.pub_key, *acc_sequence)
+        cosmos::estimate_gas(&mut self.client, msgs, self.pub_key)
             .await
             .change_context(Error::EstimateGas)
     }

--- a/ampd/src/broadcast/broadcaster.rs
+++ b/ampd/src/broadcast/broadcaster.rs
@@ -202,7 +202,9 @@ where
     ///
     /// * `Error::EstimateGas` - If the gas estimation fails
     pub async fn estimate_gas(&mut self, msgs: Vec<Any>) -> Result<Gas> {
-        cosmos::estimate_gas(&mut self.client, msgs, self.pub_key)
+        let acc_sequence = self.acc_sequence.read().await;
+
+        cosmos::estimate_gas(&mut self.client, msgs, self.pub_key, *acc_sequence)
             .await
             .change_context(Error::EstimateGas)
     }

--- a/ampd/src/broadcast/broadcaster.rs
+++ b/ampd/src/broadcast/broadcaster.rs
@@ -191,24 +191,24 @@ where
     ///
     /// * `Error::EstimateGas` - If the gas estimation fails
     pub async fn estimate_gas(&mut self, msgs: Vec<Any>) -> Result<Gas> {
-        let mut acc_sequence = self.acc_sequence.write().await;
+        let sequence = *self.acc_sequence.read().await;
 
-        let res =
-            match cosmos::estimate_gas(&mut self.client, msgs.clone(), self.pub_key, *acc_sequence)
-                .await
-            {
-                Ok(gas) => Ok(gas),
-                Err(e) => match parse_sequence_error(&e) {
-                    // Retry with the expected sequence number
-                    Some(expected_seq) => {
-                        *acc_sequence = expected_seq;
-                        cosmos::estimate_gas(&mut self.client, msgs, self.pub_key, *acc_sequence)
-                            .await
-                    }
-                    // Return the error if not a sequence mismatch error
-                    None => Err(e),
-                },
-            };
+        let res = match cosmos::estimate_gas(&mut self.client, msgs.clone(), self.pub_key, sequence)
+            .await
+        {
+            Ok(gas) => Ok(gas),
+            Err(e) => match parse_sequence_error(&e) {
+                // Retry with the expected sequence number
+                Some(expected_seq) => {
+                    let mut acc_sequence = self.acc_sequence.write().await;
+                    *acc_sequence = expected_seq;
+
+                    cosmos::estimate_gas(&mut self.client, msgs, self.pub_key, *acc_sequence).await
+                }
+                // Return the error if not a sequence mismatch error
+                None => Err(e),
+            },
+        };
 
         res.change_context(Error::EstimateGas)
     }

--- a/ampd/src/broadcast/msg_queue.rs
+++ b/ampd/src/broadcast/msg_queue.rs
@@ -175,9 +175,6 @@ where
     /// * `Error::EstimateGas` - If gas estimation fails
     /// * `Error::EnqueueMsg` - If enqueueing fails
     async fn enqueue_with_channel(&mut self, msg: Any) -> Result<oneshot::Receiver<TxResult>> {
-        // TODO: remove this once the commands broadcast through the daemon's broadcaster, so that the sequence does not get out of sync
-        self.broadcaster.reset_sequence().await?;
-
         let (tx, rx) = oneshot::channel();
         let gas = self.broadcaster.estimate_gas(vec![msg.clone()]).await?;
 

--- a/ampd/src/broadcast/msg_queue.rs
+++ b/ampd/src/broadcast/msg_queue.rs
@@ -418,7 +418,7 @@ mod tests {
     use axelar_wasm_std::{assert_err_contains, err_contains};
     use cosmos_sdk_proto::cosmos::bank::v1beta1::QueryBalanceResponse;
     use cosmos_sdk_proto::cosmos::base::v1beta1::Coin;
-    use cosmrs::proto::cosmos::auth::v1beta1::{BaseAccount, QueryAccountResponse};
+    use cosmrs::proto::cosmos::auth::v1beta1::QueryAccountResponse;
     use cosmrs::proto::cosmos::bank::v1beta1::MsgSend;
     use cosmrs::proto::cosmos::base::abci::v1beta1::GasInfo;
     use cosmrs::proto::cosmos::tx::v1beta1::SimulateResponse;
@@ -456,25 +456,8 @@ mod tests {
         gas_info: Option<GasInfo>,
         times: usize,
     ) -> cosmos::MockCosmosClient {
-        let mut cosmos_client = cosmos::MockCosmosClient::new();
-        let base_account = test_utils::create_base_account(address);
+        let mut cosmos_client = setup_client(address);
 
-        cosmos_client.expect_balance().return_once(move |_| {
-            Ok(QueryBalanceResponse {
-                balance: Some(Coin {
-                    denom: "uaxl".to_string(),
-                    amount: "1000000".to_string(),
-                }),
-            })
-        });
-        cosmos_client
-            .expect_account()
-            .times(times.saturating_add(1))
-            .returning(move |_| {
-                Ok(QueryAccountResponse {
-                    account: Some(Any::from_msg(&base_account).unwrap()),
-                })
-            });
         cosmos_client
             .expect_simulate()
             .times(times)
@@ -637,24 +620,7 @@ mod tests {
             .expect_clone()
             .times(client_count)
             .returning(move || {
-                let pub_key = random_cosmos_public_key();
-                let address: TMAddress = pub_key.account_id(PREFIX).unwrap().into();
-                let base_account = BaseAccount {
-                    address: address.to_string(),
-                    pub_key: None,
-                    account_number: 42,
-                    sequence: 10,
-                };
-
                 let mut cosmos_client = cosmos::MockCosmosClient::new();
-                cosmos_client
-                    .expect_account()
-                    .times(msg_count_per_client)
-                    .returning(move |_| {
-                        Ok(QueryAccountResponse {
-                            account: Some(Any::from_msg(&base_account).unwrap()),
-                        })
-                    });
                 cosmos_client
                     .expect_simulate()
                     .times(msg_count_per_client)

--- a/ampd/src/cosmos.rs
+++ b/ampd/src/cosmos.rs
@@ -205,7 +205,7 @@ pub async fn estimate_gas<T>(
     client: &mut T,
     msgs: Vec<Any>,
     pub_key: CosmosPublicKey,
-    _acc_sequence: u64,
+    acc_sequence: u64,
 ) -> Result<Gas>
 where
     T: CosmosClient,
@@ -213,7 +213,7 @@ where
     let tx_bytes = Tx::builder()
         .msgs(msgs)
         .pub_key(pub_key)
-        .acc_sequence(0)
+        .acc_sequence(acc_sequence)
         .build()
         .with_dummy_sig()
         .await

--- a/ampd/src/cosmos.rs
+++ b/ampd/src/cosmos.rs
@@ -29,7 +29,6 @@ use report::{ErrorExt, ResultCompatExt};
 use thiserror::Error;
 use tonic::transport::Channel;
 use tonic::{Code, Response, Status};
-use tracing::info;
 
 use crate::broadcast::Tx;
 use crate::types::debug::REDACTED_VALUE;
@@ -206,6 +205,7 @@ pub async fn estimate_gas<T>(
     client: &mut T,
     msgs: Vec<Any>,
     pub_key: CosmosPublicKey,
+    _acc_sequence: u64,
 ) -> Result<Gas>
 where
     T: CosmosClient,
@@ -220,8 +220,6 @@ where
         .expect("dummy signature must be valid")
         .to_bytes()
         .change_context(Error::TxBuilding)?;
-
-    info!("gas estimation using account sequence 0");
 
     #[allow(deprecated)]
     client
@@ -341,6 +339,7 @@ mod tests {
     #[tokio::test]
     async fn estimate_gas_success() {
         let pub_key = random_cosmos_public_key();
+        let acc_sequence = 5u64;
         let msgs = vec![Any {
             type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
             value: vec![1, 2, 3],
@@ -358,7 +357,7 @@ mod tests {
             })
         });
 
-        let actual = estimate_gas(&mut mock_client, msgs, pub_key).await;
+        let actual = estimate_gas(&mut mock_client, msgs, pub_key, acc_sequence).await;
 
         assert_eq!(actual.unwrap(), gas_used);
     }
@@ -366,6 +365,7 @@ mod tests {
     #[tokio::test]
     async fn estimate_gas_missing_gas_info() {
         let pub_key = random_cosmos_public_key();
+        let acc_sequence = 5u64;
         let msgs = vec![Any {
             type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
             value: vec![1, 2, 3],
@@ -379,7 +379,7 @@ mod tests {
             })
         });
 
-        let actual = estimate_gas(&mut mock_client, msgs, pub_key).await;
+        let actual = estimate_gas(&mut mock_client, msgs, pub_key, acc_sequence).await;
 
         assert_err_contains!(actual, Error, Error::GasInfoMissing);
     }

--- a/ampd/src/cosmos.rs
+++ b/ampd/src/cosmos.rs
@@ -205,7 +205,7 @@ pub async fn estimate_gas<T>(
     client: &mut T,
     msgs: Vec<Any>,
     pub_key: CosmosPublicKey,
-    acc_sequence: u64,
+    _acc_sequence: u64,
 ) -> Result<Gas>
 where
     T: CosmosClient,
@@ -213,7 +213,7 @@ where
     let tx_bytes = Tx::builder()
         .msgs(msgs)
         .pub_key(pub_key)
-        .acc_sequence(acc_sequence)
+        .acc_sequence(0)
         .build()
         .with_dummy_sig()
         .await


### PR DESCRIPTION
## Description
## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
