### PR TITLE
fix(ci): use temp-env package for report package test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8449,6 +8449,7 @@ dependencies = [
  "error-stack",
  "eyre",
  "itertools 0.14.0",
+ "temp-env",
  "thiserror 1.0.69",
  "tracing",
  "tracing-core",

--- a/packages/report/Cargo.toml
+++ b/packages/report/Cargo.toml
@@ -10,6 +10,7 @@ edition = { workspace = true }
 error-stack = { workspace = true }
 eyre = "0.6.8"
 itertools = { workspace = true }
+temp-env = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }


### PR DESCRIPTION
## Description

This PR removes the old env::set_var for rust_backtrace and uses the newly added package for consistency. 

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace env::set_var with temp_env::with_var in report tests and update expected locations; add temp-env dependency.
> 
> - **Tests (`packages/report/src/loggable.rs`)**:
>   - Replace `env::set_var("RUST_BACKTRACE", "1")` with `temp_env::with_var("RUST_BACKTRACE", Some("1"), ...)` and import `temp_env::with_var`.
>   - Update expected `location` line numbers in `expected_err` to match code shifts.
> - **Dependencies**:
>   - Add `temp-env` to `packages/report/Cargo.toml` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b0a2fe6513832606c0bebe40fae520b04553bd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->