### PR TITLE
feat(ampd-sdk): add latest block height method

### DIFF
--- a/packages/ampd-sdk/src/grpc/client/mod.rs
+++ b/packages/ampd-sdk/src/grpc/client/mod.rs
@@ -6,7 +6,7 @@ use ampd_proto::blockchain_service_client::BlockchainServiceClient;
 use ampd_proto::crypto_service_client::CryptoServiceClient;
 use ampd_proto::{
     AddressRequest, BroadcastRequest, ContractStateRequest, ContractsRequest, KeyRequest,
-    SignRequest, SubscribeRequest,
+    LatestBlockHeightRequest, SignRequest, SubscribeRequest,
 };
 use async_trait::async_trait;
 use axelar_wasm_std::nonempty;
@@ -65,6 +65,8 @@ pub trait Client {
     ) -> Result<T, Error>;
 
     async fn contracts(&mut self, chain: ChainName) -> Result<ContractsAddresses, Error>;
+
+    async fn latest_block_height(&mut self) -> Result<u64, Error>;
 
     async fn sign(
         &mut self,
@@ -166,6 +168,21 @@ impl Client for GrpcClient {
 
         let ampd_broadcaster_address = parse_addr(&broadcaster_address)?;
         Ok(ampd_broadcaster_address)
+    }
+
+    async fn latest_block_height(&mut self) -> Result<u64, Error> {
+        let channel = self.channel().await?;
+        let mut blockchain_client = BlockchainServiceClient::new(channel);
+
+        let height = blockchain_client
+            .latest_block_height(Request::new(LatestBlockHeightRequest {}))
+            .await
+            .inspect_err(|status| self.ensure_healthy_connection(status))
+            .into_report()?
+            .into_inner()
+            .height;
+
+        Ok(height)
     }
 
     async fn broadcast(&mut self, msg: cosmrs::Any) -> Result<BroadcastClientResponse, Error> {
@@ -464,6 +481,43 @@ mod tests {
             assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
             assert_eq!(result.unwrap(), expected_address);
         }
+    }
+
+    #[tokio::test]
+    async fn latest_block_height_should_succeed_returning_the_height() {
+        let mut mock_blockchain = MockBlockchainService::new();
+        let expected_height = 12345u64;
+        let mock_response = LatestBlockHeightResponse {
+            height: expected_height,
+        };
+
+        mock_blockchain
+            .expect_latest_block_height()
+            .return_once(move |_request| Ok(Response::new(mock_response)));
+
+        let (mut client, _) = test_setup(mock_blockchain, MockCryptoService::new()).await;
+        let result = client.latest_block_height().await;
+
+        assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
+        assert_eq!(result.unwrap(), expected_height);
+    }
+
+    #[tokio::test]
+    async fn latest_block_height_should_return_error_if_grpc_error_occurs() {
+        let mut mock_blockchain = MockBlockchainService::new();
+
+        mock_blockchain
+            .expect_latest_block_height()
+            .return_once(|_request| Err(Status::unavailable("service unavailable")));
+
+        let (mut client, _) = test_setup(mock_blockchain, MockCryptoService::new()).await;
+        let result = client.latest_block_height().await;
+
+        assert!(result.is_err(), "unexpected Ok result: {}", result.unwrap());
+        assert!(matches!(
+            result.unwrap_err().current_context(),
+            Error::Grpc(GrpcError::ServiceUnavailable(_))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
This PR is the last one in a series of changes to add latest block height retrieval to ampd grpc server and client. With this merged, new handlers can easily call this method from the existing sdk client instead of relying on tendermint client.

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
