### PR TITLE
chore(ampd): update changelog for ampd v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## [Unreleased](https://github.com/axelarnetwork/axelar-amplifier/tree/HEAD)
 
-[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.11.0..HEAD)
+[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.12.0..HEAD)
+
+## [v1.12.0](https://github.com/axelarnetwork/axelar-amplifier/tree/ampd-v1.12.0) (2025-09-19)
+
+[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.11.0..ampd-v1.12.0)
+
+- retry when there is a sequence mismatch error [#1042](https://github.com/axelarnetwork/axelar-amplifier/pull/1042)
+- add latest block height method to grpc server [#1040](https://github.com/axelarnetwork/axelar-amplifier/pull/1040)
+- deserialize cosmrs message values [#1032](https://github.com/axelarnetwork/axelar-amplifier/pull/1032)
+- add config module [#1022](https://github.com/axelarnetwork/axelar-amplifier/pull/1022)
+- fix compilation error when not using `dummy-grpc-broadcast` [#1030](https://github.com/axelarnetwork/axelar-amplifier/pull/1030)
+- setup message logger for evm handler [#1026](https://github.com/axelarnetwork/axelar-amplifier/pull/1026)
+- implement blockchain service method `contracts` [#1009](https://github.com/axelarnetwork/axelar-amplifier/pull/1009)
+- move hardcoded values into config [#1019](https://github.com/axelarnetwork/axelar-amplifier/pull/1019)
+- miscellaneous changes to add `router_api` macros to tests [#1004](https://github.com/axelarnetwork/axelar-amplifier/pull/1004)
+- track ampd error in monitoring server [#998](https://github.com/axelarnetwork/axelar-amplifier/pull/998)
+- ampd release doc update [#1012](https://github.com/axelarnetwork/axelar-amplifier/pull/1012)
+- add custom linter to basic workflow [#981](https://github.com/axelarnetwork/axelar-amplifier/pull/981)
+- record stage metrics in monitoring server [#985](https://github.com/axelarnetwork/axelar-amplifier/pull/985)
+- track error returns by rpc nodes [#973](https://github.com/axelarnetwork/axelar-amplifier/pull/973)
 
 ## [v1.11.0](https://github.com/axelarnetwork/axelar-amplifier/tree/ampd-v1.11.0) (2025-08-14)
 


### PR DESCRIPTION
## Description
Update changelog for ampd v1.12.0

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
