### PR TITLE
fix(ampd): error for invalid config paths

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,4 +18,7 @@ ignore = [
     "RUSTSEC-2026-0007",  # bytes: Integer overflow in BytesMut::reserve — transitive (tungstenite etc.), upgrade when deps allow
     "RUSTSEC-2026-0009",  # time: DoS stack exhaustion — transitive (tendermint, serde_with etc.), upgrade when deps allow,
     "RUSTSEC-2026-0049",  # rustls-webpki: CRL Distribution Point validation bypass — 0.102.x fix requires major version bump blocked on Sui/anemo upstream; 0.103.x fix blocked on Solana upstream
+    "RUSTSEC-2026-0098",  # rustls-webpki: name constraints for URI names incorrectly accepted — same upstream blockers as RUSTSEC-2026-0049
+    "RUSTSEC-2026-0099",  # rustls-webpki: name constraints accepted for wildcard certs — same upstream blockers as RUSTSEC-2026-0049
+    "RUSTSEC-2026-0104",  # rustls-webpki: reachable panic in CRL parsing — same upstream blockers as RUSTSEC-2026-0049
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "stellar-xdr",
  "sysinfo",
  "temp-env",
+ "tempfile",
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -95,6 +95,7 @@ multisig = { workspace = true, features = ["test", "library"] }
 rand = { workspace = true }
 random-string = { workspace = true }
 temp-env = { workspace = true, features = ["async_closure"] }
+tempfile = "3"
 tendermint-proto = { version = "0.40.3" }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test = { workspace = true }

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -135,7 +135,7 @@ fn set_up_logger(output: &Output) {
 }
 
 fn init_config(config_paths: &[PathBuf]) -> error_stack::Result<Config, Error> {
-    let files = find_config_files(config_paths)?;
+    let files = find_config_files(config_paths, DEFAULT_CONFIG_PATHS)?;
     let env_keys: Vec<String> = std::env::vars_os()
         .filter_map(|(k, _)| k.into_string().ok())
         .filter(|k| k.starts_with("AMPD_"))
@@ -159,13 +159,11 @@ fn init_config(config_paths: &[PathBuf]) -> error_stack::Result<Config, Error> {
 
 fn find_config_files(
     config: &[PathBuf],
+    defaults: &[&str],
 ) -> error_stack::Result<Vec<File<FileSourceFile, FileFormat>>, Error> {
     let (paths, user_supplied) = if config.is_empty() {
         (
-            DEFAULT_CONFIG_PATHS
-                .iter()
-                .map(PathBuf::from)
-                .collect::<Vec<_>>(),
+            defaults.iter().map(PathBuf::from).collect::<Vec<_>>(),
             false,
         )
     } else {
@@ -226,4 +224,144 @@ fn expand_home_dir(path: impl AsRef<Path>) -> PathBuf {
     };
 
     dirs::home_dir().map_or(path.to_path_buf(), |home| home.join(home_subfolder))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn make_file(dir: &TempDir, name: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, b"").expect("write temp file");
+        path
+    }
+
+    #[test]
+    fn find_config_files_resolves_user_supplied_path() {
+        let dir = TempDir::new().unwrap();
+        let path = make_file(&dir, "ampd.toml");
+
+        let files = find_config_files(&[path], &[]).unwrap();
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn find_config_files_collects_all_user_supplied_paths() {
+        let dir = TempDir::new().unwrap();
+        let a = make_file(&dir, "a.toml");
+        let b = make_file(&dir, "b.toml");
+
+        let files = find_config_files(&[a, b], &[]).unwrap();
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn find_config_files_errors_on_missing_user_supplied_path() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope.toml");
+
+        let err = find_config_files(&[missing.clone()], &[]).unwrap_err();
+        let formatted = format!("{err:?}");
+        assert!(
+            formatted.contains(&missing.display().to_string()),
+            "expected error to mention path, got: {formatted}",
+        );
+    }
+
+    #[test]
+    fn find_config_files_errors_when_any_user_supplied_path_is_missing() {
+        let dir = TempDir::new().unwrap();
+        let good = make_file(&dir, "good.toml");
+        let missing = dir.path().join("missing.toml");
+
+        assert!(find_config_files(&[good, missing], &[]).is_err());
+    }
+
+    #[test]
+    fn find_config_files_returns_empty_when_no_user_paths_and_no_defaults_exist() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("not-there.toml");
+        let missing_str = missing.to_str().unwrap().to_string();
+
+        let files = find_config_files(&[], &[missing_str.as_str()]).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn find_config_files_picks_up_existing_default() {
+        let dir = TempDir::new().unwrap();
+        let existing = make_file(&dir, "default.toml");
+        let existing_str = existing.to_str().unwrap().to_string();
+
+        let files = find_config_files(&[], &[existing_str.as_str()]).unwrap();
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn find_config_files_skips_missing_defaults_silently() {
+        let dir = TempDir::new().unwrap();
+        let existing = make_file(&dir, "exists.toml");
+        let missing = dir.path().join("absent.toml");
+        let existing_str = existing.to_str().unwrap().to_string();
+        let missing_str = missing.to_str().unwrap().to_string();
+
+        let files =
+            find_config_files(&[], &[missing_str.as_str(), existing_str.as_str()]).unwrap();
+        assert_eq!(files.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_config_files_errors_on_unreadable_user_supplied_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let restricted = dir.path().join("locked");
+        fs::create_dir(&restricted).unwrap();
+        let path = restricted.join("config.toml");
+        fs::write(&path, b"").unwrap();
+        fs::set_permissions(&restricted, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // root bypasses chmod, which would invalidate the test premise; detect by
+        // probing the FS rather than depending on libc
+        if canonicalize(&path).is_ok() {
+            fs::set_permissions(&restricted, fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let result = find_config_files(&[path], &[]);
+
+        fs::set_permissions(&restricted, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    #[test]
+    fn expand_home_dir_leaves_non_tilde_paths_untouched() {
+        let path = PathBuf::from("/etc/ampd/config.toml");
+        assert_eq!(expand_home_dir(&path), path);
+    }
+
+    #[test]
+    fn expand_home_dir_replaces_leading_tilde() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+
+        assert_eq!(
+            expand_home_dir(PathBuf::from("~/.ampd/config.toml")),
+            home.join(".ampd/config.toml"),
+        );
+    }
+
+    #[test]
+    fn expand_home_dir_does_not_match_tilde_inside_path_segment() {
+        // `~foo` is not a tilde-home path; it should pass through unchanged
+        let path = PathBuf::from("~foo/bar");
+        assert_eq!(expand_home_dir(&path), path);
+    }
 }

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -309,8 +309,7 @@ mod tests {
         let existing_str = existing.to_str().unwrap().to_string();
         let missing_str = missing.to_str().unwrap().to_string();
 
-        let files =
-            find_config_files(&[], &[missing_str.as_str(), existing_str.as_str()]).unwrap();
+        let files = find_config_files(&[], &[missing_str.as_str(), existing_str.as_str()]).unwrap();
         assert_eq!(files.len(), 1);
     }
 

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -135,7 +135,14 @@ fn set_up_logger(output: &Output) {
 }
 
 fn init_config(config_paths: &[PathBuf]) -> error_stack::Result<Config, Error> {
-    let files = find_config_files(config_paths, DEFAULT_CONFIG_PATHS)?;
+    init_config_with_defaults(config_paths, DEFAULT_CONFIG_PATHS)
+}
+
+fn init_config_with_defaults(
+    config_paths: &[PathBuf],
+    defaults: &[&str],
+) -> error_stack::Result<Config, Error> {
+    let files = find_config_files(config_paths, defaults)?;
     let env_keys: Vec<String> = std::env::vars_os()
         .filter_map(|(k, _)| k.into_string().ok())
         .filter(|k| k.starts_with("AMPD_"))
@@ -362,5 +369,66 @@ mod tests {
         // `~foo` is not a tilde-home path; it should pass through unchanged
         let path = PathBuf::from("~foo/bar");
         assert_eq!(expand_home_dir(&path), path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_config_files_skips_unreadable_default_with_warning() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let restricted = dir.path().join("locked");
+        fs::create_dir(&restricted).unwrap();
+        let default_path = restricted.join("default.toml");
+        fs::write(&default_path, b"").unwrap();
+        fs::set_permissions(&restricted, fs::Permissions::from_mode(0o000)).unwrap();
+
+        if canonicalize(&default_path).is_ok() {
+            fs::set_permissions(&restricted, fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let default_str = default_path.to_string_lossy().into_owned();
+        let result = find_config_files(&[], &[default_str.as_str()]);
+
+        fs::set_permissions(&restricted, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let files = result.expect("default-path errors should not propagate");
+        assert!(files.is_empty());
+    }
+
+    fn ampd_env_keys() -> Vec<String> {
+        std::env::vars_os()
+            .filter_map(|(k, _)| k.into_string().ok())
+            .filter(|k| k.starts_with("AMPD_"))
+            .collect()
+    }
+
+    #[test]
+    fn init_config_succeeds_with_user_supplied_file() {
+        let dir = TempDir::new().unwrap();
+        let path = make_file(&dir, "ampd.toml");
+
+        assert!(init_config(&[path]).is_ok());
+    }
+
+    #[test]
+    fn init_config_propagates_user_path_resolution_errors() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope.toml");
+
+        assert!(init_config(&[missing]).is_err());
+    }
+
+    #[test]
+    fn init_config_falls_back_to_default_when_no_sources_present() {
+        let keys = ampd_env_keys();
+
+        temp_env::with_vars_unset(keys.as_slice(), || {
+            // empty user paths + empty defaults + no AMPD_* env vars exercises
+            // the warn-and-fall-back branch deterministically
+            let cfg = init_config_with_defaults(&[], &[]).expect("should not error");
+            assert_eq!(cfg, Config::default());
+        });
     }
 }

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -53,15 +53,9 @@ async fn main() -> ExitCode {
     let args: Args = Args::parse();
     set_up_logger(&args.output);
 
-    let cfg = match init_config(&args.config) {
+    let cfg = match init_config_or_exit(&args.config, &args.output) {
         Ok(cfg) => cfg,
-        Err(report) => {
-            error!(err = LoggableError::from(&report).as_value(), "{report:#}");
-            if matches!(args.output, Output::Text) {
-                eprintln!("{report:?}");
-            }
-            return ExitCode::FAILURE;
-        }
+        Err(code) => return code,
     };
 
     let result = match args.cmd {
@@ -108,6 +102,20 @@ async fn main() -> ExitCode {
     }
 }
 
+fn report_init_config_failure(report: &error_stack::Report<Error>, output: &Output) {
+    error!(err = LoggableError::from(report).as_value(), "{report:#}");
+    if matches!(output, Output::Text) {
+        eprintln!("{report:?}");
+    }
+}
+
+fn init_config_or_exit(config_paths: &[PathBuf], output: &Output) -> Result<Config, ExitCode> {
+    init_config(config_paths).map_err(|report| {
+        report_init_config_failure(&report, output);
+        ExitCode::FAILURE
+    })
+}
+
 fn set_up_logger(output: &Output) {
     let error_layer = ErrorLayer::default();
     let filter_layer = EnvFilter::builder()
@@ -151,11 +159,7 @@ fn init_config_with_defaults(
     if files.is_empty() && env_keys.is_empty() {
         warn!("no config file or AMPD_* env vars found; using Config::default()");
     } else {
-        info!(
-            file_count = files.len(),
-            env_vars = ?env_keys,
-            "loading config",
-        );
+        info!(file_count = files.len(), env_vars = ?env_keys, "loading config");
     }
 
     Ok(parse_config(files)
@@ -189,11 +193,7 @@ fn find_config_files(
                 // default candidate does not exist on this install; skip silently
             }
             Err(err) if !user_supplied => {
-                warn!(
-                    path = %expanded.to_string_lossy(),
-                    err = %err,
-                    "skipping default config file",
-                );
+                warn!(path = %expanded.to_string_lossy(), err = %err, "skipping default config file");
             }
             Err(err) => {
                 return Err(Report::from(err)
@@ -238,6 +238,7 @@ mod tests {
     use std::fs;
 
     use tempfile::TempDir;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -247,6 +248,7 @@ mod tests {
         path
     }
 
+    #[traced_test]
     #[test]
     fn find_config_files_resolves_user_supplied_path() {
         let dir = TempDir::new().unwrap();
@@ -372,6 +374,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[traced_test]
     #[test]
     fn find_config_files_skips_unreadable_default_with_warning() {
         use std::os::unix::fs::PermissionsExt;
@@ -404,6 +407,7 @@ mod tests {
             .collect()
     }
 
+    #[traced_test]
     #[test]
     fn init_config_succeeds_with_user_supplied_file() {
         let dir = TempDir::new().unwrap();
@@ -420,6 +424,7 @@ mod tests {
         assert!(init_config(&[missing]).is_err());
     }
 
+    #[traced_test]
     #[test]
     fn init_config_falls_back_to_default_when_no_sources_present() {
         let keys = ampd_env_keys();
@@ -430,5 +435,33 @@ mod tests {
             let cfg = init_config_with_defaults(&[], &[]).expect("should not error");
             assert_eq!(cfg, Config::default());
         });
+    }
+
+    #[traced_test]
+    #[test]
+    fn report_init_config_failure_runs_for_text_and_json_output() {
+        let report = error_stack::Report::new(Error::LoadConfig);
+
+        // both branches should run without panicking; Text additionally writes to stderr
+        report_init_config_failure(&report, &Output::Text);
+        report_init_config_failure(&report, &Output::Json);
+    }
+
+    #[traced_test]
+    #[test]
+    fn init_config_or_exit_returns_failure_on_invalid_path() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope.toml");
+
+        assert!(init_config_or_exit(&[missing], &Output::Json).is_err());
+    }
+
+    #[traced_test]
+    #[test]
+    fn init_config_or_exit_returns_config_on_valid_path() {
+        let dir = TempDir::new().unwrap();
+        let path = make_file(&dir, "ampd.toml");
+
+        assert!(init_config_or_exit(&[path], &Output::Text).is_ok());
     }
 }

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::fs::canonicalize;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -16,18 +17,21 @@ use clap::{arg, command, Parser, ValueEnum};
 use config::ConfigError;
 use error_stack::{Report, ResultExt};
 use report::LoggableError;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_core::LevelFilter;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use valuable::Valuable;
 
+const DEFAULT_CONFIG_PATHS: &[&str] = &["~/.ampd/config.toml", "config.toml"];
+
 #[derive(Debug, Parser, Valuable)]
 #[command(version)]
 struct Args {
-    /// Set the paths for config file lookup. Can be defined multiple times (configs get merged)
-    #[arg(short, long, default_values_os_t = vec![std::path::PathBuf::from("~/.ampd/config.toml"), std::path::PathBuf::from("config.toml")])]
+    /// Set the paths for config file lookup. Can be defined multiple times (configs get merged).
+    /// If not provided, falls back to `~/.ampd/config.toml` and `./config.toml`.
+    #[arg(short, long)]
     pub config: Vec<PathBuf>,
 
     /// Set the output style of the logs
@@ -49,7 +53,16 @@ async fn main() -> ExitCode {
     let args: Args = Args::parse();
     set_up_logger(&args.output);
 
-    let cfg = init_config(&args.config);
+    let cfg = match init_config(&args.config) {
+        Ok(cfg) => cfg,
+        Err(report) => {
+            error!(err = LoggableError::from(&report).as_value(), "{report:#}");
+            if matches!(args.output, Output::Text) {
+                eprintln!("{report:?}");
+            }
+            return ExitCode::FAILURE;
+        }
+    };
 
     let result = match args.cmd {
         Some(SubCommand::Daemon) | None => {
@@ -121,30 +134,78 @@ fn set_up_logger(output: &Output) {
     };
 }
 
-fn init_config(config_paths: &[PathBuf]) -> Config {
-    let files = find_config_files(config_paths);
+fn init_config(config_paths: &[PathBuf]) -> error_stack::Result<Config, Error> {
+    let files = find_config_files(config_paths)?;
+    let env_keys: Vec<String> = std::env::vars_os()
+        .filter_map(|(k, _)| k.into_string().ok())
+        .filter(|k| k.starts_with("AMPD_"))
+        .collect();
 
-    parse_config(files)
+    if files.is_empty() && env_keys.is_empty() {
+        warn!("no config file or AMPD_* env vars found; using Config::default()");
+    } else {
+        info!(
+            file_count = files.len(),
+            env_vars = ?env_keys,
+            "loading config",
+        );
+    }
+
+    Ok(parse_config(files)
         .change_context(Error::LoadConfig)
         .inspect_err(|report| error!(err = LoggableError::from(report).as_value(), "{report}"))
-        .unwrap_or_default()
+        .unwrap_or_default())
 }
 
-fn find_config_files(config: &[PathBuf]) -> Vec<File<FileSourceFile, FileFormat>> {
-    let files = config
-        .iter()
-        .map(expand_home_dir)
-        .map(canonicalize)
-        .filter_map(Result::ok)
-        .inspect(|path| info!("found config file {}", path.to_string_lossy()))
-        .map(File::from)
-        .collect::<Vec<_>>();
+fn find_config_files(
+    config: &[PathBuf],
+) -> error_stack::Result<Vec<File<FileSourceFile, FileFormat>>, Error> {
+    let (paths, user_supplied) = if config.is_empty() {
+        (
+            DEFAULT_CONFIG_PATHS
+                .iter()
+                .map(PathBuf::from)
+                .collect::<Vec<_>>(),
+            false,
+        )
+    } else {
+        (config.to_vec(), true)
+    };
+
+    let mut files = Vec::new();
+    for path in paths {
+        let expanded = expand_home_dir(&path);
+        match canonicalize(&expanded) {
+            Ok(canonical) => {
+                info!("found config file {}", canonical.to_string_lossy());
+                files.push(File::from(canonical));
+            }
+            Err(err) if !user_supplied && err.kind() == io::ErrorKind::NotFound => {
+                // default candidate does not exist on this install; skip silently
+            }
+            Err(err) if !user_supplied => {
+                warn!(
+                    path = %expanded.to_string_lossy(),
+                    err = %err,
+                    "skipping default config file",
+                );
+            }
+            Err(err) => {
+                return Err(Report::from(err)
+                    .change_context(Error::LoadConfig)
+                    .attach_printable(format!(
+                        "failed to resolve config path: {}",
+                        expanded.display()
+                    )));
+            }
+        }
+    }
 
     if files.is_empty() {
         info!("found no config files to load");
     }
 
-    files
+    Ok(files)
 }
 
 fn parse_config(


### PR DESCRIPTION
### why

`ampd` would previously silently error out unknown config files or files without permission to read.

Fixes CPI-238

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup/config resolution and turns previously-ignored invalid `--config` paths into hard failures, which can break misconfigured deployments. Logic is well-covered by new tests, but impacts process exit behavior.
> 
> **Overview**
> `ampd`’s config bootstrap now distinguishes **user-supplied** vs **default** config paths: missing/unreadable `--config` entries produce a structured `Error::LoadConfig` report and exit non-zero, while missing defaults are silently skipped (and other default-path errors only warn).
> 
> The CLI no longer hardcodes default `--config` values; instead it applies `DEFAULT_CONFIG_PATHS` internally, logs when it is loading from files/env, and warns when falling back to `Config::default()` due to no config sources. This adds extensive unit tests around path expansion/canonicalization and config-loading failure reporting, and introduces `tempfile` as a dev-dependency. `.cargo/audit.toml` also ignores several new `rustls-webpki` advisories pending upstream fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496b7e5dff83a0887ac516c9f6e3a358a6b92184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->