### PR TITLE
chore(its): add migration to remove xrp-stellar token link

### DIFF
--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -111,18 +111,28 @@ mod tests {
         remove_stellar_xrp_token_instance(deps.as_mut().storage);
 
         // only stellar + xrp_token_id should be removed
-        assert!(state::may_load_token_instance(deps.as_ref().storage, stellar.clone(), xrp_token_id)
-            .unwrap()
-            .is_none());
+        assert!(state::may_load_token_instance(
+            deps.as_ref().storage,
+            stellar.clone(),
+            xrp_token_id
+        )
+        .unwrap()
+        .is_none());
 
-        assert!(state::may_load_token_instance(deps.as_ref().storage, xrpl, xrp_token_id)
-            .unwrap()
-            .is_some());
-        assert!(state::may_load_token_instance(deps.as_ref().storage, stellar, other_token_id)
-            .unwrap()
-            .is_some());
-        assert!(state::may_load_token_instance(deps.as_ref().storage, ethereum, xrp_token_id)
-            .unwrap()
-            .is_some());
+        assert!(
+            state::may_load_token_instance(deps.as_ref().storage, xrpl, xrp_token_id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            state::may_load_token_instance(deps.as_ref().storage, stellar, other_token_id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            state::may_load_token_instance(deps.as_ref().storage, ethereum, xrp_token_id)
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -2,6 +2,10 @@ use axelar_wasm_std::migrate_from_version;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{DepsMut, Empty, Env, Response};
+use interchain_token_service_std::TokenId;
+use router_api::ChainNameRaw;
+
+use crate::state;
 
 pub type MigrateMsg = Empty;
 
@@ -12,5 +16,73 @@ pub fn migrate(
     _env: Env,
     _msg: MigrateMsg,
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
+    remove_stellar_xrp_token_instance(deps.storage);
     Ok(Response::default())
+}
+
+/// Remove the erroneously linked XRP token instance on Stellar.
+/// XRP (token_id ba5a21ca...) was linked to a third-party custom token on Stellar
+/// via LinkToken. This must be removed because the lockUnlock/mintBurnFrom asymmetry
+/// would allow the custom token owner to drain the XRPL multisig.
+fn remove_stellar_xrp_token_instance(storage: &mut dyn cosmwasm_std::Storage) {
+    let chain: ChainNameRaw = "stellar".parse().expect("invalid chain name");
+    let token_id = TokenId::new(
+        <[u8; 32]>::try_from(
+            cosmwasm_std::HexBinary::from_hex(
+                "ba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f",
+            )
+            .expect("invalid hex")
+            .as_slice(),
+        )
+        .expect("invalid token id"),
+    );
+
+    state::remove_token_instance(storage, chain, token_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::mock_dependencies;
+
+    use super::*;
+    use crate::state::{TokenInstance, TokenSupply};
+
+    #[test]
+    fn migration_removes_stellar_xrp_token_instance() {
+        let mut deps = mock_dependencies();
+
+        let chain: ChainNameRaw = "stellar".parse().unwrap();
+        let token_id = TokenId::new(
+            <[u8; 32]>::try_from(
+                cosmwasm_std::HexBinary::from_hex(
+                    "ba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f",
+                )
+                .unwrap()
+                .as_slice(),
+            )
+            .unwrap(),
+        );
+
+        // set up the token instance that should be removed
+        state::save_token_instance(
+            deps.as_mut().storage,
+            chain.clone(),
+            token_id,
+            &TokenInstance {
+                supply: TokenSupply::Untracked,
+                decimals: 6,
+            },
+        )
+        .unwrap();
+
+        assert!(state::may_load_token_instance(deps.as_ref().storage, chain.clone(), token_id)
+            .unwrap()
+            .is_some());
+
+        remove_stellar_xrp_token_instance(deps.as_mut().storage);
+
+        assert!(state::may_load_token_instance(deps.as_ref().storage, chain, token_id)
+            .unwrap()
+            .is_none());
+    }
 }

--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -51,8 +51,11 @@ mod tests {
     fn migration_removes_stellar_xrp_token_instance() {
         let mut deps = mock_dependencies();
 
-        let chain: ChainNameRaw = "stellar".parse().unwrap();
-        let token_id = TokenId::new(
+        let stellar: ChainNameRaw = "stellar".parse().unwrap();
+        let xrpl: ChainNameRaw = "xrpl".parse().unwrap();
+        let ethereum: ChainNameRaw = "ethereum".parse().unwrap();
+
+        let xrp_token_id = TokenId::new(
             <[u8; 32]>::try_from(
                 cosmwasm_std::HexBinary::from_hex(
                     "ba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f",
@@ -62,27 +65,64 @@ mod tests {
             )
             .unwrap(),
         );
+        let other_token_id = TokenId::new([1u8; 32]);
 
-        // set up the token instance that should be removed
+        let untracked_instance = TokenInstance {
+            supply: TokenSupply::Untracked,
+            decimals: 6,
+        };
+
+        // the target: XRP on stellar
         state::save_token_instance(
             deps.as_mut().storage,
-            chain.clone(),
-            token_id,
-            &TokenInstance {
-                supply: TokenSupply::Untracked,
-                decimals: 6,
-            },
+            stellar.clone(),
+            xrp_token_id,
+            &untracked_instance,
         )
         .unwrap();
 
-        assert!(state::may_load_token_instance(deps.as_ref().storage, chain.clone(), token_id)
-            .unwrap()
-            .is_some());
+        // XRP on xrpl (should be kept)
+        state::save_token_instance(
+            deps.as_mut().storage,
+            xrpl.clone(),
+            xrp_token_id,
+            &untracked_instance,
+        )
+        .unwrap();
+
+        // different token on stellar (should be kept)
+        state::save_token_instance(
+            deps.as_mut().storage,
+            stellar.clone(),
+            other_token_id,
+            &untracked_instance,
+        )
+        .unwrap();
+
+        // XRP on ethereum (should be kept)
+        state::save_token_instance(
+            deps.as_mut().storage,
+            ethereum.clone(),
+            xrp_token_id,
+            &untracked_instance,
+        )
+        .unwrap();
 
         remove_stellar_xrp_token_instance(deps.as_mut().storage);
 
-        assert!(state::may_load_token_instance(deps.as_ref().storage, chain, token_id)
+        // only stellar + xrp_token_id should be removed
+        assert!(state::may_load_token_instance(deps.as_ref().storage, stellar.clone(), xrp_token_id)
             .unwrap()
             .is_none());
+
+        assert!(state::may_load_token_instance(deps.as_ref().storage, xrpl, xrp_token_id)
+            .unwrap()
+            .is_some());
+        assert!(state::may_load_token_instance(deps.as_ref().storage, stellar, other_token_id)
+            .unwrap()
+            .is_some());
+        assert!(state::may_load_token_instance(deps.as_ref().storage, ethereum, xrp_token_id)
+            .unwrap()
+            .is_some());
     }
 }

--- a/contracts/interchain-token-service/src/contract/migrations/mod.rs
+++ b/contracts/interchain-token-service/src/contract/migrations/mod.rs
@@ -135,4 +135,11 @@ mod tests {
                 .is_some()
         );
     }
+
+    #[test]
+    fn migration_is_no_op_when_target_absent() {
+        let mut deps = mock_dependencies();
+        // should not panic
+        remove_stellar_xrp_token_instance(deps.as_mut().storage);
+    }
 }

--- a/contracts/interchain-token-service/src/state.rs
+++ b/contracts/interchain-token-service/src/state.rs
@@ -296,6 +296,10 @@ pub fn may_load_token_instance(
         .change_context(Error::Storage)
 }
 
+pub fn remove_token_instance(storage: &mut dyn Storage, chain: ChainNameRaw, token_id: TokenId) {
+    TOKEN_INSTANCE.remove(storage, &(chain, token_id));
+}
+
 pub fn may_load_token_config(
     storage: &dyn Storage,
     token_id: &TokenId,


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> On-chain migration removes a specific `(chain, token_id)` mapping entry; while narrowly scoped, an incorrect identifier or unexpected state could affect token bridging data for that asset.
> 
> **Overview**
> Adds a `1.3` migration that **removes the erroneously linked XRP token instance on `stellar`** (hardcoded `token_id`), mitigating a lock/unlock vs mint/burn asymmetry risk.
> 
> Introduces `state::remove_token_instance` and unit tests ensuring only the `stellar`+XRP entry is deleted and the migration is a no-op when absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775b67f9dc681ae844946d1c45cd120c7c1e2c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->