### PR TITLE
feat(ampd): add event filtering to event handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
 name = "events-derive"
 version = "1.0.0"
 dependencies = [
+ "axelar-wasm-std",
  "error-stack",
  "events",
  "quote 1.0.40",

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -15,7 +15,7 @@ use valuable::Valuable;
 
 use crate::asyncutil::future::{with_retry, RetryPolicy};
 use crate::asyncutil::task::TaskError;
-use crate::grpc::reqs::EventFilters;
+use crate::event_sub::event_filter::EventFilters;
 use crate::monitoring::metrics;
 use crate::monitoring::metrics::{Msg, Stage};
 use crate::{broadcast, cosmos, event_sub, monitoring};
@@ -276,7 +276,7 @@ mod tests {
     use crate::broadcast::test_utils::create_base_account;
     use crate::broadcast::DecCoin;
     use crate::event_processor::{consume_events, Config, Error, EventHandler};
-    use crate::grpc::reqs::EventFilters;
+    use crate::event_sub::event_filter::EventFilters;
     use crate::types::{random_cosmos_public_key, TMAddress};
     use crate::{broadcast, cosmos, event_sub, monitoring, PREFIX};
 

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -15,6 +15,7 @@ use valuable::Valuable;
 
 use crate::asyncutil::future::{with_retry, RetryPolicy};
 use crate::asyncutil::task::TaskError;
+use crate::grpc::reqs::EventFilters;
 use crate::monitoring::metrics;
 use crate::monitoring::metrics::{Msg, Stage};
 use crate::{broadcast, cosmos, event_sub, monitoring};
@@ -24,6 +25,8 @@ pub trait EventHandler {
     type Err: Context;
 
     async fn handle(&self, event: &Event) -> Result<Vec<Any>, Self::Err>;
+
+    fn event_filters(&self) -> EventFilters;
 }
 
 #[derive(Error, Debug)]
@@ -273,6 +276,7 @@ mod tests {
     use crate::broadcast::test_utils::create_base_account;
     use crate::broadcast::DecCoin;
     use crate::event_processor::{consume_events, Config, Error, EventHandler};
+    use crate::grpc::reqs::EventFilters;
     use crate::types::{random_cosmos_public_key, TMAddress};
     use crate::{broadcast, cosmos, event_sub, monitoring, PREFIX};
 
@@ -290,6 +294,8 @@ mod tests {
                 type Err = EventHandlerError;
 
                 async fn handle(&self, event: &Event) -> Result<Vec<Any>, EventHandlerError>;
+
+                fn event_filters(&self) -> EventFilters;
             }
     }
 

--- a/ampd/src/event_sub/event_filter.rs
+++ b/ampd/src/event_sub/event_filter.rs
@@ -1,0 +1,231 @@
+use axelar_wasm_std::nonempty;
+use error_stack::{report, Report, Result, ResultExt};
+use thiserror::Error;
+
+use crate::types::{AxelarAddress, TMAddress};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("empty filter")]
+    EmptyFilter,
+    #[error("invalid contract address {0}")]
+    InvalidContractAddress(String),
+}
+
+#[derive(Clone, Debug)]
+pub enum EventFilter {
+    EventType(nonempty::String),
+    Contract(TMAddress),
+    EventTypeAndContract(nonempty::String, TMAddress),
+}
+
+impl TryFrom<ampd_proto::EventFilter> for EventFilter {
+    type Error = Report<Error>;
+
+    fn try_from(event_filter: ampd_proto::EventFilter) -> Result<Self, Error> {
+        let event_type = event_filter.r#type.try_into().ok();
+        let contract = if event_filter.contract.is_empty() {
+            None
+        } else {
+            let contract = event_filter
+                .contract
+                .parse::<AxelarAddress>()
+                .change_context(Error::InvalidContractAddress(event_filter.contract))?;
+
+            Some(contract.into()) // TODO: change to AxelarAddress
+        };
+
+        match (event_type, contract) {
+            (Some(event_type), Some(contract)) => {
+                Ok(EventFilter::EventTypeAndContract(event_type, contract))
+            }
+            (Some(event_type), None) => Ok(EventFilter::EventType(event_type)),
+            (None, Some(contract)) => Ok(EventFilter::Contract(contract)),
+            (None, None) => Err(report!(Error::EmptyFilter)),
+        }
+    }
+}
+
+impl EventFilter {
+    pub fn filter(&self, event_type: &str, contract: Option<&TMAddress>) -> bool {
+        match self {
+            EventFilter::EventType(event_type_filter) => event_type_filter == event_type,
+            EventFilter::Contract(contract_filter) => Some(contract_filter) == contract,
+            EventFilter::EventTypeAndContract(event_type_filter, contract_filter) => {
+                event_type_filter == event_type && Some(contract_filter) == contract
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EventFilters {
+    pub filters: Vec<EventFilter>,
+    pub include_block_begin_end: bool,
+}
+
+impl EventFilters {
+    pub fn new(filters: Vec<EventFilter>, include_block_begin_end: bool) -> Self {
+        Self {
+            filters,
+            include_block_begin_end,
+        }
+    }
+
+    pub fn filter(&self, event: &events::Event) -> bool {
+        let contract = event.contract_address();
+
+        match event {
+            events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
+                self.include_block_begin_end
+            }
+            events::Event::Abci { event_type, .. } => self.filter_abci_event(event_type, contract),
+        }
+    }
+
+    fn filter_abci_event<T>(&self, event_type: &str, contract: Option<T>) -> bool
+    where
+        T: Into<TMAddress>,
+    {
+        if self.filters.is_empty() {
+            return true;
+        }
+
+        let contract = contract.map(Into::into);
+
+        self.filters
+            .iter()
+            .any(|filter| filter.filter(event_type, contract.as_ref()))
+    }
+}
+
+impl TryFrom<(Vec<ampd_proto::EventFilter>, bool)> for EventFilters {
+    type Error = Report<Error>;
+
+    fn try_from(
+        (event_filters, include_block_begin_end): (Vec<ampd_proto::EventFilter>, bool),
+    ) -> Result<Self, Error> {
+        Ok(EventFilters {
+            filters: event_filters
+                .into_iter()
+                .map(EventFilter::try_from)
+                .collect::<Result<_, _>>()?,
+            include_block_begin_end,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axelar_wasm_std::assert_err_contains;
+
+    use super::*;
+    use crate::types::TMAddress;
+    use crate::PREFIX;
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_event_type() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(matches!(filter, EventFilter::EventType(_)));
+    }
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_contract_address() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: TMAddress::random(PREFIX).to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(matches!(filter, EventFilter::Contract(_)));
+    }
+
+    #[test]
+    fn event_filter_should_be_created_from_valid_event_type_and_contract_address() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: TMAddress::random(PREFIX).to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(matches!(filter, EventFilter::EventTypeAndContract(_, _)));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_empty_filter() {
+        let proto_filter = ampd_proto::EventFilter::default();
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::EmptyFilter);
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_invalid_contract_address() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: "invalid_address".to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_fail_for_contract_with_wrong_prefix() {
+        let address = TMAddress::random("wrong");
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let result = EventFilter::try_from(proto_filter);
+        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_event_type() {
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: "".to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+        assert!(filter.filter("test_event", None));
+        assert!(!filter.filter("other_event", None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("any_event", Some(&address)));
+        assert!(!filter.filter("any_event", Some(&TMAddress::random(PREFIX))));
+        assert!(!filter.filter("any_event", None));
+    }
+
+    #[test]
+    fn event_filter_should_match_by_both_event_type_and_contract() {
+        let address = TMAddress::random(PREFIX);
+        let proto_filter = ampd_proto::EventFilter {
+            r#type: "test_event".to_string(),
+            contract: address.to_string(),
+        };
+
+        let filter = EventFilter::try_from(proto_filter).unwrap();
+
+        assert!(filter.filter("test_event", Some(&address)));
+        assert!(!filter.filter("other_event", Some(&address)));
+        assert!(!filter.filter("test_event", Some(&TMAddress::random(PREFIX))));
+    }
+}

--- a/ampd/src/event_sub/mod.rs
+++ b/ampd/src/event_sub/mod.rs
@@ -21,6 +21,7 @@ use crate::monitoring;
 use crate::monitoring::metrics::Msg;
 use crate::tm_client::TmClient;
 
+pub mod event_filter;
 pub mod stream;
 
 #[derive(Error, Debug, Clone)]

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -30,7 +30,7 @@ use crate::{broadcast, cosmos, event_sub, monitoring, tofnd};
 
 mod blockchain_service;
 mod crypto_service;
-mod reqs;
+pub(crate) mod reqs; // TODO: remove pub(crate)
 mod status;
 
 #[derive(Error, Debug)]

--- a/ampd/src/grpc/mod.rs
+++ b/ampd/src/grpc/mod.rs
@@ -30,7 +30,7 @@ use crate::{broadcast, cosmos, event_sub, monitoring, tofnd};
 
 mod blockchain_service;
 mod crypto_service;
-pub(crate) mod reqs; // TODO: remove pub(crate)
+mod reqs;
 mod status;
 
 #[derive(Error, Debug)]

--- a/ampd/src/grpc/reqs.rs
+++ b/ampd/src/grpc/reqs.rs
@@ -143,7 +143,7 @@ pub enum Error {
     InvalidChainName(String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum EventFilter {
     EventType(nonempty::String),
     Contract(TMAddress),
@@ -184,13 +184,20 @@ impl EventFilter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct EventFilters {
     filters: Vec<EventFilter>,
     include_block_begin_end: bool,
 }
 
 impl EventFilters {
+    pub fn new(filters: Vec<EventFilter>, include_block_begin_end: bool) -> Self {
+        Self {
+            filters,
+            include_block_begin_end,
+        }
+    }
+
     pub fn filter(&self, event: &events::Event) -> bool {
         let contract = event.contract_address();
 

--- a/ampd/src/grpc/reqs.rs
+++ b/ampd/src/grpc/reqs.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use ampd_proto::{
     Algorithm, BroadcastRequest, ContractStateRequest, ContractsRequest, KeyId, KeyRequest,
     SignRequest, SubscribeRequest,
@@ -7,12 +5,13 @@ use ampd_proto::{
 use axelar_wasm_std::chain::ChainName;
 use axelar_wasm_std::nonempty;
 use cosmrs::Any;
-use error_stack::{bail, ensure, report, Report, Result, ResultExt};
+use error_stack::{bail, ensure, report, Result, ResultExt};
 use thiserror::Error;
 use tonic::Request;
 
-use crate::types::{AxelarAddress, TMAddress};
-use crate::{tofnd, PREFIX};
+use crate::event_sub::event_filter::EventFilters;
+use crate::tofnd;
+use crate::types::AxelarAddress;
 
 type ContractQuery = Vec<u8>;
 type KeyIdString = nonempty::String;
@@ -33,7 +32,8 @@ impl Validate for Request<SubscribeRequest> {
             include_block_begin_end,
         } = self.into_inner();
 
-        (filters, include_block_begin_end).try_into()
+        EventFilters::try_from((filters, include_block_begin_end))
+            .change_context(Error::InvalidFilter)
     }
 }
 
@@ -63,17 +63,6 @@ impl Validate for Request<ContractStateRequest> {
 
         Ok((contract, query))
     }
-}
-
-fn validate_address(address: &str) -> Result<AxelarAddress, Error> {
-    let address = AxelarAddress::from_str(address)
-        .change_context(Error::InvalidContractAddress(address.to_string()))?;
-    ensure!(
-        address.prefix() == PREFIX,
-        Error::InvalidContractAddress(address.to_string())
-    );
-
-    Ok(address)
 }
 
 impl Validate for Request<ContractsRequest> {
@@ -128,8 +117,8 @@ fn validate_key_id(key_id: KeyId) -> Result<(KeyIdString, tofnd::Algorithm), Err
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("empty filter")]
-    EmptyFilter,
+    #[error("invalid filter")]
+    InvalidFilter,
     #[error("invalid contract address {0}")]
     InvalidContractAddress(String),
     #[error("invalid query")]
@@ -146,109 +135,6 @@ pub enum Error {
     InvalidChainName(String),
 }
 
-#[derive(Clone, Debug)]
-pub enum EventFilter {
-    EventType(nonempty::String),
-    Contract(AxelarAddress),
-    EventTypeAndContract(nonempty::String, AxelarAddress),
-}
-
-impl TryFrom<ampd_proto::EventFilter> for EventFilter {
-    type Error = Report<Error>;
-
-    fn try_from(event_filter: ampd_proto::EventFilter) -> Result<Self, Error> {
-        let event_type = event_filter.r#type.try_into().ok();
-        let contract = if event_filter.contract.is_empty() {
-            None
-        } else {
-            let contract = event_filter
-                .contract
-                .parse::<AxelarAddress>()
-                .change_context(Error::InvalidContractAddress(event_filter.contract))?;
-
-            Some(contract)
-        };
-
-        match (event_type, contract) {
-            (Some(event_type), Some(contract)) => {
-                Ok(EventFilter::EventTypeAndContract(event_type, contract))
-            }
-            (Some(event_type), None) => Ok(EventFilter::EventType(event_type)),
-            (None, Some(contract)) => Ok(EventFilter::Contract(contract)),
-            (None, None) => Err(report!(Error::EmptyFilter)),
-        }
-    }
-}
-
-impl EventFilter {
-    pub fn filter(&self, event_type: &str, contract: Option<&TMAddress>) -> bool {
-        match self {
-            EventFilter::EventType(event_type_filter) => event_type_filter == event_type,
-            EventFilter::Contract(contract_filter) => Some(contract_filter.as_ref()) == contract,
-            EventFilter::EventTypeAndContract(event_type_filter, contract_filter) => {
-                event_type_filter == event_type && Some(contract_filter.as_ref()) == contract
-            }
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct EventFilters {
-    filters: Vec<EventFilter>,
-    include_block_begin_end: bool,
-}
-
-impl EventFilters {
-    pub fn new(filters: Vec<EventFilter>, include_block_begin_end: bool) -> Self {
-        Self {
-            filters,
-            include_block_begin_end,
-        }
-    }
-
-    pub fn filter(&self, event: &events::Event) -> bool {
-        let contract = event.contract_address();
-
-        match event {
-            events::Event::BlockBegin(_) | events::Event::BlockEnd(_) => {
-                self.include_block_begin_end
-            }
-            events::Event::Abci { event_type, .. } => self.filter_abci_event(event_type, contract),
-        }
-    }
-
-    fn filter_abci_event<T>(&self, event_type: &str, contract: Option<T>) -> bool
-    where
-        T: Into<TMAddress>,
-    {
-        if self.filters.is_empty() {
-            return true;
-        }
-
-        let contract = contract.map(Into::into);
-
-        self.filters
-            .iter()
-            .any(|filter| filter.filter(event_type, contract.as_ref()))
-    }
-}
-
-impl TryFrom<(Vec<ampd_proto::EventFilter>, bool)> for EventFilters {
-    type Error = Report<Error>;
-
-    fn try_from(
-        (event_filters, include_block_begin_end): (Vec<ampd_proto::EventFilter>, bool),
-    ) -> Result<Self, Error> {
-        Ok(EventFilters {
-            filters: event_filters
-                .into_iter()
-                .map(EventFilter::try_from)
-                .collect::<Result<_, _>>()?,
-            include_block_begin_end,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::iter;
@@ -259,112 +145,7 @@ mod tests {
 
     use super::*;
     use crate::types::TMAddress;
-
-    #[test]
-    fn event_filter_should_be_created_from_valid_event_type() {
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "test_event".to_string(),
-            contract: "".to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-        assert!(matches!(filter, EventFilter::EventType(_)));
-    }
-
-    #[test]
-    fn event_filter_should_be_created_from_valid_contract_address() {
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "".to_string(),
-            contract: TMAddress::random(PREFIX).to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-        assert!(matches!(filter, EventFilter::Contract(_)));
-    }
-
-    #[test]
-    fn event_filter_should_be_created_from_valid_event_type_and_contract_address() {
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "test_event".to_string(),
-            contract: TMAddress::random(PREFIX).to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-        assert!(matches!(filter, EventFilter::EventTypeAndContract(_, _)));
-    }
-
-    #[test]
-    fn event_filter_should_fail_for_empty_filter() {
-        let proto_filter = ampd_proto::EventFilter::default();
-
-        let result = EventFilter::try_from(proto_filter);
-        assert_err_contains!(result, Error, Error::EmptyFilter);
-    }
-
-    #[test]
-    fn event_filter_should_fail_for_invalid_contract_address() {
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "".to_string(),
-            contract: "invalid_address".to_string(),
-        };
-
-        let result = EventFilter::try_from(proto_filter);
-        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
-    }
-
-    #[test]
-    fn event_filter_should_fail_for_contract_with_wrong_prefix() {
-        let address = TMAddress::random("wrong");
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "".to_string(),
-            contract: address.to_string(),
-        };
-
-        let result = EventFilter::try_from(proto_filter);
-        assert_err_contains!(result, Error, Error::InvalidContractAddress(_));
-    }
-
-    #[test]
-    fn event_filter_should_match_by_event_type() {
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "test_event".to_string(),
-            contract: "".to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-        assert!(filter.filter("test_event", None));
-        assert!(!filter.filter("other_event", None));
-    }
-
-    #[test]
-    fn event_filter_should_match_by_contract() {
-        let address = TMAddress::random(PREFIX);
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "".to_string(),
-            contract: address.to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-
-        assert!(filter.filter("any_event", Some(&address)));
-        assert!(!filter.filter("any_event", Some(&TMAddress::random(PREFIX))));
-        assert!(!filter.filter("any_event", None));
-    }
-
-    #[test]
-    fn event_filter_should_match_by_both_event_type_and_contract() {
-        let address = TMAddress::random(PREFIX);
-        let proto_filter = ampd_proto::EventFilter {
-            r#type: "test_event".to_string(),
-            contract: address.to_string(),
-        };
-
-        let filter = EventFilter::try_from(proto_filter).unwrap();
-
-        assert!(filter.filter("test_event", Some(&address)));
-        assert!(!filter.filter("other_event", Some(&address)));
-        assert!(!filter.filter("test_event", Some(&TMAddress::random(PREFIX))));
-    }
+    use crate::PREFIX;
 
     #[test]
     fn event_filters_should_be_created_from_valid_proto_filters() {
@@ -395,7 +176,7 @@ mod tests {
         });
 
         let result = req.validate();
-        assert_err_contains!(result, Error, Error::EmptyFilter);
+        assert_err_contains!(result, Error, Error::InvalidFilter);
     }
 
     #[test]
@@ -517,7 +298,7 @@ mod tests {
 
     #[test]
     fn validate_contract_state_should_extract_contract_and_query() {
-        let address = AxelarAddress::random(PREFIX);
+        let address = AxelarAddress::random();
         let query_json = serde_json::json!({"get_config": {}});
         let query_bytes = serde_json::to_vec(&query_json).unwrap();
 

--- a/ampd/src/grpc/status.rs
+++ b/ampd/src/grpc/status.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn reqs_errors_to_status() {
-        let empty_filter = reqs::Error::EmptyFilter;
+        let empty_filter = reqs::Error::InvalidFilter;
         let invalid_contract_address =
             reqs::Error::InvalidContractAddress("invalid_contract_address".to_string());
         let invalid_query = reqs::Error::InvalidQuery;

--- a/ampd/src/grpc/testdata/reqs_errors_to_status.golden
+++ b/ampd/src/grpc/testdata/reqs_errors_to_status.golden
@@ -1,7 +1,7 @@
 [
     (
         InvalidArgument,
-        EmptyFilter,
+        InvalidFilter,
     ),
     (
         InvalidArgument,

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -21,11 +21,11 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::evm::finalizer;
 use crate::evm::finalizer::Finalization;
 use crate::evm::json_rpc::EthereumClient;
 use crate::evm::verifier::verify_message;
-use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -3,15 +3,14 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use ethers_core::types::{TransactionReceipt, U64};
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use futures::future::join_all;
 use router_api::ChainName;
 use serde::Deserialize;
@@ -239,7 +238,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/evm_verify_msg.rs
+++ b/ampd/src/handlers/evm_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -24,6 +25,7 @@ use crate::evm::finalizer;
 use crate::evm::finalizer::Finalization;
 use crate::evm::json_rpc::EthereumClient;
 use crate::evm::verifier::verify_message;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;
@@ -232,6 +234,16 @@ where
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/evm_verify_verifier_set.rs
+++ b/ampd/src/handlers/evm_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -23,6 +24,7 @@ use crate::evm::finalizer;
 use crate::evm::finalizer::Finalization;
 use crate::evm::json_rpc::EthereumClient;
 use crate::evm::verifier::verify_verifier_set;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -206,6 +208,16 @@ where
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/evm_verify_verifier_set.rs
+++ b/ampd/src/handlers/evm_verify_verifier_set.rs
@@ -20,11 +20,11 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::evm::finalizer;
 use crate::evm::finalizer::Finalization;
 use crate::evm::json_rpc::EthereumClient;
 use crate::evm::verifier::verify_verifier_set;
-use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/evm_verify_verifier_set.rs
+++ b/ampd/src/handlers/evm_verify_verifier_set.rs
@@ -2,15 +2,14 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use ethers_core::types::{TransactionReceipt, U64};
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use multisig::verifier_set::VerifierSet;
 use router_api::ChainName;
 use serde::Deserialize;
@@ -213,7 +212,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use async_trait::async_trait;
+use axelar_wasm_std::nonempty_str;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
@@ -18,6 +19,7 @@ use tokio::sync::watch::Receiver;
 use tracing::info;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error::{self, DeserializeEvent, MessageToSign};
 use crate::tofnd::{self, Multisig};
 use crate::types::{PublicKey, TMAddress};
@@ -171,6 +173,16 @@ where
                 Ok(vec![])
             }
         }
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-signing_started"),
+                self.multisig.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -2,13 +2,12 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use async_trait::async_trait;
-use axelar_wasm_std::nonempty_str;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use cosmwasm_std::{HexBinary, Uint64};
 use error_stack::ResultExt;
-use events::try_from;
+use events::{try_from, EventType};
 use hex::encode;
 use multisig::msg::ExecuteMsg;
 use multisig::types::MsgToSign;
@@ -178,7 +177,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-signing_started"),
+                SigningStartedEvent::event_type(),
                 self.multisig.clone(),
             )],
             true,

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -19,7 +19,7 @@ use tokio::sync::watch::Receiver;
 use tracing::info;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error::{self, DeserializeEvent, MessageToSign};
 use crate::tofnd::{self, Multisig};
 use crate::types::{PublicKey, TMAddress};

--- a/ampd/src/handlers/mvx_verify_msg.rs
+++ b/ampd/src/handlers/mvx_verify_msg.rs
@@ -21,7 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/mvx_verify_msg.rs
+++ b/ampd/src/handlers/mvx_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -20,6 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -185,6 +187,16 @@ where
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/mvx_verify_msg.rs
+++ b/ampd/src/handlers/mvx_verify_msg.rs
@@ -3,14 +3,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use multiversx_sdk::data::address::Address;
 use router_api::{chain_name, ChainName};
@@ -192,7 +191,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/mvx_verify_verifier_set.rs
+++ b/ampd/src/handlers/mvx_verify_verifier_set.rs
@@ -2,14 +2,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use multisig::verifier_set::VerifierSet;
 use multiversx_sdk::data::address::Address;
@@ -172,7 +171,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/mvx_verify_verifier_set.rs
+++ b/ampd/src/handlers/mvx_verify_verifier_set.rs
@@ -21,7 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/mvx_verify_verifier_set.rs
+++ b/ampd/src/handlers/mvx_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -20,6 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -165,6 +167,16 @@ where
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/solana_verify_msg.rs
+++ b/ampd/src/handlers/solana_verify_msg.rs
@@ -21,7 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;

--- a/ampd/src/handlers/solana_verify_msg.rs
+++ b/ampd/src/handlers/solana_verify_msg.rs
@@ -3,14 +3,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58SolanaTxSignatureAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use router_api::ChainName;
 use serde::Deserialize;
 use solana_sdk::pubkey::Pubkey;
@@ -191,7 +190,7 @@ impl<C: SolanaRpcClientProxy> EventHandler for Handler<C> {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/solana_verify_msg.rs
+++ b/ampd/src/handlers/solana_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58SolanaTxSignatureAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -20,6 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;
@@ -184,6 +186,16 @@ impl<C: SolanaRpcClientProxy> EventHandler for Handler<C> {
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/solana_verify_verifier_set.rs
+++ b/ampd/src/handlers/solana_verify_verifier_set.rs
@@ -20,7 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/solana_verify_verifier_set.rs
+++ b/ampd/src/handlers/solana_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58SolanaTxSignatureAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -19,6 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -177,6 +179,16 @@ impl<C: SolanaRpcClientProxy> EventHandler for Handler<C> {
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/solana_verify_verifier_set.rs
+++ b/ampd/src/handlers/solana_verify_verifier_set.rs
@@ -2,14 +2,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58SolanaTxSignatureAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use multisig::verifier_set::VerifierSet;
 use router_api::ChainName;
 use serde::Deserialize;
@@ -184,7 +183,7 @@ impl<C: SolanaRpcClientProxy> EventHandler for Handler<C> {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/stacks_verify_msg.rs
+++ b/ampd/src/handlers/stacks_verify_msg.rs
@@ -3,7 +3,6 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use clarity_serialization::types::{PrincipalData, TypeSignature};
 use cosmrs::cosmwasm::MsgExecuteContract;
@@ -11,7 +10,7 @@ use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use router_api::ChainName;
 use serde::Deserialize;
 use tokio::sync::watch::Receiver;
@@ -208,7 +207,7 @@ impl EventHandler for Handler {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/stacks_verify_msg.rs
+++ b/ampd/src/handlers/stacks_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use clarity_serialization::types::{PrincipalData, TypeSignature};
 use cosmrs::cosmwasm::MsgExecuteContract;
@@ -19,6 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -201,6 +203,16 @@ impl EventHandler for Handler {
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/stacks_verify_msg.rs
+++ b/ampd/src/handlers/stacks_verify_msg.rs
@@ -20,7 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/stacks_verify_verifier_set.rs
+++ b/ampd/src/handlers/stacks_verify_verifier_set.rs
@@ -20,7 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/stacks_verify_verifier_set.rs
+++ b/ampd/src/handlers/stacks_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use clarity_serialization::types::{PrincipalData, TypeSignature};
 use cosmrs::cosmwasm::MsgExecuteContract;
@@ -19,6 +20,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -181,6 +183,16 @@ impl EventHandler for Handler {
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/stacks_verify_verifier_set.rs
+++ b/ampd/src/handlers/stacks_verify_verifier_set.rs
@@ -2,7 +2,6 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use clarity_serialization::types::{PrincipalData, TypeSignature};
 use cosmrs::cosmwasm::MsgExecuteContract;
@@ -10,7 +9,7 @@ use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use multisig::verifier_set::VerifierSet;
 use router_api::ChainName;
 use serde::Deserialize;
@@ -188,7 +187,7 @@ impl EventHandler for Handler {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/starknet_verify_msg.rs
+++ b/ampd/src/handlers/starknet_verify_msg.rs
@@ -21,7 +21,7 @@ use tracing::info;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;

--- a/ampd/src/handlers/starknet_verify_msg.rs
+++ b/ampd/src/handlers/starknet_verify_msg.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::FieldElementAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -20,6 +21,7 @@ use tracing::info;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;
@@ -165,6 +167,16 @@ where
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/starknet_verify_msg.rs
+++ b/ampd/src/handlers/starknet_verify_msg.rs
@@ -2,14 +2,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::FieldElementAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use futures::future::join_all;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -172,7 +171,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier.clone(),
             )],
             true,

--- a/ampd/src/handlers/starknet_verify_verifier_set.rs
+++ b/ampd/src/handlers/starknet_verify_verifier_set.rs
@@ -24,7 +24,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/starknet_verify_verifier_set.rs
+++ b/ampd/src/handlers/starknet_verify_verifier_set.rs
@@ -6,14 +6,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::FieldElementAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use multisig::verifier_set::VerifierSet;
 use router_api::{chain_name, ChainName};
@@ -180,7 +179,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/starknet_verify_verifier_set.rs
+++ b/ampd/src/handlers/starknet_verify_verifier_set.rs
@@ -6,6 +6,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::FieldElementAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -23,6 +24,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -173,6 +175,16 @@ where
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -21,6 +22,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;
@@ -181,6 +183,16 @@ impl EventHandler for Handler {
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -3,14 +3,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use router_api::{chain_name, ChainName};
 use serde::Deserialize;
@@ -188,7 +187,7 @@ impl EventHandler for Handler {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/stellar_verify_msg.rs
+++ b/ampd/src/handlers/stellar_verify_msg.rs
@@ -22,7 +22,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;

--- a/ampd/src/handlers/stellar_verify_verifier_set.rs
+++ b/ampd/src/handlers/stellar_verify_verifier_set.rs
@@ -2,14 +2,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use multisig::verifier_set::VerifierSet;
 use router_api::{chain_name, ChainName};
@@ -168,7 +167,7 @@ impl EventHandler for Handler {
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/stellar_verify_verifier_set.rs
+++ b/ampd/src/handlers/stellar_verify_verifier_set.rs
@@ -22,7 +22,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;

--- a/ampd/src/handlers/stellar_verify_verifier_set.rs
+++ b/ampd/src/handlers/stellar_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -21,6 +22,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
 use crate::monitoring;
@@ -161,6 +163,16 @@ impl EventHandler for Handler {
             .vote_msg(poll_id, vec![vote])
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -3,14 +3,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58TxDigestAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use router_api::{chain_name, ChainName};
 use serde::Deserialize;
@@ -173,7 +172,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58TxDigestAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -19,6 +20,7 @@ use tracing::info;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -166,6 +168,16 @@ where
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/sui_verify_msg.rs
+++ b/ampd/src/handlers/sui_verify_msg.rs
@@ -20,7 +20,7 @@ use tracing::info;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/sui_verify_verifier_set.rs
+++ b/ampd/src/handlers/sui_verify_verifier_set.rs
@@ -21,7 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/sui_verify_verifier_set.rs
+++ b/ampd/src/handlers/sui_verify_verifier_set.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58TxDigestAndEventIndex;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -20,6 +21,7 @@ use valuable::Valuable;
 use voting_verifier::msg::ExecuteMsg;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -164,6 +166,16 @@ where
             .vote_msg(poll_id, vote)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-verifier_set_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/sui_verify_verifier_set.rs
+++ b/ampd/src/handlers/sui_verify_verifier_set.rs
@@ -2,14 +2,13 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::Base58TxDigestAndEventIndex;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
 use events::Error::EventTypeMismatch;
-use events::{try_from, Event};
+use events::{try_from, Event, EventType};
 use lazy_static::lazy_static;
 use multisig::verifier_set::VerifierSet;
 use router_api::{chain_name, ChainName};
@@ -171,7 +170,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-verifier_set_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/handlers/xrpl_multisig.rs
+++ b/ampd/src/handlers/xrpl_multisig.rs
@@ -21,7 +21,7 @@ use tracing::info;
 use xrpl_types::types::XRPLAccountId;
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error::{self, DeserializeEvent};
 use crate::tofnd::{Algorithm, Multisig};
 use crate::types::{PublicKey, TMAddress};

--- a/ampd/src/handlers/xrpl_multisig.rs
+++ b/ampd/src/handlers/xrpl_multisig.rs
@@ -2,14 +2,13 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use async_trait::async_trait;
-use axelar_wasm_std::nonempty_str;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use cosmwasm_std::{HexBinary, Uint64};
 use error_stack::ResultExt;
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use hex::encode;
 use multisig::msg::ExecuteMsg;
 use multisig::types::MsgToSign;
@@ -186,7 +185,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-signing_started"),
+                SigningStartedEvent::event_type(),
                 self.multisig.clone(),
             )],
             true,

--- a/ampd/src/handlers/xrpl_multisig.rs
+++ b/ampd/src/handlers/xrpl_multisig.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use async_trait::async_trait;
+use axelar_wasm_std::nonempty_str;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
@@ -20,6 +21,7 @@ use tracing::info;
 use xrpl_types::types::XRPLAccountId;
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error::{self, DeserializeEvent};
 use crate::tofnd::{Algorithm, Multisig};
 use crate::types::{PublicKey, TMAddress};
@@ -179,6 +181,16 @@ where
                 Ok(vec![])
             }
         }
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-signing_started"),
+                self.multisig.clone(),
+            )],
+            true,
+        )
     }
 }
 

--- a/ampd/src/handlers/xrpl_verify_msg.rs
+++ b/ampd/src/handlers/xrpl_verify_msg.rs
@@ -25,7 +25,7 @@ use xrpl_types::msg::XRPLMessage;
 use xrpl_types::types::{xrpl_account_id_string, XRPLAccountId};
 
 use crate::event_processor::EventHandler;
-use crate::grpc::reqs::{EventFilter, EventFilters};
+use crate::event_sub::event_filter::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;

--- a/ampd/src/handlers/xrpl_verify_msg.rs
+++ b/ampd/src/handlers/xrpl_verify_msg.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHash;
+use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
@@ -24,6 +25,7 @@ use xrpl_types::msg::XRPLMessage;
 use xrpl_types::types::{xrpl_account_id_string, XRPLAccountId};
 
 use crate::event_processor::EventHandler;
+use crate::grpc::reqs::{EventFilter, EventFilters};
 use crate::handlers::errors::Error;
 use crate::monitoring;
 use crate::monitoring::metrics;
@@ -202,5 +204,15 @@ where
             .vote_msg(poll_id, votes)
             .into_any()
             .expect("vote msg should serialize")])
+    }
+
+    fn event_filters(&self) -> EventFilters {
+        EventFilters::new(
+            vec![EventFilter::EventTypeAndContract(
+                nonempty_str!("wasm-messages_poll_started"),
+                self.voting_verifier_contract.clone(),
+            )],
+            true,
+        )
     }
 }

--- a/ampd/src/handlers/xrpl_verify_msg.rs
+++ b/ampd/src/handlers/xrpl_verify_msg.rs
@@ -4,14 +4,13 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use axelar_wasm_std::msg_id::HexTxHash;
-use axelar_wasm_std::nonempty_str;
 use axelar_wasm_std::voting::{PollId, Vote};
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Any;
 use error_stack::ResultExt;
-use events::try_from;
 use events::Error::EventTypeMismatch;
+use events::{try_from, EventType};
 use futures::future::join_all;
 use lazy_static::lazy_static;
 use router_api::{chain_name, ChainName};
@@ -209,7 +208,7 @@ where
     fn event_filters(&self) -> EventFilters {
         EventFilters::new(
             vec![EventFilter::EventTypeAndContract(
-                nonempty_str!("wasm-messages_poll_started"),
+                PollStartedEvent::event_type(),
                 self.voting_verifier_contract.clone(),
             )],
             true,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -53,6 +53,7 @@ use starknet_providers::jsonrpc::HttpTransport;
 use thiserror::Error;
 use tofnd::{Multisig, MultisigClient};
 use tokio::signal::unix::{signal, SignalKind};
+use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use types::{CosmosPublicKey, TMAddress};
@@ -722,7 +723,14 @@ impl App {
         H: EventHandler + Send + Sync + 'static,
     {
         let label = label.as_ref().to_string();
-        let event_sub = self.event_subscriber.subscribe();
+        let filters = handler.event_filters();
+        let event_sub = self
+            .event_subscriber
+            .subscribe()
+            .filter(move |event| match event {
+                Ok(event) => filters.filter(event),
+                Err(_) => true,
+            });
         let msg_queue_client = self.msg_queue_client.clone();
 
         CancellableTask::create(|token| {

--- a/ampd/src/types/mod.rs
+++ b/ampd/src/types/mod.rs
@@ -4,8 +4,13 @@ use std::str::FromStr;
 
 use cosmrs::AccountId;
 use deref_derive::Deref;
+use error_stack::{ensure, Report};
 use ethers_core::types::{Address, H256};
+use report::ResultCompatExt;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::PREFIX;
 
 pub mod debug;
 mod key;
@@ -16,6 +21,15 @@ pub use key::{CosmosPublicKey, PublicKey};
 
 pub type EVMAddress = Address;
 pub type Hash = H256;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid Axelar address {0}")]
+    InvalidAxelarAddress(String),
+
+    #[error("invalid prefix for Axelar address {0}")]
+    InvalidAxelarAddressPrefix(String),
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Deref)]
 pub struct TMAddress(AccountId);
@@ -52,10 +66,63 @@ impl fmt::Display for TMAddress {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Deref)]
+pub struct AxelarAddress(TMAddress);
+
+impl TryFrom<TMAddress> for AxelarAddress {
+    type Error = Report<Error>;
+
+    fn try_from(value: TMAddress) -> error_stack::Result<AxelarAddress, Error> {
+        ensure!(
+            value.prefix() == PREFIX,
+            Error::InvalidAxelarAddressPrefix(value.to_string())
+        );
+
+        Ok(Self(value))
+    }
+}
+
+impl From<AxelarAddress> for TMAddress {
+    fn from(value: AxelarAddress) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for AxelarAddress {
+    type Err = Report<Error>;
+
+    fn from_str(s: &str) -> error_stack::Result<AxelarAddress, Error> {
+        let value =
+            TMAddress::from_str(s).change_context(Error::InvalidAxelarAddress(s.to_string()))?;
+        value.try_into()
+    }
+}
+
+impl TryFrom<AccountId> for AxelarAddress {
+    type Error = Report<Error>;
+
+    fn try_from(account_id: AccountId) -> error_stack::Result<AxelarAddress, Error> {
+        let value = TMAddress::from(account_id);
+        value.try_into()
+    }
+}
+
+impl AsRef<TMAddress> for AxelarAddress {
+    fn as_ref(&self) -> &TMAddress {
+        &self.0
+    }
+}
+
+impl fmt::Display for AxelarAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[cfg(test)]
 pub mod test_utils {
     use super::key::test_utils::random_cosmos_public_key;
-    use crate::types::TMAddress;
+    use crate::types::{AxelarAddress, TMAddress};
 
     impl TMAddress {
         pub fn random(prefix: &str) -> Self {
@@ -64,6 +131,12 @@ pub mod test_utils {
                     .account_id(prefix)
                     .expect("failed to convert to account identifier"),
             )
+        }
+    }
+
+    impl AxelarAddress {
+        pub fn random(prefix: &str) -> Self {
+            Self(TMAddress::random(prefix))
         }
     }
 }

--- a/ampd/src/types/mod.rs
+++ b/ampd/src/types/mod.rs
@@ -123,6 +123,7 @@ impl fmt::Display for AxelarAddress {
 pub mod test_utils {
     use super::key::test_utils::random_cosmos_public_key;
     use crate::types::{AxelarAddress, TMAddress};
+    use crate::PREFIX;
 
     impl TMAddress {
         pub fn random(prefix: &str) -> Self {
@@ -135,8 +136,8 @@ pub mod test_utils {
     }
 
     impl AxelarAddress {
-        pub fn random(prefix: &str) -> Self {
-            Self(TMAddress::random(prefix))
+        pub fn random() -> Self {
+            Self(TMAddress::random(PREFIX))
         }
     }
 }

--- a/packages/events-derive/Cargo.toml
+++ b/packages/events-derive/Cargo.toml
@@ -10,6 +10,7 @@ edition = { workspace = true }
 proc-macro = true
 
 [dependencies]
+axelar-wasm-std = { workspace = true }
 error-stack = { workspace = true }
 quote = { workspace = true }
 serde = "1.0.183"

--- a/packages/events-derive/src/lib.rs
+++ b/packages/events-derive/src/lib.rs
@@ -70,5 +70,11 @@ pub fn try_from(arg: TokenStream, input: TokenStream) -> TokenStream {
                 Self::try_from(&event)
             }
         }
+
+        impl _internal_events::EventType for #event_struct {
+            fn event_type() -> axelar_wasm_std::nonempty::String {
+                axelar_wasm_std::nonempty_str!(#event_type)
+            }
+        }
     })
 }

--- a/packages/events-derive/tests/macro.rs
+++ b/packages/events-derive/tests/macro.rs
@@ -1,4 +1,5 @@
 use error_stack::{Result, ResultExt};
+use events::EventType;
 use serde::Deserialize;
 
 #[allow(dead_code)]
@@ -62,4 +63,9 @@ fn convert_matching_event() {
 
     let res: Result<TestEvent, events::Error> = correct_event.try_into();
     assert!(res.is_ok());
+}
+
+#[test]
+fn struct_implements_event_type_trait() {
+    assert_eq!(TestEvent::event_type(), "test_event");
 }

--- a/packages/events/src/event.rs
+++ b/packages/events/src/event.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
-use axelar_wasm_std::FnExt;
+use axelar_wasm_std::{nonempty, FnExt};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use cosmrs::AccountId;
@@ -191,6 +191,10 @@ impl TryFrom<ampd_proto::subscribe_response::Event> for Event {
             }),
         }
     }
+}
+
+pub trait EventType {
+    fn event_type() -> nonempty::String;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
This will add the ability to filter events for event handlers, reducing overhead and preventing the monitoring server to be saturated

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
