### PR TITLE
fix(multisig): remove duplicate prover chain mappings for multisig migration

### DIFF
--- a/contracts/multisig/src/contract/migrations/mod.rs
+++ b/contracts/multisig/src/contract/migrations/mod.rs
@@ -46,9 +46,7 @@ fn migrate_authorized_callers(
     let authorized_callers: Vec<_> = AUTHORIZED_CALLERS
         .range(deps.storage, None, None, Order::Ascending)
         .filter_map(|value| value.ok())
-        .dedup_by(|&(_, ref chain_name_a), &(_, ref chain_name_b)| {
-            chain_name_a == chain_name_b
-        })
+        .dedup_by(|(_, chain_name_a), (_, chain_name_b)| chain_name_a == chain_name_b)
         .collect();
 
     for (contract_address, chain_name) in authorized_callers {
@@ -156,15 +154,14 @@ mod tests {
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), None);
 
-        let res = migrate(
+        assert!(migrate(
             deps.as_mut(),
             env,
             MigrateMsg {
                 coordinator: cosmos_addr!(COORDINATOR).to_string(),
             },
-        );
-
-        assert!(res.is_ok());
+        )
+        .is_ok());
 
         let res = prover_by_chain(&deps.storage, chain_name!("chain1"));
         assert!(res.is_ok());


### PR DESCRIPTION
## Description

Multisig v2.3 enforces that there is a 1-to-1 mapping between authorized multisig prover and chain. Multisig v2.1 does not enforce this constraint. This has unfortunately led to situations where the multisig on devnet maps multiple provers to a single chain. This change forces the the migration code to choose one prover per chain.

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
