### PR TITLE
fix(voting-verifier): skip new verifier set poll while one is in progress

### DIFF
--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -1481,6 +1481,76 @@ mod test {
     }
 
     #[test]
+    fn should_not_start_new_poll_while_verifier_set_poll_in_progress() {
+        let msg_id_format = MessageIdFormat::HexTxHashAndEventIndex;
+        let verifiers = verifiers(2);
+        let mut deps = setup(verifiers.clone(), &msg_id_format);
+
+        let verifier_set = build_verifier_set(KeyType::Ecdsa, &ecdsa_test_data::signers());
+
+        // first call: starts poll 1
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&cosmos_addr!(SENDER), &[]),
+            ExecuteMsg::VerifyVerifierSet {
+                message_id: message_id("id", 0, &msg_id_format),
+                new_verifier_set: verifier_set.clone(),
+            },
+        )
+        .unwrap();
+        assert!(!res.events.is_empty(), "first call should emit PollStarted");
+
+        // second call while poll 1 is in progress: must be a no-op
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&cosmos_addr!(SENDER), &[]),
+            ExecuteMsg::VerifyVerifierSet {
+                message_id: message_id("different_id", 1, &msg_id_format),
+                new_verifier_set: verifier_set.clone(),
+            },
+        )
+        .unwrap();
+        assert_eq!(res, Response::new());
+
+        // votes on poll 1 still reach consensus because the mapping was not overwritten
+        for verifier in verifiers {
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                message_info(&verifier.address, &[]),
+                ExecuteMsg::Vote {
+                    poll_id: 1u64.into(),
+                    votes: vec![Vote::SucceededOnChain],
+                },
+            )
+            .unwrap();
+        }
+
+        execute(
+            deps.as_mut(),
+            mock_env_expired(),
+            message_info(&cosmos_addr!(SENDER), &[]),
+            ExecuteMsg::EndPoll {
+                poll_id: 1u64.into(),
+            },
+        )
+        .unwrap();
+
+        let status: VerificationStatus = from_json(
+            query(
+                deps.as_ref(),
+                mock_env(),
+                QueryMsg::VerifierSetStatus(verifier_set),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(status, VerificationStatus::SucceededOnSourceChain);
+    }
+
+    #[test]
     #[allow(clippy::arithmetic_side_effects)]
     fn voting_parameter_changes_should_not_affect_existing_polls() {
         let verifiers = verifiers(10);

--- a/contracts/voting-verifier/src/contract/execute.rs
+++ b/contracts/voting-verifier/src/contract/execute.rs
@@ -63,8 +63,14 @@ pub fn verify_verifier_set(
     new_verifier_set: VerifierSet,
 ) -> Result<Response, ContractError> {
     let status = verifier_set_status(deps.as_ref(), &new_verifier_set, env.block.height)?;
-    if status.is_confirmed() {
-        return Ok(Response::new());
+    match status {
+        VerificationStatus::SucceededOnSourceChain | VerificationStatus::InProgress => {
+            return Ok(Response::new());
+        }
+        VerificationStatus::NotFoundOnSourceChain
+        | VerificationStatus::FailedToVerify
+        | VerificationStatus::FailedOnSourceChain
+        | VerificationStatus::Unknown => {}
     }
 
     let config = CONFIG.load(deps.storage).expect("failed to load config");


### PR DESCRIPTION
### why

Fixes CPI-304

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain verifier-set poll creation logic; scope is narrow and covered by a new test, but it affects cross-chain verification behavior.
> 
> **Overview**
> **`verify_verifier_set`** no longer starts a second poll when the same verifier set is already **`InProgress`**. It now returns an empty response for both **`SucceededOnSourceChain`** and **`InProgress`**, instead of only skipping when already confirmed—so a repeat **`VerifyVerifierSet`** (e.g. different `message_id`) cannot overwrite the verifier-set→poll mapping and strand the active poll.
> 
> A contract test covers the regression: second call is a no-op while poll 1 is open, votes still complete poll 1, and status ends as **`SucceededOnSourceChain`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3d81cc48913d6a257898138f0ca7b8801d5272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->