### PR TITLE
fix(ampd): revert move hardcoded values into config PR 1019

### DIFF
--- a/ampd/README.md
+++ b/ampd/README.md
@@ -27,9 +27,6 @@ gas_price=[gas price with denom, i.e. "0.007uaxl"]
 queue_cap=[max messages to queue when broadcasting]
 tx_fetch_interval=[how often to query for transaction inclusion in a block]
 tx_fetch_max_retries=[how many times to query for transaction inclusion in a block before failing]
-tx_confirmation_buffer_size=[maximum concurrent transaction confirmations (higher values improve throughput, lower values reduce resource usage; tune based on network and system capacity)]
-tx_confirmation_queue_cap=[maximum size of the confirmation queue (larger values buffer more transactions during spikes but use more memory; smaller values risk dropping requests under load)]
-
 
 [tofnd_config]
 key_uid=[uid of key used for signing transactions]
@@ -66,7 +63,6 @@ from Avalanche testnet, Sui testnet and Stacks testnet.
 ```yaml
 tm_jsonrpc="http://localhost:26657"
 tm_grpc="tcp://localhost:9090"
-
 event_buffer_cap=10000
 
 [service_registry]
@@ -81,8 +77,6 @@ gas_price="0.00005uamplifier"
 queue_cap="1000"
 tx_fetch_interval="600ms"
 tx_fetch_max_retries="10"
-tx_confirmation_buffer_size = 10
-tx_confirmation_queue_cap = 1000
 
 [tofnd_config]
 key_uid="axelar"

--- a/ampd/src/broadcast/config.rs
+++ b/ampd/src/broadcast/config.rs
@@ -18,18 +18,6 @@ pub struct Config {
     pub queue_cap: usize,
     #[serde(with = "humantime_serde")]
     pub broadcast_interval: Duration,
-    // Maximum number of transaction confirmations to process concurrently.
-    // - Controls parallelism when confirming transactions
-    // - Higher values increase throughput for confirming many transactions
-    // - Lower values reduce resource consumption
-    // - Balance based on network capacity and system resources
-    pub tx_confirmation_buffer_size: usize,
-    // Maximum capacity of the transaction confirmation queue.
-    // - Determines how many transactions can be queued for confirmation before backpressure
-    // - Larger values provide more buffering for high-volume transaction periods
-    // - Too small may cause confirmation requests to be dropped during traffic spikes
-    // - Too large may consume excessive memory if confirmations become backlogged
-    pub tx_confirmation_queue_cap: usize,
 }
 
 impl Default for Config {
@@ -45,8 +33,6 @@ impl Default for Config {
             batch_gas_limit: 1000000,
             queue_cap: 1000,
             broadcast_interval: Duration::from_secs(5),
-            tx_confirmation_buffer_size: 10,
-            tx_confirmation_queue_cap: 1000,
         }
     }
 }

--- a/ampd/src/commands/mod.rs
+++ b/ampd/src/commands/mod.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::pin::Pin;
 
 use clap::Subcommand;
@@ -164,7 +165,7 @@ async fn instantiate_broadcaster(
         .await
         .change_context(Error::Broadcaster)?;
 
-    let (_, monitoring_client) = monitoring::Server::new(monitoring::Config::Disabled)
+    let (_, monitoring_client) = monitoring::Server::new(None::<SocketAddr>)
         .expect("should never fail to create dummy monitoring client");
 
     let (msg_queue, _) = broadcast::MsgQueue::new_msg_queue_and_client(

--- a/ampd/src/config.rs
+++ b/ampd/src/config.rs
@@ -7,7 +7,7 @@ use crate::handlers::config::deserialize_handler_configs;
 use crate::handlers::{self};
 use crate::tofnd::Config as TofndConfig;
 use crate::url::Url;
-use crate::{broadcast, event_processor, event_sub, grpc, monitoring, tm_client};
+use crate::{broadcast, event_processor, grpc, monitoring};
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(default)]
@@ -16,8 +16,6 @@ pub struct Config {
     pub tm_jsonrpc: Url,
     #[serde(deserialize_with = "Url::deserialize_sensitive")]
     pub tm_grpc: Url,
-    #[serde(with = "humantime_serde")]
-    pub default_rpc_timeout: Duration,
     pub tm_grpc_timeout: Duration,
     pub event_processor: event_processor::Config,
     pub broadcast: broadcast::Config,
@@ -29,8 +27,6 @@ pub struct Config {
     #[serde(deserialize_with = "grpc::deserialize_config")]
     pub grpc: grpc::Config,
     pub monitoring_server: monitoring::Config,
-    pub event_sub: event_sub::Config,
-    pub tm_client: tm_client::Config,
 }
 
 impl Default for Config {
@@ -40,7 +36,6 @@ impl Default for Config {
                 .expect("Url should be created validly"),
             tm_grpc: Url::new_non_sensitive("tcp://localhost:9090")
                 .expect("Url should be created validly"),
-            default_rpc_timeout: Duration::from_secs(3),
             tm_grpc_timeout: Duration::from_secs(5),
             broadcast: broadcast::Config::default(),
             handlers: vec![],
@@ -50,8 +45,6 @@ impl Default for Config {
             rewards: RewardsConfig::default(),
             grpc: grpc::Config::default(),
             monitoring_server: monitoring::Config::default(),
-            event_sub: event_sub::Config::default(),
-            tm_client: tm_client::Config::default(),
         }
     }
 }
@@ -671,71 +664,32 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_monitoring_server_config_enabled_with_all_fields() {
+    fn deserialize_monitoring_server_config_with_bind_address_and_enabled() {
         let bind_address = "0.0.0.0:3001";
         let config_str = format!(
             "
             [monitoring_server]
             enabled = true
             bind_address = '{bind_address}'
-            channel_size = 500
             ",
         );
         let cfg: Config = toml::from_str(&config_str).unwrap();
         assert_eq!(
-            cfg.monitoring_server,
-            monitoring::Config::Enabled {
-                bind_address: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 3001),
-                channel_size: 500,
-            }
+            cfg.monitoring_server.bind_address,
+            Some(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 3001))
         );
     }
 
     #[test]
-    fn deserialize_monitoring_server_config_enabled_without_any_fields_should_use_default() {
+    fn deserialize_monitoring_server_config_without_bind_address_enabled() {
         let config_str = "
             [monitoring_server]
             enabled = true
             ";
         let cfg: Config = toml::from_str(config_str).unwrap();
         assert_eq!(
-            cfg.monitoring_server,
-            monitoring::Config::Enabled {
-                bind_address: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000),
-                channel_size: 1000,
-            }
-        );
-    }
-
-    #[test]
-    fn deserialize_monitoring_server_config_enabled_with_partial_fields() {
-        let config_str_1 = "
-            [monitoring_server]
-            enabled = true
-            bind_address = '0.0.0.0:3000'
-            ";
-        let cfg: Config = toml::from_str(config_str_1).unwrap();
-        assert_eq!(
-            cfg.monitoring_server,
-            monitoring::Config::Enabled {
-                bind_address: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 3000),
-                channel_size: 1000,
-            }
-        );
-
-        let config_str_2 = "
-        [monitoring_server]
-        enabled = true
-        channel_size = 500
-        ";
-        let cfg: Config = toml::from_str(config_str_2).unwrap();
-
-        assert_eq!(
-            cfg.monitoring_server,
-            monitoring::Config::Enabled {
-                bind_address: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000),
-                channel_size: 500,
-            }
+            cfg.monitoring_server.bind_address,
+            Some(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000))
         );
     }
 
@@ -746,22 +700,6 @@ mod tests {
             enabled = false
             ";
         let cfg: Config = toml::from_str(config_str).unwrap();
-        assert_eq!(cfg.monitoring_server, monitoring::Config::Disabled);
-    }
-
-    #[test]
-    fn deserialize_event_sub_config() {
-        let config_str = "
-            [event_sub]
-            block_processing_buffer = 10
-            poll_interval = '5s'
-            retry_delay = '3s'
-            retry_max_attempts = 3
-            ";
-        let cfg: Config = toml::from_str(config_str).unwrap();
-        assert_eq!(cfg.event_sub.block_processing_buffer, 10);
-        assert_eq!(cfg.event_sub.poll_interval, Duration::from_secs(5));
-        assert_eq!(cfg.event_sub.retry_delay, Duration::from_secs(3));
-        assert_eq!(cfg.event_sub.retry_max_attempts, 3);
+        assert_eq!(cfg.monitoring_server.bind_address, None);
     }
 }

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -5,7 +5,6 @@ use events::Event;
 use futures::{future, StreamExt, TryStreamExt};
 use mockall::automock;
 use report::LoggableError;
-use serde::{Deserialize, Serialize};
 use tendermint::block;
 use thiserror::Error;
 use tokio::sync::broadcast::{self, Sender};
@@ -23,6 +22,24 @@ use crate::tm_client::TmClient;
 
 pub mod stream;
 
+// The maximum number of blocks to process concurrently.
+// - A value of 1 ensures sequential processing, preventing the event sub
+//   from downloading events from multiple blocks simultaneously. This minimizes
+//   memory usage but may slow down event processing.
+// - Higher values enable parallel block processing, improving throughput but
+//   increasing memory usage and potential resource contention.
+// - Setting this too high may cause excessive memory consumption, while setting
+//   it too low may lead to slower processing and underutilization of downstream
+//   consumers.
+const BLOCK_PROCESSING_BUFFER: usize = 10;
+// Interval to poll for new blocks
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+// Retry policy for block processing and event retrival
+const BLOCK_PROCESSING_RETRY_POLICY: RetryPolicy = RetryPolicy::RepeatConstant {
+    sleep: Duration::from_secs(3),
+    max_attempts: 3,
+};
+
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("failed querying the latest block")]
@@ -33,39 +50,6 @@ pub enum Error {
     EventDecoding { block: block::Height },
     #[error("failed receiving event from broadcast stream")]
     BroadcastStreamRecv(#[from] BroadcastStreamRecvError),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub struct Config {
-    // The maximum number of blocks to process concurrently.
-    // - A value of 1 ensures sequential processing, preventing the event sub
-    //   from downloading events from multiple blocks simultaneously. This minimizes
-    //   memory usage but may slow down event processing.
-    // - Higher values enable parallel block processing, improving throughput but
-    //   increasing memory usage and potential resource contention.
-    // - Setting this too high may cause excessive memory consumption, while setting
-    //   it too low may lead to slower processing and underutilization of downstream
-    //   consumers.
-    pub block_processing_buffer: usize,
-    // Interval to poll for new blocks
-    #[serde(with = "humantime_serde")]
-    pub poll_interval: Duration,
-
-    // Retry policy for block processing and event retrival
-    #[serde(with = "humantime_serde")]
-    pub retry_delay: Duration,
-    pub retry_max_attempts: u64,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            block_processing_buffer: 10,
-            poll_interval: Duration::from_secs(5),
-            retry_delay: Duration::from_secs(3),
-            retry_max_attempts: 3,
-        }
-    }
 }
 
 #[automock]
@@ -96,8 +80,6 @@ pub struct EventPublisher<T: TmClient + Sync> {
     poll_interval: Duration,
     tx: Sender<std::result::Result<Event, Error>>,
     delay: Duration,
-    block_processing_buffer: usize,
-    retry_policy: RetryPolicy,
     monitoring_client: monitoring::Client,
 }
 
@@ -107,19 +89,14 @@ impl<T: TmClient + Sync + std::fmt::Debug> EventPublisher<T> {
         client: T,
         capacity: usize,
         delay: Duration,
-        poll_interval: Duration,
-        block_processing_buffer: usize,
-        retry_policy: RetryPolicy,
         monitoring_client: monitoring::Client,
     ) -> (Self, EventSubscriber) {
         let (tx, _) = broadcast::channel(capacity);
         let publisher = EventPublisher {
             tm_client: client,
-            poll_interval,
+            poll_interval: POLL_INTERVAL,
             tx: tx.clone(),
             delay,
-            block_processing_buffer,
-            retry_policy,
             monitoring_client,
         };
         let subscriber = EventSubscriber { tx };
@@ -131,13 +108,9 @@ impl<T: TmClient + Sync + std::fmt::Debug> EventPublisher<T> {
     pub async fn run(self, token: CancellationToken) -> Result<(), Error> {
         let block_stream = stream::blocks(&self.tm_client, self.poll_interval, self.delay)
             .filter(|_| future::ready(self.has_subscriber())); // skip processing blocks when no subscriber exists
-        let event_stream = stream::events(
-            &self.tm_client,
-            block_stream,
-            self.retry_policy,
-            self.block_processing_buffer,
-        )
-        .take_until(token.cancelled());
+        let event_stream =
+            stream::events(&self.tm_client, block_stream, BLOCK_PROCESSING_RETRY_POLICY)
+                .take_until(token.cancelled());
 
         tokio::pin!(event_stream);
         while let Some(event) = event_stream.next().await {
@@ -192,34 +165,10 @@ mod tests {
     use tendermint::{abci, block};
     use tokio_util::sync::CancellationToken;
 
-    use crate::asyncutil::future::RetryPolicy;
-    use crate::event_sub::{Config, Error, EventPublisher, EventSub, EventSubscriber};
-    use crate::monitoring;
+    use crate::event_sub::{Error, EventPublisher, EventSub};
     use crate::monitoring::metrics::Msg;
     use crate::monitoring::test_utils;
     use crate::tm_client::{self, MockTmClient};
-
-    fn create_test_event_publisher(
-        tm_client: MockTmClient,
-        monitoring_client: monitoring::Client,
-    ) -> (EventPublisher<MockTmClient>, EventSubscriber) {
-        let config = Config::default();
-        let capacity = 100;
-        let delay = Duration::from_secs(1);
-
-        let retry_policy =
-            RetryPolicy::repeat_constant(config.retry_delay, config.retry_max_attempts);
-        let (event_publisher, subscriber) = EventPublisher::new(
-            tm_client,
-            capacity,
-            delay,
-            config.poll_interval,
-            config.block_processing_buffer,
-            retry_policy,
-            monitoring_client,
-        );
-        (event_publisher, subscriber)
-    }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn should_skip_processing_blocks_when_no_subscriber_exists() {
@@ -247,7 +196,7 @@ mod tests {
         let token = CancellationToken::new();
         let (monitoring_client, _) = test_utils::monitoring_client();
         let (event_publisher, _subscriber) =
-            create_test_event_publisher(tm_client, monitoring_client);
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
         let handle = tokio::spawn(event_publisher.run(token.child_token()));
 
         while *call_count.read().unwrap() < 10 {
@@ -310,7 +259,7 @@ mod tests {
         let token = CancellationToken::new();
         let (monitoring_client, _) = test_utils::monitoring_client();
         let (event_publisher, subscriber) =
-            create_test_event_publisher(tm_client, monitoring_client);
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
         let mut stream = subscriber.subscribe();
         let handle = tokio::spawn(event_publisher.run(token.child_token()));
 
@@ -429,7 +378,7 @@ mod tests {
         let token = CancellationToken::new();
         let (monitoring_client, mut receiver) = test_utils::monitoring_client();
         let (event_publisher, subscriber) =
-            create_test_event_publisher(tm_client, monitoring_client);
+            EventPublisher::new(tm_client, 100, Duration::from_secs(1), monitoring_client);
         let mut stream = subscriber.subscribe();
         let handle = tokio::spawn(event_publisher.run(token.child_token()));
 

--- a/ampd/src/monitoring/endpoints/metrics.rs
+++ b/ampd/src/monitoring/endpoints/metrics.rs
@@ -27,6 +27,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+// safe upper bound for expected metric throughput;
+// shouldn't exceed 1000 message
+const CHANNEL_SIZE: usize = 1000;
+
 /// content-Type for Prometheus/OpenMetrics text format responses.
 const OPENMETRICS_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 
@@ -148,8 +152,8 @@ impl Client {
 ///
 /// Panics if the Prometheus registry cannot be created or
 /// if metrics cannot be registered. This should never happen in normal operation.
-pub fn create_endpoint(channel_size: usize) -> (MethodRouter, Process, Client) {
-    let (tx, rx) = mpsc::channel(channel_size);
+pub fn create_endpoint() -> (MethodRouter, Process, Client) {
+    let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
 
     let mut registry = <Registry>::default();
     let metrics = Metrics::new(&mut registry);
@@ -632,8 +636,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn should_update_all_metrics_successfully() {
-        let channel_size = 1000;
-        let (router, process, client) = create_endpoint(channel_size);
+        let (router, process, client) = create_endpoint();
         _ = process.run(CancellationToken::new());
 
         let router = Router::new().route("/test", router);

--- a/ampd/src/monitoring/server.rs
+++ b/ampd/src/monitoring/server.rs
@@ -28,44 +28,27 @@ pub enum Error {
 
 /// Configuration for the monitoring server
 ///
-/// This enum ensures that the logical relationship between fields is maintained:
-/// - When monitoring is disabled, no fields are required
-/// - When monitoring is enabled, bind_address and channel_size are optional and will use sensible defaults if not specified
-#[derive(Clone, PartialEq, Debug)]
-pub enum Config {
-    Disabled,
-    Enabled {
-        bind_address: SocketAddrV4,
-        // Safe upper bound for expected metric throughput.
-        channel_size: usize,
-    },
-}
-
-/// The default configuration of the monitoring server is disabled.
-impl Default for Config {
-    fn default() -> Self {
-        Self::Disabled
-    }
+/// Controls whether the monitoring server is enabled and on which address it binds.
+/// When `bind_address` is `None`, the server is disabled.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct Config {
+    /// The address to bind the monitoring server to.
+    /// When `None`, the server is disabled.
+    pub bind_address: Option<SocketAddrV4>,
 }
 
 impl Config {
     /// Creates a new configuration with monitoring enabled using the default bind address
     ///
     /// The default bind address is `127.0.0.1:3000`.
-    /// The default channel size is `1000`.
     pub fn enabled() -> Self {
-        Self::Enabled {
-            bind_address: Self::default_bind_addr(),
-            channel_size: Self::default_channel_size(),
+        Self {
+            bind_address: Some(Self::default_bind_addr()),
         }
     }
 
     fn default_bind_addr() -> SocketAddrV4 {
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 3000)
-    }
-
-    fn default_channel_size() -> usize {
-        1000
     }
 }
 
@@ -79,23 +62,11 @@ impl Serialize for Config {
         struct ConfigCompat {
             enabled: bool,
             bind_address: SocketAddrV4,
-            channel_size: usize,
         }
 
-        let compat = match self {
-            Config::Disabled => ConfigCompat {
-                enabled: false,
-                bind_address: Self::default_bind_addr(),
-                channel_size: Self::default_channel_size(),
-            },
-            Config::Enabled {
-                bind_address,
-                channel_size,
-            } => ConfigCompat {
-                enabled: true,
-                bind_address: *bind_address,
-                channel_size: *channel_size,
-            },
+        let compat = ConfigCompat {
+            enabled: self.bind_address.is_some(),
+            bind_address: self.bind_address.unwrap_or_else(Self::default_bind_addr),
         };
 
         compat.serialize(serializer)
@@ -114,19 +85,12 @@ impl<'de> Deserialize<'de> for Config {
             enabled: bool,
             #[serde(default = "Config::default_bind_addr")]
             bind_address: SocketAddrV4,
-            #[serde(default = "Config::default_channel_size")]
-            channel_size: usize,
         }
 
         let compat = ConfigCompat::deserialize(deserializer)?;
 
-        Ok(if compat.enabled {
-            Config::Enabled {
-                bind_address: compat.bind_address,
-                channel_size: compat.channel_size,
-            }
-        } else {
-            Config::Disabled
+        Ok(Config {
+            bind_address: compat.enabled.then_some(compat.bind_address),
         })
     }
 }
@@ -174,14 +138,10 @@ impl Server {
     ///
     /// Returns an error if the server cannot be created or if metrics endpoints
     /// cannot be initialized.
-    pub fn new(config: Config) -> Result<(Server, Client), Error> {
-        match config {
-            Config::Enabled {
-                bind_address,
-                channel_size,
-            } => Self::create_server_with_client(TcpConnector::from(bind_address), channel_size),
-
-            Config::Disabled => {
+    pub fn new(connector: Option<impl Into<TcpConnector>>) -> Result<(Server, Client), Error> {
+        match connector {
+            Some(connector) => Self::create_server_with_client(connector.into()),
+            None => {
                 info!("monitoring server is disabled");
                 Ok((
                     Server::Disabled,
@@ -193,13 +153,9 @@ impl Server {
         }
     }
 
-    fn create_server_with_client(
-        tcp_connector: TcpConnector,
-        channel_size: usize,
-    ) -> Result<(Server, Client), Error> {
+    fn create_server_with_client(tcp_connector: TcpConnector) -> Result<(Server, Client), Error> {
         let status_router = status::create_endpoint();
-        let (metrics_router, metrics_process, metrics_client) =
-            metrics::create_endpoint(channel_size);
+        let (metrics_router, metrics_process, metrics_client) = metrics::create_endpoint();
 
         let server = Server::Enabled {
             server: HttpServer {
@@ -397,7 +353,6 @@ mod tests {
         // Test parsing enabled config from environment variable
         env::set_var("TEST_MONITORING_ENABLED", "true");
         env::set_var("TEST_MONITORING_BIND_ADDRESS", "127.0.0.1:4000");
-        env::set_var("TEST_MONITORING_CHANNEL_SIZE", "500");
 
         let enabled_config: Config = cfg::builder()
             .add_source(Environment::with_prefix("TEST_MONITORING"))
@@ -405,13 +360,9 @@ mod tests {
             .unwrap()
             .try_deserialize()
             .unwrap();
-
         assert_eq!(
-            enabled_config,
-            Config::Enabled {
-                bind_address: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4000),
-                channel_size: 500,
-            }
+            enabled_config.bind_address,
+            Some(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4000))
         );
 
         // Test parsing disabled config from environment variable
@@ -422,18 +373,17 @@ mod tests {
             .unwrap()
             .try_deserialize()
             .unwrap();
-        assert_eq!(disabled_config, Config::Disabled);
+        assert_eq!(disabled_config.bind_address, None);
 
         // Clean up
         env::remove_var("TEST_MONITORING_ENABLED");
         env::remove_var("TEST_MONITORING_BIND_ADDRESS");
-        env::remove_var("TEST_MONITORING_CHANNEL_SIZE");
     }
 
     #[test]
     #[traced_test]
     fn disabled_client_discards_messages_without_error() {
-        let (_, client) = Server::new(Config::Disabled).unwrap(); // Creates disabled server and client
+        let (_, client) = Server::new(None::<SocketAddr>).unwrap(); // Creates disabled server and client
 
         // Should succeed without doing anything
         client.metrics().record_metric(metrics::Msg::BlockReceived);
@@ -454,7 +404,7 @@ mod tests {
 
     #[async_test]
     async fn disabled_server_shuts_down_when_cancelled() {
-        let (server, _) = Server::new(Config::Disabled).unwrap(); // Creates disabled server
+        let (server, _) = Server::new(None::<SocketAddr>).unwrap(); // Creates disabled server
         let cancel = CancellationToken::new();
 
         let handle = tokio::spawn(server.run(cancel.clone()));
@@ -475,14 +425,10 @@ mod tests {
     async fn server_startup_fails_when_address_unavailable() {
         // First, bind to a specific port to make it unavailable
         let listener = listener().await.connect().await.unwrap();
-        let blocked_addr = convert_to_socketaddrv4(listener.local_addr().unwrap());
+        let blocked_addr = listener.local_addr().unwrap();
 
         // Create a server on the same address - creation should succeed
-        let (server, _) = Server::new(Config::Enabled {
-            bind_address: blocked_addr,
-            channel_size: 1000,
-        })
-        .unwrap();
+        let (server, _) = Server::new(Some(blocked_addr)).unwrap();
 
         // But running the server should fail
         let cancel = CancellationToken::new();
@@ -500,15 +446,10 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_responds_to_status_endpoint_and_shuts_down_gracefully() {
-        let bind_address = listener().await.bind_address().unwrap();
-        let channel_size = 1000;
-        let status_url = create_endpoint_url(bind_address, "status");
+        let connector = listener().await;
+        let status_url = create_endpoint_url(connector.bind_address().ok(), "status");
 
-        let (server, _) = Server::new(Config::Enabled {
-            bind_address: convert_to_socketaddrv4(bind_address),
-            channel_size,
-        })
-        .unwrap();
+        let (server, _) = Server::new(Some(connector)).unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -532,15 +473,10 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_continues_serving_after_all_metrics_clients_dropped() {
-        let bind_address = listener().await.bind_address().unwrap();
-        let channel_size = 1000;
-        let metrics_url = create_endpoint_url(bind_address, "metrics");
+        let connector = listener().await;
+        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
 
-        let (server, monitoring_client) = Server::new(Config::Enabled {
-            bind_address: convert_to_socketaddrv4(bind_address),
-            channel_size,
-        })
-        .unwrap();
+        let (server, monitoring_client) = Server::new(Some(connector)).unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -569,15 +505,10 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn metrics_endpoint_increments_counters_when_messages_sent() {
-        let bind_address = listener().await.bind_address().unwrap();
-        let channel_size = 1000;
-        let metrics_url = create_endpoint_url(bind_address, "metrics");
+        let connector = listener().await;
+        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
 
-        let (server, monitoring_client) = Server::new(Config::Enabled {
-            bind_address: convert_to_socketaddrv4(bind_address),
-            channel_size,
-        })
-        .unwrap();
+        let (server, monitoring_client) = Server::new(Some(connector)).unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -608,13 +539,7 @@ mod tests {
     #[async_test(start_paused = true)]
     #[traced_test]
     async fn enabled_server_shuts_down_gracefully_when_cancellation_token_triggered() {
-        let channel_size = 1000;
-        let bind_address = convert_to_socketaddrv4(listener().await.bind_address().unwrap());
-        let (server, monitoring_client) = Server::new(Config::Enabled {
-            bind_address,
-            channel_size,
-        })
-        .unwrap();
+        let (server, monitoring_client) = Server::new(Some(listener().await)).unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -655,15 +580,10 @@ mod tests {
 
     #[async_test(start_paused = true)]
     async fn enabled_server_handles_concurrent_metrics_requests_correctly() {
-        let bind_address = listener().await.bind_address().unwrap();
-        let channel_size = 1000;
-        let metrics_url = create_endpoint_url(bind_address, "metrics");
+        let connector = listener().await;
+        let metrics_url = create_endpoint_url(connector.bind_address().ok(), "metrics");
 
-        let (server, original_client) = Server::new(Config::Enabled {
-            bind_address: convert_to_socketaddrv4(bind_address),
-            channel_size,
-        })
-        .unwrap();
+        let (server, original_client) = Server::new(Some(connector)).unwrap();
         let cancel = CancellationToken::new();
 
         let server_handle = tokio::spawn(server.run(cancel.clone()));
@@ -705,15 +625,8 @@ mod tests {
             .into()
     }
 
-    fn create_endpoint_url(bind_address: SocketAddr, endpoint: &str) -> String {
-        format!("http://{}/{endpoint}", bind_address)
-    }
-
-    fn convert_to_socketaddrv4(addr: SocketAddr) -> SocketAddrV4 {
-        match addr {
-            SocketAddr::V4(v4) => v4,
-            SocketAddr::V6(_) => panic!("expected IPv4 address in this test"),
-        }
+    fn create_endpoint_url(bind_address: Option<SocketAddr>, endpoint: &str) -> String {
+        format!("http://{}/{endpoint}", bind_address.unwrap())
     }
 
     fn send_multiple_metrics(

--- a/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
+++ b/ampd/src/monitoring/testdata/ensure_correct_default_config.golden
@@ -1,16 +1,14 @@
 Enabled Config:
-Enabled { bind_address: 127.0.0.1:3000, channel_size: 1000 }
+Config { bind_address: Some(127.0.0.1:3000) }
 
 Disabled Config:
-Disabled
+Config { bind_address: None }
 
 Enabled Serialized:
 enabled = true
 bind_address = "127.0.0.1:3000"
-channel_size = 1000
 
 
 Disabled Serialized:
 enabled = false
 bind_address = "127.0.0.1:3000"
-channel_size = 1000

--- a/ampd/src/testdata/deserialize_valid_grpc_config.golden
+++ b/ampd/src/testdata/deserialize_valid_grpc_config.golden
@@ -1,7 +1,6 @@
 {
   "tm_jsonrpc": "http://localhost:26657/",
   "tm_grpc": "tcp://localhost:9090",
-  "default_rpc_timeout": "3s",
   "tm_grpc_timeout": {
     "secs": 5,
     "nanos": 0
@@ -11,8 +10,7 @@
     "retry_max_attempts": 3,
     "stream_timeout": "15s",
     "stream_buffer_size": 100000,
-    "delay": "1s",
-    "tx_broadcast_buffer_size": 10
+    "delay": "1s"
   },
   "broadcast": {
     "chain_id": "axelar-dojo-1",
@@ -22,9 +20,7 @@
     "gas_price": "0.00005uaxl",
     "batch_gas_limit": 1000000,
     "queue_cap": 1000,
-    "broadcast_interval": "5s",
-    "tx_confirmation_buffer_size": 10,
-    "tx_confirmation_queue_cap": 1000
+    "broadcast_interval": "5s"
   },
   "handlers": [],
   "tofnd_config": {
@@ -61,17 +57,6 @@
   },
   "monitoring_server": {
     "enabled": false,
-    "bind_address": "127.0.0.1:3000",
-    "channel_size": 1000
-  },
-  "event_sub": {
-    "block_processing_buffer": 10,
-    "poll_interval": "5s",
-    "retry_delay": "3s",
-    "retry_max_attempts": 3
-  },
-  "tm_client": {
-    "max_retries": 15,
-    "retry_delay": "1s"
+    "bind_address": "127.0.0.1:3000"
   }
 }

--- a/ampd/src/tests/config_template.toml
+++ b/ampd/src/tests/config_template.toml
@@ -1,6 +1,5 @@
 tm_jsonrpc = 'http://localhost:26657/'
 tm_grpc = 'tcp://localhost:9090'
-default_rpc_timeout = '3s'
 
 [tm_grpc_timeout]
 secs = 5
@@ -12,7 +11,6 @@ retry_max_attempts = 3
 stream_timeout = '15s'
 stream_buffer_size = 100000
 delay = '1s'
-tx_broadcast_buffer_size = 10
 
 [broadcast]
 chain_id = 'axelar-dojo-1'
@@ -23,8 +21,6 @@ gas_price = '0.00005uaxl'
 batch_gas_limit = 1000000
 queue_cap = 1000
 broadcast_interval = '5s'
-tx_confirmation_buffer_size = 10
-tx_confirmation_queue_cap = 1000
 
 [[handlers]]
 type = 'EvmMsgVerifier'
@@ -183,14 +179,3 @@ multisig = 'axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqecnww6'
 [monitoring_server]
 enabled = false
 bind_address = '127.0.0.1:3000'
-channel_size = 1000
-
-[event_sub]
-block_processing_buffer = 10
-poll_interval = '5s'
-retry_delay = '3s'
-retry_max_attempts = 3
-
-[tm_client]
-max_retries = 15
-retry_delay = '1s'

--- a/ampd/src/tm_client.rs
+++ b/ampd/src/tm_client.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use error_stack::{Report, Result};
 use mockall::automock;
-use serde::{Deserialize, Serialize};
 use tendermint::block::Height;
 use tendermint_rpc::{Client, HttpClient};
 
@@ -13,37 +12,8 @@ pub type BlockResultsResponse = tendermint_rpc::endpoint::block_results::Respons
 pub type BlockResponse = tendermint_rpc::endpoint::block::Response;
 pub type Error = tendermint_rpc::Error;
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub struct Config {
-    pub max_retries: u64,
-    #[serde(with = "humantime_serde")]
-    pub retry_delay: Duration,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            max_retries: 15,
-            retry_delay: Duration::from_secs(1),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct TendermintClient {
-    client: HttpClient,
-    retry_policy: RetryPolicy,
-}
-
-impl TendermintClient {
-    pub fn new(client: HttpClient, max_retries: u64, retry_delay: Duration) -> Self {
-        let retry_policy = RetryPolicy::repeat_constant(retry_delay, max_retries);
-        Self {
-            client,
-            retry_policy,
-        }
-    }
-}
+const MAX_RETRIES: u64 = 15;
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[automock]
 #[async_trait]
@@ -53,17 +23,20 @@ pub trait TmClient {
 }
 
 #[async_trait]
-impl TmClient for TendermintClient {
+impl TmClient for HttpClient {
     async fn latest_block(&self) -> Result<BlockResponse, Error> {
-        future::with_retry(|| Client::latest_block(&self.client), self.retry_policy)
-            .await
-            .map_err(Report::from)
+        future::with_retry(
+            || Client::latest_block(self),
+            RetryPolicy::repeat_constant(RETRY_DELAY, MAX_RETRIES),
+        )
+        .await
+        .map_err(Report::from)
     }
 
     async fn block_results(&self, height: Height) -> Result<BlockResultsResponse, Error> {
         future::with_retry(
-            || Client::block_results(&self.client, height),
-            self.retry_policy,
+            || Client::block_results(self, height),
+            RetryPolicy::repeat_constant(RETRY_DELAY, MAX_RETRIES),
         )
         .await
         .map_err(Report::from)


### PR DESCRIPTION
This reverts commit 72b07d71662367e750f2c0d252e3904b5463e820.

## Description
## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
