### PR TITLE
fix(voting-verifier): cap verify_messages batch at 1000

### DIFF
--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -507,6 +507,48 @@ mod test {
     }
 
     #[test]
+    fn should_fail_if_messages_exceed_max_per_poll() {
+        use crate::contract::execute::MAX_MESSAGES_PER_POLL;
+
+        let msg_id_format = MessageIdFormat::HexTxHashAndEventIndex;
+        let verifiers = verifiers(2);
+        let mut deps = setup(verifiers.clone(), &msg_id_format);
+
+        let count = u64::try_from(MAX_MESSAGES_PER_POLL)
+            .unwrap()
+            .saturating_add(1);
+        let messages: Vec<Message> = (0..count)
+            .map(|i| Message {
+                cc_id: CrossChainId::new(source_chain(), message_id("id", i, &msg_id_format))
+                    .unwrap(),
+                source_address: alloy_primitives::Address::random()
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
+                destination_chain: chain_name!("destination-chain"),
+                destination_address: address!("destination-address"),
+                payload_hash: [0; 32],
+            })
+            .collect();
+        let msg = ExecuteMsg::VerifyMessages(messages);
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&cosmos_addr!(SENDER), &[]),
+            msg,
+        )
+        .unwrap_err();
+        assert_contract_err_strings_equal(
+            err,
+            ContractError::TooManyMessages {
+                actual: MAX_MESSAGES_PER_POLL.saturating_add(1),
+                max: MAX_MESSAGES_PER_POLL,
+            },
+        );
+    }
+
+    #[test]
     fn should_fail_if_messages_are_not_from_same_source() {
         let msg_id_format = MessageIdFormat::HexTxHashAndEventIndex;
         let verifiers = verifiers(2);

--- a/contracts/voting-verifier/src/contract/execute.rs
+++ b/contracts/voting-verifier/src/contract/execute.rs
@@ -24,6 +24,16 @@ use crate::state::{
     self, poll_messages, poll_verifier_sets, PollContent, CONFIG, POLLS, POLL_ID, VOTES,
 };
 
+/// Maximum number of messages allowed in a single `VerifyMessages` call.
+///
+/// This bounds the size of any poll created in the voting verifier so that a
+/// single oversized poll cannot inflate the gas cost of `Vote` past ampd's
+/// `batch_gas_limit`, which would otherwise let an attacker delay the
+/// verification of any included message indefinitely. Both `VerifyMessages`
+/// and ampd's `Vote` scale linearly with poll size, so capping the size of
+/// the poll caps the worst-case gas cost of voting on it.
+pub const MAX_MESSAGES_PER_POLL: usize = 1000;
+
 pub fn update_voting_parameters(
     deps: DepsMut,
     voting_threshold: Option<MajorityThreshold>,
@@ -97,6 +107,13 @@ pub fn verify_messages(
 ) -> Result<Response, ContractError> {
     if messages.is_empty() {
         return Err(report!(ContractError::EmptyMessages));
+    }
+
+    if messages.len() > MAX_MESSAGES_PER_POLL {
+        return Err(report!(ContractError::TooManyMessages {
+            actual: messages.len(),
+            max: MAX_MESSAGES_PER_POLL,
+        }));
     }
 
     let config = CONFIG.load(deps.storage).expect("failed to load config");

--- a/contracts/voting-verifier/src/error.rs
+++ b/contracts/voting-verifier/src/error.rs
@@ -23,6 +23,9 @@ pub enum ContractError {
     #[error("empty batch of messages")]
     EmptyMessages,
 
+    #[error("too many messages in batch: {actual} exceeds maximum {max}")]
+    TooManyMessages { actual: usize, max: usize },
+
     #[error("all messages must have the same source chain {0}")]
     SourceChainMismatch(ChainName),
 


### PR DESCRIPTION
### why
This is done to prevent arbitrary sized batch sizes for verify messages that can be used to DoS message verification on amplifier.

Fixes CPI-307

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain execution behavior by rejecting oversized `VerifyMessages` batches, which could impact integrations relying on larger submissions. Low implementation complexity but touches message-verification flow and error handling.
> 
> **Overview**
> Prevents DoS via oversized message-verification polls by introducing `MAX_MESSAGES_PER_POLL` (1000) and rejecting `ExecuteMsg::VerifyMessages` batches larger than this limit.
> 
> Adds a new `ContractError::TooManyMessages` error and a unit test asserting the new rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c1d7c056265a131f5b9ec2e3c1bb8de938210a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->