### PR TITLE
fix(service-registry): reject bond_verifier calls with multi-denom funds

### DIFF
--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -224,7 +224,8 @@ mod test {
         message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{
-        coins, from_json, Api, CosmosMsg, Empty, OwnedDeps, StdResult, Uint128, WasmQuery,
+        coin, coins, from_json, Api, Coin, CosmosMsg, Empty, OwnedDeps, StdResult, Uint128,
+        WasmQuery,
     };
     use router_api::{chain_name, cosmos_addr, ChainName};
     use service_registry_api::{Verifier, WeightedVerifier};
@@ -2044,6 +2045,50 @@ mod test {
         ));
     }
 
+    #[test]
+    fn bond_multiple_denoms_should_fail() {
+        let mut deps = setup();
+
+        let service_name = "validators";
+        let min_verifier_bond: nonempty::Uint128 = Uint128::new(100).try_into().unwrap();
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&cosmos_addr!(GOVERNANCE_ADDRESS), &[]),
+            ExecuteMsg::RegisterService {
+                service_name: service_name.into(),
+                coordinator_contract: cosmos_addr!(COORDINATOR_ADDRESS).to_string(),
+                min_num_verifiers: 0,
+                max_num_verifiers: Some(100),
+                min_verifier_bond,
+                bond_denom: AXL_DENOMINATION.into(),
+                unbonding_period_days: 10,
+                description: "Some service".into(),
+            },
+        );
+        assert!(res.is_ok());
+
+        let funds: Vec<Coin> = vec![
+            coin(min_verifier_bond.into_inner().u128(), AXL_DENOMINATION),
+            coin(5, "funnydenom"),
+        ];
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&cosmos_addr!(VERIFIER_ADDRESS), &funds),
+            ExecuteMsg::BondVerifier {
+                service_name: service_name.into(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(err_contains!(
+            err.report,
+            ContractError,
+            ContractError::WrongDenom
+        ));
+    }
     #[test]
     fn bond_but_not_authorized() {
         let mut deps = setup();

--- a/contracts/service-registry/src/contract/execute.rs
+++ b/contracts/service-registry/src/contract/execute.rs
@@ -102,6 +102,11 @@ pub fn bond_verifier(
 ) -> Result<Response, ContractError> {
     let service = state::service(deps.storage, &service_name, None)?;
 
+    // should only have a single denomination
+    if info.funds.len() > 1 {
+        return Err(ContractError::WrongDenom.into());
+    }
+
     let bond: Option<nonempty::Uint128> = if !info.funds.is_empty() {
         Some(
             info.funds


### PR DESCRIPTION
### why
Arda issue 313: if the caller sends several Coin, one of which has the intended denom (i.e. uaxl), then all other Coin are lost.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain `BondVerifier` execution behavior by rejecting transactions that attach multiple denominations, which could break existing callers that send extra coins but prevents silent fund loss.
> 
> **Overview**
> Prevents accidental loss of extra coins during `ExecuteMsg::BondVerifier` by **rejecting any call that includes more than one coin denom**, even if the expected `bond_denom` is present.
> 
> Adds a unit test (`bond_multiple_denoms_should_fail`) to assert multi-denom bonding fails with `ContractError::WrongDenom`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e39dc1c08e2da9d48adaab98bf02c79538cd6508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->