### PR TITLE
chore(ampd): add name to task runs

### DIFF
--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -285,8 +285,8 @@ impl App {
                 )
                 .await
             {
-                Ok(task) => {
-                    self.event_processor = self.event_processor.add_task(task);
+                Ok((task_name, task)) => {
+                    self.event_processor = self.event_processor.add_task(task_name, task);
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, config = ?config,
@@ -305,7 +305,7 @@ impl App {
         verifier: &TMAddress,
         event_processor_config: &event_processor::Config,
         default_rpc_timeout: Duration,
-    ) -> Result<CancellableTask<Result<(), event_processor::Error>>, Error> {
+    ) -> Result<(String, CancellableTask<Result<(), event_processor::Error>>), Error> {
         match config {
             handlers::config::Config::EvmMsgVerifier {
                 chain,
@@ -325,19 +325,23 @@ impl App {
 
                 check_finalizer(&chain.name, &chain.finalization, &rpc_client).await?;
 
-                Ok(self.create_handler_task(
-                    format!("{}-msg-verifier", chain.name),
-                    handlers::evm_verify_msg::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        chain.name.clone(),
-                        chain.finalization.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-msg-verifier", chain.name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::evm_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain.name.clone(),
+                            chain.finalization.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::EvmVerifierSetVerifier {
@@ -358,61 +362,77 @@ impl App {
 
                 check_finalizer(&chain.name, &chain.finalization, &rpc_client).await?;
 
-                Ok(self.create_handler_task(
-                    format!("{}-verifier-set-verifier", chain.name),
-                    handlers::evm_verify_verifier_set::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        chain.name.clone(),
-                        chain.finalization.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-verifier-set-verifier", chain.name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::evm_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain.name.clone(),
+                            chain.finalization.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::MultisigSigner {
                 cosmwasm_contract,
                 chain_name,
-            } => Ok(self.create_handler_task(
-                "multisig-signer",
-                handlers::multisig::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    chain_name.clone(),
-                    self.multisig_client.clone(),
-                    self.block_height_monitor.latest_block_height(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+            } => {
+                let task_name = "multisig-signer".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::multisig::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain_name.clone(),
+                            self.multisig_client.clone(),
+                            self.block_height_monitor.latest_block_height(),
+                        ),
+                        event_processor_config.clone(),
+                        self.monitoring_client.clone(),
+                    ),
+                ))
+            }
             handlers::config::Config::SuiMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "sui-msg-verifier",
-                handlers::sui_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    json_rpc::Client::new_http(
-                        rpc_url.clone(),
-                        reqwest::ClientBuilder::new()
-                            .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .build()
-                            .change_context(Error::Connection)?,
+            } => {
+                let task_name = "sui-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::sui_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            json_rpc::Client::new_http(
+                                rpc_url.clone(),
+                                reqwest::ClientBuilder::new()
+                                    .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .build()
+                                    .change_context(Error::Connection)?,
+                                self.monitoring_client.clone(),
+                                SUI_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        SUI_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::XRPLMsgVerifier {
                 cosmwasm_contract,
                 chain_name,
@@ -436,278 +456,358 @@ impl App {
                     chain_name.clone(),
                 );
 
-                Ok(self.create_handler_task(
-                    format!("{}-msg-verifier", chain_name),
-                    handlers::xrpl_verify_msg::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-msg-verifier", chain_name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::xrpl_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::XRPLMultisigSigner {
                 cosmwasm_contract,
                 chain_name,
-            } => Ok(self.create_handler_task(
-                "xrpl-multisig-signer",
-                handlers::xrpl_multisig::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    chain_name.clone(),
-                    self.multisig_client.clone(),
-                    self.block_height_monitor.latest_block_height(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+            } => {
+                let task_name = "xrpl-multisig-signer".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::xrpl_multisig::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain_name.clone(),
+                            self.multisig_client.clone(),
+                            self.block_height_monitor.latest_block_height(),
+                        ),
+                        event_processor_config.clone(),
+                        self.monitoring_client.clone(),
+                    ),
+                ))
+            }
             handlers::config::Config::SuiVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "sui-verifier-set-verifier",
-                handlers::sui_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    json_rpc::Client::new_http(
-                        rpc_url.clone(),
-                        reqwest::ClientBuilder::new()
-                            .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .build()
-                            .change_context(Error::Connection)?,
+            } => {
+                let task_name = "sui-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::sui_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            json_rpc::Client::new_http(
+                                rpc_url.clone(),
+                                reqwest::ClientBuilder::new()
+                                    .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .build()
+                                    .change_context(Error::Connection)?,
+                                self.monitoring_client.clone(),
+                                SUI_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        SUI_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::MvxMsgVerifier {
                 cosmwasm_contract,
                 proxy_url,
-            } => Ok(self.create_handler_task(
-                "mvx-msg-verifier",
-                handlers::mvx_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    mvx::proxy::Client::new(
-                        GatewayProxy::new(proxy_url.to_string().trim_end_matches('/').into()),
+            } => {
+                let task_name = "mvx-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::mvx_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            mvx::proxy::Client::new(
+                                GatewayProxy::new(
+                                    proxy_url.to_string().trim_end_matches('/').into(),
+                                ),
+                                self.monitoring_client.clone(),
+                                MULTIVERSX_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        MULTIVERSX_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::MvxVerifierSetVerifier {
                 cosmwasm_contract,
                 proxy_url,
-            } => Ok(self.create_handler_task(
-                "mvx-worker-set-verifier",
-                handlers::mvx_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    mvx::proxy::Client::new(
-                        GatewayProxy::new(proxy_url.to_string().trim_end_matches('/').into()),
+            } => {
+                let task_name = "mvx-worker-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::mvx_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            mvx::proxy::Client::new(
+                                GatewayProxy::new(
+                                    proxy_url.to_string().trim_end_matches('/').into(),
+                                ),
+                                self.monitoring_client.clone(),
+                                MULTIVERSX_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        MULTIVERSX_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::StellarMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "stellar-msg-verifier",
-                handlers::stellar_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    stellar::rpc_client::Client::new(
-                        rpc_url.clone(),
+            } => {
+                let task_name = "stellar-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stellar_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            stellar::rpc_client::Client::new(
+                                rpc_url.clone(),
+                                self.monitoring_client.clone(),
+                                STELLAR_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STELLAR_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StellarVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "stellar-verifier-set-verifier",
-                handlers::stellar_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    stellar::rpc_client::Client::new(
-                        rpc_url.clone(),
+            } => {
+                let task_name = "stellar-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stellar_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            stellar::rpc_client::Client::new(
+                                rpc_url.clone(),
+                                self.monitoring_client.clone(),
+                                STELLAR_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STELLAR_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StarknetMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "starknet-msg-verifier",
-                handlers::starknet_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(
-                        HttpTransport::new(rpc_url.clone()),
+            } => {
+                let task_name = "starknet-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::starknet_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            starknet::json_rpc::Client::new_with_transport(
+                                HttpTransport::new(rpc_url.clone()),
+                                self.monitoring_client.clone(),
+                                STARKNET_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STARKNET_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StarknetVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "starknet-verifier-set-verifier",
-                handlers::starknet_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(
-                        HttpTransport::new(rpc_url.clone()),
+            } => {
+                let task_name = "starknet-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::starknet_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            starknet::json_rpc::Client::new_with_transport(
+                                HttpTransport::new(rpc_url.clone()),
+                                self.monitoring_client.clone(),
+                                STARKNET_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STARKNET_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::SolanaMsgVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "solana-msg-verifier",
-                handlers::solana_verify_msg::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    solana::Client::new(
-                        RpcClient::new_with_timeout_and_commitment(
-                            rpc_url.to_string(),
-                            rpc_timeout.unwrap_or(default_rpc_timeout),
-                            CommitmentConfig::finalized(),
+            } => {
+                let task_name = "solana-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::solana_verify_msg::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            solana::Client::new(
+                                RpcClient::new_with_timeout_and_commitment(
+                                    rpc_url.to_string(),
+                                    rpc_timeout.unwrap_or(default_rpc_timeout),
+                                    CommitmentConfig::finalized(),
+                                ),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
                         ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::SolanaVerifierSetVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "solana-verifier-set-verifier",
-                handlers::solana_verify_verifier_set::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    solana::Client::new(
-                        RpcClient::new_with_timeout_and_commitment(
-                            rpc_url.to_string(),
-                            rpc_timeout.unwrap_or(default_rpc_timeout),
-                            CommitmentConfig::finalized(),
-                        ),
+            } => {
+                let task_name = "solana-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::solana_verify_verifier_set::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            solana::Client::new(
+                                RpcClient::new_with_timeout_and_commitment(
+                                    rpc_url.to_string(),
+                                    rpc_timeout.unwrap_or(default_rpc_timeout),
+                                    CommitmentConfig::finalized(),
+                                ),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .await,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .await,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::StacksMsgVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "stacks-msg-verifier",
-                handlers::stacks_verify_msg::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    Client::new_http(
-                        rpc_url.clone(),
-                        rpc_timeout.unwrap_or(default_rpc_timeout),
+            } => {
+                let task_name = "stacks-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stacks_verify_msg::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            Client::new_http(
+                                rpc_url.clone(),
+                                rpc_timeout.unwrap_or(default_rpc_timeout),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            )?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .change_context(Error::Connection)?,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
-                    )?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .change_context(Error::Connection)?,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StacksVerifierSetVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "stacks-verifier-set-verifier",
-                handlers::stacks_verify_verifier_set::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    Client::new_http(
-                        rpc_url.clone(),
-                        rpc_timeout.unwrap_or(default_rpc_timeout),
+            } => {
+                let task_name = "stacks-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stacks_verify_verifier_set::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            Client::new_http(
+                                rpc_url.clone(),
+                                rpc_timeout.unwrap_or(default_rpc_timeout),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            )?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .change_context(Error::Connection)?,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
-                    )?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .change_context(Error::Connection)?,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
         }
     }
 
@@ -775,33 +875,54 @@ impl App {
         });
 
         TaskGroup::new("ampd")
-            .add_task(CancellableTask::create(|token| {
-                block_height_monitor
-                    .run(token)
-                    .change_context(Error::BlockHeightMonitor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                event_publisher
-                    .run(token)
-                    .change_context(Error::EventPublisher)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                monitoring_server.run(token).change_context(Error::Monitor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                event_processor
-                    .run(token)
-                    .change_context(Error::EventProcessor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                grpc_server.run(token).change_context(Error::GrpcServer)
-            }))
-            .add_task(CancellableTask::create(|_| {
-                tx_confirmer.run().change_context(Error::TxConfirmation)
-            }))
-            .add_task(CancellableTask::create(|_| {
-                broadcaster_task.run().change_context(Error::Broadcaster)
-            }))
+            .add_task(
+                "block-height-monitor",
+                CancellableTask::create(|token| {
+                    block_height_monitor
+                        .run(token)
+                        .change_context(Error::BlockHeightMonitor)
+                }),
+            )
+            .add_task(
+                "event-publisher",
+                CancellableTask::create(|token| {
+                    event_publisher
+                        .run(token)
+                        .change_context(Error::EventPublisher)
+                }),
+            )
+            .add_task(
+                "monitoring-server",
+                CancellableTask::create(|token| {
+                    monitoring_server.run(token).change_context(Error::Monitor)
+                }),
+            )
+            .add_task(
+                "event-processor",
+                CancellableTask::create(|token| {
+                    event_processor
+                        .run(token)
+                        .change_context(Error::EventProcessor)
+                }),
+            )
+            .add_task(
+                "grpc-server",
+                CancellableTask::create(|token| {
+                    grpc_server.run(token).change_context(Error::GrpcServer)
+                }),
+            )
+            .add_task(
+                "tx-confirmer",
+                CancellableTask::create(|_| {
+                    tx_confirmer.run().change_context(Error::TxConfirmation)
+                }),
+            )
+            .add_task(
+                "broadcaster-task",
+                CancellableTask::create(|_| {
+                    broadcaster_task.run().change_context(Error::Broadcaster)
+                }),
+            )
             .run(main_token)
             .await
     }


### PR DESCRIPTION
## Description

This PR adds task name to ampd tasks to help with debugging sub-tasks inside a group.

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
