### PR TITLE
fix(coordinator): coordinator v2 migration defaults to multisig prover addresses

### DIFF
--- a/contracts/coordinator/src/contract/migrations/mod.rs
+++ b/contracts/coordinator/src/contract/migrations/mod.rs
@@ -148,12 +148,12 @@ fn migrate_all_provers(
             .transpose()?
             .or_else(|| provers_by_chain.get(&contracts.chain_name).cloned());
 
-        if let Some(pa) = prover_address {
+        if let Some(addr) = prover_address {
             save_contracts_to_state(
                 deps.storage,
                 ChainContractsRecord {
                     chain_name: contracts.chain_name.clone(),
-                    prover_address: pa,
+                    prover_address: addr,
                     verifier_address: address::validate_cosmwasm_address(
                         deps.api,
                         &contracts.verifier_address,

--- a/contracts/coordinator/src/contract/migrations/mod.rs
+++ b/contracts/coordinator/src/contract/migrations/mod.rs
@@ -144,12 +144,13 @@ fn migrate_all_provers(
             .prover_address
             .as_ref()
             .map(|addr| {
-                provers_by_chain.remove(&contracts.chain_name);
                 address::validate_cosmwasm_address(deps.api, addr)
                     .change_context(MigrationError::InvalidChainContracts)
             })
             .transpose()?
-            .or_else(|| provers_by_chain.remove(&contracts.chain_name));
+            .or_else(|| provers_by_chain.get(&contracts.chain_name).cloned());
+
+        provers_by_chain.remove(&contracts.chain_name);
 
         if let Some(addr) = prover_address {
             save_contracts_to_state(


### PR DESCRIPTION
## Description

The Coordinator v2's migration message allows you to optionally provide a prover address for each chain. Instead of defaulting to the prover address stored in the coordinator's state, this change causes the coordinator to use the provided prover address by default. Consequently, the provided prover addresses will be treated as overrides.

### Reasoning

The migration process for coordinator v2 described [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/releases/cosmwasm/2025-09-Coordinator-v2.1.0.md) requires the multisig to be migrated to v2.3 first. Migrating the multisig to v2.3 removes any duplicate `prover -> chain` mappings from the multisig's state (migrating account chooses which provers to keep). When we then migrate to coordinator v2, the coordinator's `chain -> prover` mapping must be synchronized with the multisig's state in order to ensure the protocol continues to operate correctly. In the event that these maps differ on some chain/prover pair, as was the case on devnet-amplifier, this override will bring the coordinator's map to match with the multisig's map. The alternative would be to correct the coordinator's state afterwards by repeatedly calling `RegisterChain`, but we probably don't want this because it requires more manual intervention.

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migration now uses provided `prover_address` over state, and fails with a list of chains if any registered provers are missing corresponding `chain_contracts`.
> 
> - **Migration logic**:
>   - Prefer provided `prover_address` over stored/state prover when saving `ChainContracts`.
>   - Collect legacy provers into a `HashMap` and remove as processed; error if any remain.
>   - Update `MigrationError::MissingContracts` to accept `Vec<ChainName>` and report all missing chains.
> - **Tests**:
>   - Add test ensuring provided prover overrides state.
>   - Add test asserting failure when registered provers lack corresponding contracts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25585754ee4d69265e125ad01e09fa0b24d10443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->