### PR TITLE
chore: bump anchor and solana program versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3db7f5f8a6b16fa2b6e1b0222e656249c3abedf052e3943babf248929571204"
+checksum = "b972f5fbd02524c92e4eb487c3c648904572702670f3d6fc81aef5f1751b1569"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.40",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a12661acaba9866a5f2d8d8d46a1eed8b484f41dc9f94f808c3b07d35726816"
+checksum = "9acfcb07a92084bcfa9f6cc49a5c2e8e0e986f25f4b7caa184b7a2c9c9e561c2"
 dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.106",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dff08bc0187aafc559da8f63b5adeab0bcdf97128765c72dd9a4861f70627fc"
+checksum = "8f46cc38f819377f07663b8eb492a701427950065e79d2d7b622a782443deb7a"
 dependencies = [
  "anchor-syn",
  "quote 1.0.40",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2af8ce12fb8cf782a3e127d376698a4548a518e38b4686f9c439adce4730b48"
+checksum = "9c34748789107c9838329e058ca7b253e67f37b39ceae5a0a6c8d99f5d1bf1fe"
 dependencies = [
  "anchor-syn",
  "quote 1.0.40",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338be5df076369b99585264aaa46c66229ead67568d61bd38c3ab0fa7a15e554"
+checksum = "1a28a3e5eefa03d9c5ef02b2139198f652547d38dddafc9c5545152dfba54556"
 dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.106",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c4ec70cef4ef7e2d87b4e9c550f727a43d691d3d7f3e4d6b2e3bd530ae098d"
+checksum = "dfaa03865053cb168bfc4debe5992be87f397aa027dd81b69a2e44f2e5bae1c5"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f610cb50e10e4c404cc774f20a4eb602b904f68ea04590f8b1eb22a1e28b33e5"
+checksum = "eef330db08f9ceee45c18ef96b15b869883d280c0ab5c6ff5d2e2f6481da7911"
 dependencies = [
  "anchor-syn",
  "quote 1.0.40",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9ead49a9689493f8857a61dd1abf1d70eeeeb0683f8c1e09b015ab5bdd382d"
+checksum = "e0e80ff4e3ddb8c85aafd37926335c28f820516311e7106e5b7482b42e798aaa"
 dependencies = [
  "anchor-syn",
  "proc-macro-crate 3.5.0",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4d1372743444967347b60f9311d2ee54a630152fd1d6d805adebd7fcd72056"
+checksum = "2672af0ef4dfd5f5b6199355867b580cd8b4048093ef5208dd2b441305c15b8b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.40",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254d0cb160ea5c4c6a8c2f847bbd0f384fef733ebc36ef8426ae95f1bfda5757"
+checksum = "8de9dce227fa0c08be20fef008c5b04681e1e0a15cb396e9619a9a1f800ff6cd"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a855d34b1b0488f37ccc759c8bd4a696cd3a7bba8cb0734c2a965109f707da"
+checksum = "c62f42cb7e348c033bd9bfba59979bcd66431c026ba23490af94045aa357a950"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
@@ -9965,9 +9965,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-gateway"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99ca0054740903450969fb1e6f2116b7fa4226494157fb6ccac6bbe2a20ca9d"
+checksum = "5d0360377d14b777ec5c7d9e678fb6d7ac9c5fb1b56d4a31c825b4f32fa278ba"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -9985,12 +9985,11 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-std"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868dc81fd889a70532209cad62512ba8d2d2c171611a6c0b4d7413496bf377"
+checksum = "b68b1ed52c5aca3c640ec0955398bade43296be94a46eee3839e93adb82d94ac"
 dependencies = [
  "alloy-primitives",
- "anchor-lang",
  "arrayref",
  "bnum 0.10.0",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ its-msg-translator-api = { version = "^1.0.0", path = "packages/its-msg-translat
 its-solana-translator = { version = "^1.0.0", path = "contracts/its-solana-translator" }
 
 # Solana
-anchor-lang = { version = "1.0.0-rc.5", features = ["event-cpi"] }
-solana-axelar-gateway = "1.0.0"
-solana-axelar-std = "1.0.0"
+anchor-lang = { version = "1.0.0", features = ["event-cpi"] }
+solana-axelar-gateway = "1.1.0"
+solana-axelar-std = "1.1.0"
 solana-client = "3.1.10"
 solana-sdk = "3.0.0"
 solana-transaction-status = "3.1.10"


### PR DESCRIPTION
### why

bump to latest anchor and solana version programs.

Part of CPI-198

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it upgrades Solana/Anchor program libraries, which can introduce subtle build/runtime or on-chain behavior changes. Review lockfile updates and downstream compilation/tests for compatibility.
> 
> **Overview**
> Bumps Solana program dependencies in the workspace: upgrades `anchor-lang` from `1.0.0-rc.5` to `1.0.0` and updates `solana-axelar-gateway`/`solana-axelar-std` from `1.0.0` to `1.1.0`.
> 
> Updates `Cargo.lock` accordingly, including the Anchor crate family version bump and the refreshed `solana-axelar-std` dependency set (notably dropping its `anchor-lang` dependency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e664d22a807a6533b7ccb6048e7b5e8c216f42d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->