### PR TITLE
chore(its): increase test coverage for token config queries

### DIFF
--- a/contracts/interchain-token-service/src/contract/query.rs
+++ b/contracts/interchain-token-service/src/contract/query.rs
@@ -92,10 +92,11 @@ pub fn is_contract_enabled(deps: Deps) -> Result<Binary, Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::state;
     use cosmwasm_std::from_json;
     use cosmwasm_std::testing::mock_dependencies;
+
+    use super::*;
+    use crate::state;
 
     #[test]
     fn query_token_config() {

--- a/contracts/interchain-token-service/src/contract/query.rs
+++ b/contracts/interchain-token-service/src/contract/query.rs
@@ -104,7 +104,7 @@ mod tests {
         let token_id = TokenId::new([1; 32]);
 
         let result = token_config(deps.as_ref(), token_id).unwrap();
-        let config: Option<msg::TokenConfig> = from_json(result).unwrap();
+        let config: Option<state::TokenConfig> = from_json(result).unwrap();
         assert_eq!(config, None);
 
         let origin_chain: ChainNameRaw = "ethereum".try_into().unwrap();
@@ -118,7 +118,7 @@ mod tests {
         .unwrap();
 
         let result = token_config(deps.as_ref(), token_id).unwrap();
-        let config: Option<msg::TokenConfig> = from_json(result).unwrap();
+        let config: Option<state::TokenConfig> = from_json(result).unwrap();
         assert_eq!(config.unwrap().origin_chain, origin_chain);
     }
 }

--- a/contracts/interchain-token-service/src/contract/query.rs
+++ b/contracts/interchain-token-service/src/contract/query.rs
@@ -89,3 +89,35 @@ pub fn is_contract_enabled(deps: Deps) -> Result<Binary, Error> {
     to_json_binary(&killswitch::is_contract_active(deps.storage))
         .change_context(Error::JsonSerialization)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state;
+    use cosmwasm_std::from_json;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn query_token_config() {
+        let mut deps = mock_dependencies();
+        let token_id = TokenId::new([1; 32]);
+
+        let result = token_config(deps.as_ref(), token_id).unwrap();
+        let config: Option<msg::TokenConfig> = from_json(result).unwrap();
+        assert_eq!(config, None);
+
+        let origin_chain: ChainNameRaw = "ethereum".try_into().unwrap();
+        state::save_token_config(
+            deps.as_mut().storage,
+            token_id,
+            &state::TokenConfig {
+                origin_chain: origin_chain.clone(),
+            },
+        )
+        .unwrap();
+
+        let result = token_config(deps.as_ref(), token_id).unwrap();
+        let config: Option<msg::TokenConfig> = from_json(result).unwrap();
+        assert_eq!(config.unwrap().origin_chain, origin_chain);
+    }
+}

--- a/contracts/interchain-token-service/tests/query.rs
+++ b/contracts/interchain-token-service/tests/query.rs
@@ -162,6 +162,61 @@ fn query_token_chain_config() {
 }
 
 #[test]
+fn query_token_config() {
+    let (
+        mut deps,
+        utils::TestMessage {
+            router_message,
+            source_its_contract,
+            source_its_chain,
+            destination_its_chain,
+            ..
+        },
+    ) = utils::setup();
+
+    let token_id = TokenId::new([1; 32]);
+
+    let token_config = utils::query_token_config(deps.as_ref(), token_id).unwrap();
+    assert_eq!(token_config, None);
+
+    let deploy_message = interchain_token_service_std::DeployInterchainToken {
+        token_id,
+        name: "Test Token".try_into().unwrap(),
+        symbol: "TEST".try_into().unwrap(),
+        decimals: 18,
+        minter: None,
+    };
+
+    let hub_message = interchain_token_service_std::HubMessage::SendToHub {
+        destination_chain: destination_its_chain.clone(),
+        message: deploy_message.into(),
+    };
+
+    assert_ok!(utils::execute_hub_message(
+        deps.as_mut(),
+        router_message.cc_id.clone(),
+        source_its_contract.clone(),
+        hub_message,
+    ));
+
+    let token_config = utils::query_token_config(deps.as_ref(), token_id).unwrap();
+    assert!(token_config.is_some());
+    let config = token_config.unwrap();
+    assert_eq!(config.origin_chain, source_its_chain);
+}
+
+#[test]
+fn query_token_config_non_existent() {
+    let mut deps = mock_dependencies();
+    utils::instantiate_contract(deps.as_mut()).unwrap();
+
+    let token_id = TokenId::new([1; 32]);
+
+    let token_config = utils::query_token_config(deps.as_ref(), token_id).unwrap();
+    assert_eq!(token_config, None);
+}
+
+#[test]
 fn query_contract_enable_disable_lifecycle() {
     let mut deps = mock_dependencies();
     utils::instantiate_contract(deps.as_mut()).unwrap();

--- a/contracts/interchain-token-service/tests/query.rs
+++ b/contracts/interchain-token-service/tests/query.rs
@@ -206,17 +206,6 @@ fn query_token_config() {
 }
 
 #[test]
-fn query_token_config_non_existent() {
-    let mut deps = mock_dependencies();
-    utils::instantiate_contract(deps.as_mut()).unwrap();
-
-    let token_id = TokenId::new([1; 32]);
-
-    let token_config = utils::query_token_config(deps.as_ref(), token_id).unwrap();
-    assert_eq!(token_config, None);
-}
-
-#[test]
 fn query_contract_enable_disable_lifecycle() {
     let mut deps = mock_dependencies();
     utils::instantiate_contract(deps.as_mut()).unwrap();


### PR DESCRIPTION
## Description

I've noticed that `token_config` function in query.rs was not covered.
```
pub fn token_config(deps: Deps, token_id: TokenId) -> Result<Binary, Error>
```
Increase test coverage for token config query: https://app.codecov.io/gh/axelarnetwork/axelar-amplifier/pull/1046/indirect-changes#7562f7ac12aab80e3a10d702cda16bd8-L82


## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add unit and integration tests to cover `token_config` query behavior from empty to populated state.
> 
> - **Tests**:
>   - **Unit tests** (`contracts/interchain-token-service/src/contract/query.rs`):
>     - Add `query_token_config` test validating `token_config` returns `None` before save and correct `origin_chain` after persisting config.
>   - **Integration tests** (`contracts/interchain-token-service/tests/query.rs`):
>     - Add `query_token_config` test exercising deployment via `HubMessage::SendToHub`, then asserting `query_token_config` transitions from `None` to populated with correct `origin_chain`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ed3ba0f64433f2433ae0d6e8a71da5dbb1a4cae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->