### PR TITLE
chore: simplify hashing of sign_digest

### DIFF
--- a/ampd/src/broadcast/mod.rs
+++ b/ampd/src/broadcast/mod.rs
@@ -227,14 +227,7 @@ where
 
     broadcaster
         .broadcast(vec![batch_req], |sign_doc| {
-            let mut hasher = Sha256::new();
-            hasher.update(sign_doc);
-
-            let sign_digest: [u8; 32] = hasher
-                .finalize()
-                .to_vec()
-                .try_into()
-                .expect("hash size must be 32");
+            let sign_digest: [u8; 32] = Sha256::digest(sign_doc).into();
 
             signer.sign(key_id, sign_digest, pub_key.into(), tofnd::Algorithm::Ecdsa)
         })


### PR DESCRIPTION
### why

Misc. 

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic hashing refactor on the same sign-doc bytes with no new logic paths; digest should remain identical.
> 
> **Overview**
> Replaces the manual **SHA-256** hasher (`new` → `update` → `finalize` → `try_into`) with **`Sha256::digest(sign_doc).into()`** when building the **32-byte `sign_digest`** passed to **`signer.sign`** in the Cosmos batch broadcast path.
> 
> Signing behavior should be unchanged; this is a small readability refactor in **`ampd/src/broadcast/mod.rs`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a52f019b8becac80d7635082d2303b75bf30970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->