### PR TITLE
chore(ampd): allow rebonding via ampd

### DIFF
--- a/ampd/src/commands/bond_verifier.rs
+++ b/ampd/src/commands/bond_verifier.rs
@@ -2,7 +2,7 @@ use axelar_wasm_std::nonempty;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::tx::Msg;
 use cosmrs::Coin;
-use error_stack::Result;
+use error_stack::{report, Result};
 use report::ResultCompatExt;
 use service_registry_api::msg::ExecuteMsg;
 use valuable::Valuable;
@@ -14,8 +14,12 @@ use crate::{Error, PREFIX};
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Args {
     service_name: nonempty::String,
-    amount: u128,
-    denom: String,
+    /// Amount to bond. If omitted (along with `denom`), the transaction carries no funds, which
+    /// the service registry interprets as a request to rebond stake currently in the
+    /// `Unbonding` or `RequestedUnbonding` state.
+    amount: Option<u128>,
+    /// Denomination of the amount being bonded. Required if `amount` is provided.
+    denom: Option<String>,
     #[clap(flatten)]
     broadcast: BroadcastArgs,
 }
@@ -28,7 +32,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
         broadcast,
     } = args;
 
-    let coin = Coin::new(amount, denom.as_str()).change_context(Error::InvalidInput)?;
+    let funds = build_funds(amount, denom)?;
 
     let pub_key = verifier_pub_key(config.tofnd_config.clone()).await?;
 
@@ -41,7 +45,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
         sender: pub_key.account_id(PREFIX).change_context(Error::Tofnd)?,
         contract: config.service_registry.cosmwasm_contract.as_ref().clone(),
         msg,
-        funds: vec![coin],
+        funds,
     }
     .into_any()
     .expect("failed to serialize proto message");
@@ -52,4 +56,73 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
         "successfully broadcast bond verifier transaction, tx hash: {}",
         tx_hash
     )))
+}
+
+fn build_funds(amount: Option<u128>, denom: Option<String>) -> Result<Vec<Coin>, Error> {
+    match (amount, denom) {
+        (None, None) => Ok(vec![]),
+        (Some(amount), Some(denom)) => Ok(vec![
+            Coin::new(amount, denom.as_str()).change_context(Error::InvalidInput)?
+        ]),
+        _ => Err(report!(Error::InvalidInput)
+            .attach_printable("amount and denom must be provided together")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: Args,
+    }
+
+    fn parse(input: &[&str]) -> std::result::Result<Args, clap::Error> {
+        TestCli::try_parse_from(std::iter::once("test").chain(input.iter().copied()))
+            .map(|cli| cli.args)
+    }
+
+    #[test]
+    fn cli_accepts_service_name_only_for_rebond() {
+        let args = parse(&["validators"]).unwrap();
+        assert_eq!(args.amount, None);
+        assert_eq!(args.denom, None);
+    }
+
+    #[test]
+    fn cli_accepts_service_name_amount_and_denom() {
+        let args = parse(&["validators", "100", "uaxl"]).unwrap();
+        assert_eq!(args.amount, Some(100));
+        assert_eq!(args.denom.as_deref(), Some("uaxl"));
+    }
+
+    #[test]
+    fn build_funds_empty_when_neither_provided() {
+        let funds = build_funds(None, None).unwrap();
+        assert!(funds.is_empty());
+    }
+
+    #[test]
+    fn build_funds_single_coin_when_both_provided() {
+        let funds = build_funds(Some(100), Some("uaxl".into())).unwrap();
+        assert_eq!(funds.len(), 1);
+        assert_eq!(funds[0].amount, 100);
+        assert_eq!(funds[0].denom.as_ref(), "uaxl");
+    }
+
+    #[test]
+    fn build_funds_errors_when_only_amount_provided() {
+        let err = build_funds(Some(100), None).unwrap_err();
+        assert!(matches!(err.current_context(), Error::InvalidInput));
+    }
+
+    #[test]
+    fn build_funds_errors_when_only_denom_provided() {
+        let err = build_funds(None, Some("uaxl".into())).unwrap_err();
+        assert!(matches!(err.current_context(), Error::InvalidInput));
+    }
 }


### PR DESCRIPTION
### why

Allow rebonding to align with the Service Registry contract.

Fixes CPI-312

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change in ampd that exposes existing contract rebond semantics; stake moves still occur on-chain only when the registry accepts empty-fund bonds.
> 
> **Overview**
> Extends the **`ampd` `bond-verifier` command** so verifiers can **rebond** stake that is in **`Unbonding` / `RequestedUnbonding`**, matching Service Registry behavior when **`BondVerifier`** is executed with **no attached funds**.
> 
> **`amount` and `denom` are now optional** (must be supplied together). Omitting both builds an **empty `funds` vector** for the execute message; providing both keeps the existing **deposit bond** path. A new **`build_funds`** helper enforces that pairing and returns **`InvalidInput`** if only one is set. **CLI and unit tests** cover service-name-only rebond, full bond args, and the fund-building cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1cc2a989709ef7ff84f4147269b354c3a3386b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->