### PR TITLE
feat(service-registry): require verifier to be authorized before registering for chain support

### DIFF
--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -163,7 +163,6 @@ fn match_verifier(
 
     let res = VERIFIERS
         .load(storage, (service_name, sender_addr))
-        .map(|verifier| verifier.address)
         .change_context(ContractError::VerifierNotFound)
         .change_context(permission_control::Error::Unauthorized);
 
@@ -172,7 +171,16 @@ fn match_verifier(
         state::service(storage, service_name, None)
             .change_context(permission_control::Error::Unauthorized)?;
     }
-    res.map(|addr| addr == sender_addr)
+    let verifier = res?;
+
+    if matches!(msg, ExecuteMsg::RegisterChainSupport { .. })
+        && verifier.authorization_state != AuthorizationState::Authorized
+    {
+        return Err(Report::new(ContractError::Unauthorized)
+            .change_context(permission_control::Error::Unauthorized));
+    }
+
+    Ok(verifier.address == sender_addr)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -2081,7 +2089,7 @@ mod test {
         assert!(res.is_ok());
 
         let chain_name = chain_name!(ETHEREUM);
-        let res = execute(
+        let err = execute(
             deps.as_mut(),
             mock_env(),
             message_info(&cosmos_addr!(VERIFIER_ADDRESS), &[]),
@@ -2089,8 +2097,14 @@ mod test {
                 service_name: service_name.into(),
                 chains: vec![chain_name.clone()],
             },
-        );
-        assert!(res.is_ok());
+        )
+        .unwrap_err();
+
+        assert!(err_contains!(
+            err.report,
+            ContractError,
+            ContractError::Unauthorized,
+        ));
 
         let verifiers: Vec<WeightedVerifier> = from_json(
             query(

--- a/packages/service-registry-api/src/msg.rs
+++ b/packages/service-registry-api/src/msg.rs
@@ -60,7 +60,7 @@ pub enum ExecuteMsg {
         service_name: String,
     },
 
-    /// Register support for the specified chains. Called by the verifier.
+    /// Register support for the specified chains. Called by an authorized verifier.
     #[permission(Specific(verifier))]
     RegisterChainSupport {
         service_name: String,


### PR DESCRIPTION
Fixes CPI-271.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain permission enforcement for `RegisterChainSupport`, which can block previously-accepted transactions if callers aren’t explicitly authorized. Limited scope but impacts verifier onboarding/ops flows.
> 
> **Overview**
> **Chain support registration now requires explicit verifier authorization.** The contract’s `match_verifier` permission check rejects `ExecuteMsg::RegisterChainSupport` unless the caller’s verifier record is in `AuthorizationState::Authorized`, while leaving `DeregisterChainSupport` behavior unchanged.
> 
> Tests were updated to assert `ContractError::Unauthorized` when a bonded-but-not-authorized verifier attempts to register chain support, and the API message docs were clarified to reflect the new requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f71f7ebc9e8255ca29c1d478e172605c452ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->