### PR TITLE
feat: add solana address format

### DIFF
--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -252,6 +252,14 @@ mod tests {
             addr,
             &address::AddressFormat::Solana
         ));
+
+        // Valid Solana address (all 32 bytes equal to 0)
+        let addr = "11111111111111111111111111111111";
+        assert_ok!(address::validate_address(
+            addr,
+            &address::AddressFormat::Solana
+        ));
+
         // Invalid address: contains invalid character '0' (zero)
         let invalid_char_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8D0";
         assert_err_contains!(
@@ -259,6 +267,7 @@ mod tests {
             address::Error,
             address::Error::InvalidAddress(..)
         );
+
         // Invalid address: contains invalid character 'O'
         let invalid_char_addr2 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DO";
         assert_err_contains!(
@@ -266,6 +275,7 @@ mod tests {
             address::Error,
             address::Error::InvalidAddress(..)
         );
+
         // Invalid address: incorrect length (too short)
         let short_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh";
         assert_err_contains!(
@@ -273,6 +283,7 @@ mod tests {
             address::Error,
             address::Error::InvalidAddress(..)
         );
+
         // Invalid address: incorrect length (too long)
         let long_addr = format!("{}A", addr);
         assert_err_contains!(
@@ -280,6 +291,7 @@ mod tests {
             address::Error,
             address::Error::InvalidAddress(..)
         );
+
         // Invalid address: contains invalid character 'I'
         let invalid_char_addr3 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DI";
         assert_err_contains!(
@@ -287,6 +299,7 @@ mod tests {
             address::Error,
             address::Error::InvalidAddress(..)
         );
+
         // Invalid address: contains invalid character 'l'
         let invalid_char_addr4 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8Dl";
         assert_err_contains!(

--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -20,7 +20,7 @@ pub enum AddressFormat {
     Eip55,
     Sui,
     Stellar,
-    Base58Solana,
+    Solana,
     Starknet,
 }
 
@@ -44,7 +44,7 @@ pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Err
             ScAddress::from_str(address)
                 .change_context(Error::InvalidAddress(address.to_string()))?;
         }
-        AddressFormat::Base58Solana => {
+        AddressFormat::Solana => {
             const SOLANA_PUBKEY_LEN: usize = 32;
             const MAX_BASE58_LEN: usize = 44;
             if address.len() > MAX_BASE58_LEN {
@@ -244,47 +244,47 @@ mod tests {
         let addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8D";
         assert_ok!(address::validate_address(
             addr,
-            &address::AddressFormat::Base58Solana
+            &address::AddressFormat::Solana
         ));
         // Invalid address: contains invalid character '0' (zero)
         let invalid_char_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8D0";
         assert_err_contains!(
-            address::validate_address(invalid_char_addr, &address::AddressFormat::Base58Solana),
+            address::validate_address(invalid_char_addr, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );
         // Invalid address: contains invalid character 'O'
         let invalid_char_addr2 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DO";
         assert_err_contains!(
-            address::validate_address(invalid_char_addr2, &address::AddressFormat::Base58Solana),
+            address::validate_address(invalid_char_addr2, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );
         // Invalid address: incorrect length (too short)
         let short_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh";
         assert_err_contains!(
-            address::validate_address(short_addr, &address::AddressFormat::Base58Solana),
+            address::validate_address(short_addr, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );
         // Invalid address: incorrect length (too long)
         let long_addr = format!("{}A", addr);
         assert_err_contains!(
-            address::validate_address(&long_addr, &address::AddressFormat::Base58Solana),
+            address::validate_address(&long_addr, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );
         // Invalid address: contains invalid character 'I'
         let invalid_char_addr3 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DI";
         assert_err_contains!(
-            address::validate_address(invalid_char_addr3, &address::AddressFormat::Base58Solana),
+            address::validate_address(invalid_char_addr3, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );
         // Invalid address: contains invalid character 'l'
         let invalid_char_addr4 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8Dl";
         assert_err_contains!(
-            address::validate_address(invalid_char_addr4, &address::AddressFormat::Base58Solana),
+            address::validate_address(invalid_char_addr4, &address::AddressFormat::Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );


### PR DESCRIPTION
## Description

Adds support for Solana address format

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Solana address validation with Base58 checks and comprehensive tests.
> 
> - **Address validation (`packages/axelar-wasm-std/src/address.rs`)**:
>   - Adds `AddressFormat::Solana` with Base58 decoding and length checks (32-byte pubkey; 32–44 char input).
>   - Uses `ensure!` for validation; imports `ensure` from `cosmwasm_std`.
> - **Tests**:
>   - Introduces `validate_solana_address` tests covering valid addresses and multiple invalid cases (length and forbidden characters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b1d0307f71272af201567168357b3d1436d4896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->