### PR TITLE
chore: fix clippy warnings + bump `cosmwasm-check`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-wasm = "build --release --lib --target wasm32-unknown-unknown --locked --workspace --exclude ampd --exclude integration-tests"
+wasm = "build --release --lib --target wasm32-unknown-unknown --locked --workspace --exclude ampd --exclude ampd-handlers --exclude ampd-sdk --exclude ampd-proto --exclude events --exclude integration-tests"
 unit-test = "test --lib"
 clippy-check = "clippy --all-targets -- -D warnings -A deprecated"
 fmt-check = "fmt --all --check"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ wasm = "build --release --lib --target wasm32-unknown-unknown --locked --workspa
 unit-test = "test --lib"
 clippy-check = "clippy --all-targets -- -D warnings -A deprecated"
 fmt-check = "fmt --all --check"
-sort-check = "sort --workspace --check --check-format"
+sort-check = "sort --workspace --check --check-format --grouped"
 
 [build]
 rustflags = ["--cfg", "tracing_unstable"]

--- a/.github/workflows/ci-lints.yaml
+++ b/.github/workflows/ci-lints.yaml
@@ -57,7 +57,7 @@ jobs:
         run: cargo +nightly fmt-check # alias
 
       - name: Run cargo sort
-        run: cargo sort-check --grouped # alias
+        run: cargo sort-check # alias
 
       - name: Run cargo clippy
         run: cargo clippy-check # alias

--- a/.github/workflows/ci-wasm-build.yaml
+++ b/.github/workflows/ci-wasm-build.yaml
@@ -34,7 +34,7 @@ jobs:
           done
 
       - name: Install cosmwasm-check
-        run: cargo install --version 3.0.1 --locked cosmwasm-check
+        run: cargo install --version 3.0.7 --locked cosmwasm-check
 
       - name: Check wasm contracts
         run: cosmwasm-check ./target/wasm32-unknown-unknown/release/*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
@@ -3909,7 +3909,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
- "rand 0.9.4",
+ "rand 0.9.1",
  "siphasher 1.0.1",
 ]
 
@@ -6958,10 +6958,11 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
+ "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -8153,7 +8154,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
@@ -8239,9 +8240,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -8826,7 +8827,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.4",
+ "rand 0.9.1",
  "rlp",
  "ruint-macro",
  "serde",
@@ -11946,9 +11947,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87af771d7f577931913089f9ca9a9f85d8a6238d59b2977f4c383d133c8abd3b"
+checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
@@ -13537,7 +13538,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.1",
  "rustls 0.23.36",
  "rustls-pki-types",
  "sha1",
@@ -13798,7 +13799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.4",
+ "rand 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
@@ -3761,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -3909,7 +3909,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
- "rand 0.9.1",
+ "rand 0.9.4",
  "siphasher 1.0.1",
 ]
 
@@ -6958,11 +6958,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -8154,7 +8153,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
@@ -8240,9 +8239,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -8467,6 +8466,7 @@ dependencies = [
  "error-stack",
  "eyre",
  "itertools 0.14.0",
+ "rusty-fork",
  "temp-env",
  "thiserror 1.0.69",
  "tracing",
@@ -8826,7 +8826,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde",
@@ -11946,9 +11946,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
+checksum = "87af771d7f577931913089f9ca9a9f85d8a6238d59b2977f4c383d133c8abd3b"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
@@ -13537,7 +13537,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rustls 0.23.36",
  "rustls-pki-types",
  "sha1",
@@ -13798,7 +13798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.1",
+ "rand 0.9.4",
 ]
 
 [[package]]

--- a/ampd-handlers/src/lib.rs
+++ b/ampd-handlers/src/lib.rs
@@ -12,7 +12,7 @@ pub mod test_utils;
 
 use std::path::PathBuf;
 
-use clap::{command, Parser};
+use clap::Parser;
 
 #[derive(Parser)]
 #[command(version)]

--- a/ampd-handlers/src/solana/verifier_set_verifier.rs
+++ b/ampd-handlers/src/solana/verifier_set_verifier.rs
@@ -53,7 +53,7 @@ pub fn verify_verifier_set(
 fn to_verifier_set(vs: &VerifierSet) -> Option<solana_axelar_std::VerifierSet> {
     let mut signers = BTreeMap::new();
 
-    for (_cosmwasm_adr, signer) in vs.signers.iter() {
+    for signer in vs.signers.values() {
         let pub_key = to_pub_key(&signer.pub_key)?;
         let weight = signer.weight.u128();
         signers.insert(pub_key, weight);

--- a/ampd-handlers/src/stellar/verifier.rs
+++ b/ampd-handlers/src/stellar/verifier.rs
@@ -286,7 +286,7 @@ mod test {
     fn should_not_verify_verifier_set_if_signer_hash_does_not_match() {
         let (gateway_address, tx_response, mut confirmation) = matching_verifier_set_and_tx_block();
 
-        let signers = vec![random_signer(), random_signer(), random_signer()];
+        let signers = [random_signer(), random_signer(), random_signer()];
         confirmation.verifier_set = VerifierSet {
             signers: signers
                 .iter()
@@ -388,7 +388,7 @@ mod test {
         let account_id = stellar_xdr::curr::Hash::from(Hash::random().0);
         let gateway_address = ScAddress::Contract(account_id.clone().into());
 
-        let signers = vec![random_signer(), random_signer(), random_signer()];
+        let signers = [random_signer(), random_signer(), random_signer()];
         let created_at = rand::random();
         let threshold = Uint128::new(2u128);
 

--- a/ampd/src/broadcast/dec_coin.rs
+++ b/ampd/src/broadcast/dec_coin.rs
@@ -9,7 +9,6 @@ use report::ResultCompatExt;
 use serde::{Deserialize, Serialize};
 use serde_with::SerializeDisplay;
 use thiserror::Error;
-use tracing::error;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/ampd/src/broadcast/mod.rs
+++ b/ampd/src/broadcast/mod.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 use typed_builder::TypedBuilder;
 
 use crate::monitoring::metrics;

--- a/ampd/src/broadcast/proto.rs
+++ b/ampd/src/broadcast/proto.rs
@@ -1,5 +1,9 @@
 use prost::Name;
 
+#[allow(
+    dead_code,
+    reason = "tonic generates the full proto message set; ampd uses only a subset"
+)]
 pub mod axelar {
     pub mod auxiliary {
         pub mod v1beta1 {
@@ -8,6 +12,10 @@ pub mod axelar {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "tonic generates the full proto message set; ampd uses only a subset"
+)]
 mod cosmos {
     pub mod base {
         pub mod abci {
@@ -18,6 +26,10 @@ mod cosmos {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "tonic generates the full proto message set; ampd uses only a subset"
+)]
 mod tendermint {
     #[allow(clippy::large_enum_variant)]
     pub mod abci {

--- a/ampd/src/main.rs
+++ b/ampd/src/main.rs
@@ -13,7 +13,7 @@ use ampd::commands::{
 use ampd::config::Config;
 use ampd::Error;
 use axelar_wasm_std::FnExt;
-use clap::{arg, command, Parser, ValueEnum};
+use clap::{Parser, ValueEnum};
 use config::ConfigError;
 use error_stack::{Report, ResultExt};
 use report::LoggableError;
@@ -273,7 +273,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let missing = dir.path().join("nope.toml");
 
-        let err = find_config_files(&[missing.clone()], &[]).unwrap_err();
+        let err = find_config_files(std::slice::from_ref(&missing), &[]).unwrap_err();
         let formatted = format!("{err:?}");
         assert!(
             formatted.contains(&missing.display().to_string()),

--- a/contracts/axelarnet-gateway/src/contract/execute.rs
+++ b/contracts/axelarnet-gateway/src/contract/execute.rs
@@ -8,7 +8,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     Addr, CosmosMsg, DepsMut, Event, HexBinary, MessageInfo, QuerierWrapper, Response, Storage,
 };
-use error_stack::{bail, ensure, report, ResultExt};
+use error_stack::{bail, ensure, ResultExt};
 use itertools::Itertools;
 use router_api::{Address, ChainName, CrossChainId, Message};
 use sha3::{Digest, Keccak256};

--- a/contracts/axelarnet-gateway/src/state.rs
+++ b/contracts/axelarnet-gateway/src/state.rs
@@ -2,7 +2,6 @@ use axelar_wasm_std::{FnExt, IntoContractError};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, StdError, Storage};
 use cw_storage_plus::{Item, Map};
-use error_stack::report;
 use router_api::{ChainName, CrossChainId, Message};
 
 use crate::msg;

--- a/contracts/axelarnet-gateway/tests/utils/deps.rs
+++ b/contracts/axelarnet-gateway/tests/utils/deps.rs
@@ -47,8 +47,8 @@ pub fn axelar_query_handler(
 }
 
 pub trait OwnedDepsExt {
-    fn as_default_mut(&mut self) -> DepsMut<Empty>;
-    fn as_default_deps(&self) -> Deps<Empty>;
+    fn as_default_mut(&mut self) -> DepsMut<'_, Empty>;
+    fn as_default_deps(&self) -> Deps<'_, Empty>;
 }
 
 impl<S: Storage, A: Api, Q: Querier, C: CustomQuery> OwnedDepsExt for OwnedDeps<S, A, Q, C> {

--- a/contracts/chain-codec-evm/src/test/test_data.rs
+++ b/contracts/chain-codec-evm/src/test/test_data.rs
@@ -1,10 +1,8 @@
 use std::collections::BTreeMap;
 
 use axelar_wasm_std::{nonempty, Participant};
-use cosmwasm_schema::cw_serde;
 use cosmwasm_std::testing::MockApi;
 use cosmwasm_std::{Addr, HexBinary, Uint128};
-use multisig::key::Signature;
 use multisig::msg::Signer;
 use multisig::verifier_set::VerifierSet;
 use router_api::{CrossChainId, Message};
@@ -96,15 +94,6 @@ pub fn messages() -> Vec<Message> {
         .to_array::<32>()
         .unwrap(),
     }]
-}
-
-#[cw_serde]
-pub struct TestOperator {
-    pub address: Addr,
-    pub pub_key: multisig::key::PublicKey,
-    pub operator: HexBinary,
-    pub weight: Uint128,
-    pub signature: Option<Signature>,
 }
 
 // Generate a verifier set matches axelar-gmp-sdk-solidity repo test data

--- a/contracts/chain-codec-solana/src/solana.rs
+++ b/contracts/chain-codec-solana/src/solana.rs
@@ -91,7 +91,7 @@ pub fn encode_execute_data(
 fn to_verifier_set(vs: &VerifierSet) -> Result<solana_axelar_std::VerifierSet, Error> {
     let mut signers = BTreeMap::new();
 
-    for (_cosmwasm_adr, signer) in vs.signers.iter() {
+    for signer in vs.signers.values() {
         let pub_key = to_pub_key(&signer.pub_key)?;
         let weight = signer.weight.u128();
         signers.insert(pub_key, weight);

--- a/contracts/event-verifier/src/contract/execute.rs
+++ b/contracts/event-verifier/src/contract/execute.rs
@@ -431,20 +431,28 @@ mod tests {
 
         let ev = event("test-event");
         // Initial status should be Unknown
-        let res =
-            query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height).unwrap();
+        let res = query::events_status(
+            deps.as_ref(),
+            std::slice::from_ref(&ev),
+            mock_env().block.height,
+        )
+        .unwrap();
         assert_eq!(res[0].status, VerificationStatus::Unknown);
 
         // Status should be InProgress after poll creation
         create_poll(&mut deps, &ev);
-        let res =
-            query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height).unwrap();
+        let res = query::events_status(
+            deps.as_ref(),
+            std::slice::from_ref(&ev),
+            mock_env().block.height,
+        )
+        .unwrap();
         assert_eq!(res[0].status, VerificationStatus::InProgress);
 
         // Status should be FailedToVerify after poll expiration with no consensus
         let res = query::events_status(
             deps.as_ref(),
-            &[ev.clone()],
+            std::slice::from_ref(&ev),
             mock_env().block.height + POLL_BLOCK_EXPIRY,
         )
         .unwrap();
@@ -494,8 +502,12 @@ mod tests {
 
             create_poll_and_cast_votes(&mut deps, &ev, &verifiers, votes.to_vec());
 
-            let res = query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height)
-                .unwrap();
+            let res = query::events_status(
+                deps.as_ref(),
+                std::slice::from_ref(&ev),
+                mock_env().block.height,
+            )
+            .unwrap();
             assert_eq!(res[0].status, *expected_status);
         }
     }
@@ -603,8 +615,12 @@ mod tests {
             poll_id,
             vec![Vote::SucceededOnChain],
         ));
-        let res =
-            query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height).unwrap();
+        let res = query::events_status(
+            deps.as_ref(),
+            std::slice::from_ref(&ev),
+            mock_env().block.height,
+        )
+        .unwrap();
         assert_eq!(res[0].status, VerificationStatus::InProgress);
 
         // Third vote should reach quorum under 3/3 and succeed
@@ -615,8 +631,12 @@ mod tests {
             poll_id,
             vec![Vote::SucceededOnChain],
         ));
-        let res =
-            query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height).unwrap();
+        let res = query::events_status(
+            deps.as_ref(),
+            std::slice::from_ref(&ev),
+            mock_env().block.height,
+        )
+        .unwrap();
         assert_eq!(res[0].status, VerificationStatus::SucceededOnSourceChain);
     }
 
@@ -652,8 +672,12 @@ mod tests {
             vec![Vote::SucceededOnChain],
         ));
 
-        let res =
-            query::events_status(deps.as_ref(), &[ev.clone()], mock_env().block.height).unwrap();
+        let res = query::events_status(
+            deps.as_ref(),
+            std::slice::from_ref(&ev),
+            mock_env().block.height,
+        )
+        .unwrap();
         assert_eq!(res[0].status, VerificationStatus::SucceededOnSourceChain);
     }
 

--- a/contracts/interchain-token-service/src/contract/execute/mod.rs
+++ b/contracts/interchain-token-service/src/contract/execute/mod.rs
@@ -1,6 +1,6 @@
 use axelar_wasm_std::{killswitch, nonempty, FnExt, IntoContractError};
 use cosmwasm_std::{Addr, DepsMut, HexBinary, QuerierWrapper, Response, Storage, Uint256};
-use error_stack::{bail, ensure, report, Result, ResultExt};
+use error_stack::{bail, ensure, Result, ResultExt};
 use interceptors::{deploy_token_to_destination_chain, deploy_token_to_source_chain};
 use interchain_token_service_std::{
     DeployInterchainToken, HubMessage, InterchainTransfer, LinkToken, Message,

--- a/contracts/its-abi-translator/src/abi.rs
+++ b/contracts/its-abi-translator/src/abi.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{FixedBytes, U256};
 use alloy_sol_types::{sol, SolValue};
 use axelar_wasm_std::{nonempty, IntoContractError};
 use cosmwasm_std::{HexBinary, Uint256};
-use error_stack::{bail, ensure, report, Report, ResultExt};
+use error_stack::{bail, ensure, Report, ResultExt};
 use interchain_token_service_std::{HubMessage, Message, TokenId};
 use router_api::ChainNameRaw;
 // ITS Message payload types

--- a/contracts/multisig-prover/src/error.rs
+++ b/contracts/multisig-prover/src/error.rs
@@ -121,5 +121,5 @@ pub enum ContractError {
     StorageError,
 
     #[error(transparent)]
-    ChainCodecError(#[from] chain_codec_api::ClientError),
+    ChainCodecError(#[from] Box<chain_codec_api::ClientError>),
 }

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -205,7 +205,7 @@ impl PrimaryKey<'_> for KeyType {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<cw_storage_plus::Key> {
+    fn key(&self) -> Vec<cw_storage_plus::Key<'_>> {
         vec![cw_storage_plus::Key::Val8(
             vec![*self as u8]
                 .try_into()

--- a/contracts/multisig/src/multisig.rs
+++ b/contracts/multisig/src/multisig.rs
@@ -58,7 +58,7 @@ mod test {
 
     #[test]
     fn optimize_signatures() {
-        let signers = vec![
+        let signers = [
             signer(cosmos_addr!("signer0"), 1),
             signer(cosmos_addr!("signer1"), 3),
             signer(cosmos_addr!("signer2"), 5),

--- a/contracts/rewards/src/contract/execute.rs
+++ b/contracts/rewards/src/contract/execute.rs
@@ -420,8 +420,7 @@ mod test {
         simulated_participation.insert(cosmos_addr!("verifier_3"), 7);
 
         let event_count = 10;
-        let mut cur_height = epoch_block_start;
-        for i in 0..event_count {
+        for (cur_height, i) in (epoch_block_start..).zip(0..event_count) {
             for (verifier, part_count) in &simulated_participation {
                 // simulates a verifier participating in only part_count events
                 if i < *part_count {
@@ -436,7 +435,6 @@ mod test {
                     .unwrap();
                 }
             }
-            cur_height += 1;
         }
 
         let tally =

--- a/contracts/rewards/src/state.rs
+++ b/contracts/rewards/src/state.rs
@@ -73,7 +73,7 @@ impl PrimaryKey<'_> for PoolId {
     type Suffix = Addr;
     type SuperSuffix = (ChainName, Addr);
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         let mut keys = self.chain_name.key();
         keys.extend(self.contract.key());
         keys
@@ -94,7 +94,7 @@ impl KeyDeserialize for PoolId {
 }
 
 impl Prefixer<'_> for PoolId {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         self.key()
     }
 }
@@ -112,7 +112,7 @@ impl PrimaryKey<'_> for TallyId {
     type Suffix = ();
     type SuperSuffix = (PoolId, u64);
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         let mut keys = self.pool_id.key();
         keys.extend(self.epoch_num.key());
         keys

--- a/contracts/voting-verifier/src/contract/query.rs
+++ b/contracts/voting-verifier/src/contract/query.rs
@@ -329,7 +329,7 @@ mod tests {
             )
             .unwrap();
 
-        let messages = (0..poll.poll_size as u64).map(message);
+        let messages = (0..poll.poll_size).map(message);
         messages.clone().enumerate().for_each(|(idx, msg)| {
             poll_messages()
                 .save(

--- a/packages/ampd-sdk/src/grpc/client/mod.rs
+++ b/packages/ampd-sdk/src/grpc/client/mod.rs
@@ -291,6 +291,10 @@ impl HandlerTaskClient for GrpcClient {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
+    #![allow(
+        clippy::result_large_err,
+        reason = "gRPC mocks return Result<_, tonic::Status>; Status is large and out of our control"
+    )]
     use std::vec;
 
     use ampd_proto::blockchain_service_server::BlockchainService;
@@ -382,6 +386,10 @@ pub mod test_utils {
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(
+        clippy::result_large_err,
+        reason = "gRPC mocks return Result<_, tonic::Status>; Status is large and out of our control"
+    )]
     use std::str::FromStr;
     use std::vec;
 

--- a/packages/ampd-sdk/src/grpc/connection_pool.rs
+++ b/packages/ampd-sdk/src/grpc/connection_pool.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 use tonic::transport;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::future::{with_retry, RetryPolicy};
 

--- a/packages/ampd-sdk/src/runtime.rs
+++ b/packages/ampd-sdk/src/runtime.rs
@@ -161,6 +161,10 @@ fn start_shutdown_signal_monitor(token: CancellationToken) {
 
 #[cfg(test)]
 mod tests {
+    #![allow(
+        clippy::result_large_err,
+        reason = "gRPC mocks return Result<_, tonic::Status>; Status is large and out of our control"
+    )]
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::str::FromStr;

--- a/packages/axelar-wasm-std/src/chain.rs
+++ b/packages/axelar-wasm-std/src/chain.rs
@@ -112,13 +112,13 @@ impl PrimaryKey<'_> for ChainName {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }
 
 impl Prefixer<'_> for ChainName {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }
@@ -273,13 +273,13 @@ impl PrimaryKey<'_> for ChainNameRaw {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }
 
 impl Prefixer<'_> for ChainNameRaw {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }

--- a/packages/axelar-wasm-std/src/fixed_size/hexbinary.rs
+++ b/packages/axelar-wasm-std/src/fixed_size/hexbinary.rs
@@ -110,13 +110,13 @@ impl<const N: usize> PrimaryKey<'_> for HexBinary<N> {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }
 
 impl<const N: usize> Prefixer<'_> for HexBinary<N> {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }

--- a/packages/axelar-wasm-std/src/nonempty/hexbinary.rs
+++ b/packages/axelar-wasm-std/src/nonempty/hexbinary.rs
@@ -64,13 +64,13 @@ impl PrimaryKey<'_> for HexBinary {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }
 
 impl Prefixer<'_> for HexBinary {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }

--- a/packages/axelar-wasm-std/src/voting.rs
+++ b/packages/axelar-wasm-std/src/voting.rs
@@ -123,13 +123,13 @@ impl PrimaryKey<'_> for PollId {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Val64(self.0.to_be_bytes())]
     }
 }
 
 impl Prefixer<'_> for PollId {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Val64(self.0.to_be_bytes())]
     }
 }
@@ -322,8 +322,8 @@ impl WeightedPoll {
 
         let consensus_participants = self
             .participation
-            .iter()
-            .filter_map(|(address, _)| {
+            .keys()
+            .filter_map(|address| {
                 voting_history.get(address).and_then(|votes| {
                     let voted_consensus = votes.iter().zip(results.iter()).all(|(vote, result)| {
                         result.is_none() || Some(vote) == result.as_ref()

--- a/packages/interchain-token-service-std/src/primitives.rs
+++ b/packages/interchain-token-service-std/src/primitives.rs
@@ -173,7 +173,7 @@ impl PrimaryKey<'_> for TokenId {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         self.0.key()
     }
 }
@@ -189,7 +189,7 @@ impl KeyDeserialize for TokenId {
 }
 
 impl Prefixer<'_> for TokenId {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         self.key()
     }
 }

--- a/packages/multisig-prover-api/src/payload.rs
+++ b/packages/multisig-prover-api/src/payload.rs
@@ -62,7 +62,7 @@ impl PrimaryKey<'_> for PayloadId {
     type Suffix = PayloadId;
     type SuperSuffix = PayloadId;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }

--- a/packages/report/Cargo.toml
+++ b/packages/report/Cargo.toml
@@ -18,5 +18,8 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 valuable = { version = "0.1.0", features = ["derive"] }
 
+[dev-dependencies]
+rusty-fork = "0.3"
+
 [lints]
 workspace = true

--- a/packages/report/src/loggable.rs
+++ b/packages/report/src/loggable.rs
@@ -179,6 +179,7 @@ impl<'a> From<&'a Frame> for FrameType<'a> {
 #[cfg(test)]
 mod tests {
     use error_stack::Report;
+    use rusty_fork::rusty_fork_test;
     use temp_env::with_var;
     use thiserror::Error;
     use tracing::instrument;
@@ -196,52 +197,58 @@ mod tests {
         FromString(String),
     }
 
-    #[test]
-    fn correct_error_log() {
-        with_var("RUST_BACKTRACE", Some("1"), || {
-            let line_offset = line!();
-            let report = Report::new(Error::FromString("error1".to_string()))
-                .attach_printable("foo1")
-                .change_context(Error::FromString("error2".to_string()))
-                .attach_printable("test1")
-                .attach_printable("test2")
-                .change_context(Error::FromString("error3".to_string()))
-                .attach(5);
+    rusty_fork_test! {
+        // Runs in its own forked process so this test is always the first backtrace
+        // capture, making RUST_BACKTRACE=1 (set below) take effect. std caches the
+        // backtrace-enabled decision once per process, so in the shared test binary a
+        // sibling test capturing first could lock it to "disabled" and flake this one.
+        #[test]
+        fn correct_error_log() {
+            with_var("RUST_BACKTRACE", Some("1"), || {
+                let line_offset = line!();
+                let report = Report::new(Error::FromString("error1".to_string()))
+                    .attach_printable("foo1")
+                    .change_context(Error::FromString("error2".to_string()))
+                    .attach_printable("test1")
+                    .attach_printable("test2")
+                    .change_context(Error::FromString("error3".to_string()))
+                    .attach(5);
 
-            let mut err = LoggableError::from(&report);
+                let mut err = LoggableError::from(&report);
 
-            let root_err = err.cause.as_mut().unwrap().cause.as_mut().unwrap();
+                let root_err = err.cause.as_mut().unwrap().cause.as_mut().unwrap();
 
-            assert!(root_err.backtrace.is_some());
-            assert!(!root_err.backtrace.as_ref().unwrap().lines.is_empty());
+                assert!(root_err.backtrace.is_some());
+                assert!(!root_err.backtrace.as_ref().unwrap().lines.is_empty());
 
-            root_err.backtrace = None;
+                root_err.backtrace = None;
 
-            let expected_err = LoggableError {
-                msg: "error3".to_string(),
-                attachments: vec!["opaque attachment".to_string()],
-                location: format!("packages/report/src/loggable.rs:{}:18", line_offset + 6),
-                cause: Some(Box::new(LoggableError {
-                    msg: "error2".to_string(),
-                    attachments: vec!["test1".to_string(), "test2".to_string()],
-                    location: format!("packages/report/src/loggable.rs:{}:18", line_offset + 3),
+                let expected_err = LoggableError {
+                    msg: "error3".to_string(),
+                    attachments: vec!["opaque attachment".to_string()],
+                    location: format!("packages/report/src/loggable.rs:{}:22", line_offset + 6),
                     cause: Some(Box::new(LoggableError {
-                        msg: "error1".to_string(),
-                        attachments: vec!["foo1".to_string()],
-                        location: format!("packages/report/src/loggable.rs:{}:26", line_offset + 1),
-                        cause: None,
+                        msg: "error2".to_string(),
+                        attachments: vec!["test1".to_string(), "test2".to_string()],
+                        location: format!("packages/report/src/loggable.rs:{}:22", line_offset + 3),
+                        cause: Some(Box::new(LoggableError {
+                            msg: "error1".to_string(),
+                            attachments: vec!["foo1".to_string()],
+                            location: format!("packages/report/src/loggable.rs:{}:30", line_offset + 1),
+                            cause: None,
+                            backtrace: None,
+                            spantrace: None,
+                        })),
                         backtrace: None,
                         spantrace: None,
                     })),
                     backtrace: None,
                     spantrace: None,
-                })),
-                backtrace: None,
-                spantrace: None,
-            };
+                };
 
-            assert_eq!(err, expected_err);
-        });
+                assert_eq!(err, expected_err);
+            });
+        }
     }
 
     #[test]

--- a/packages/router-api/src/primitives.rs
+++ b/packages/router-api/src/primitives.rs
@@ -239,7 +239,7 @@ impl PrimaryKey<'_> for CrossChainId {
     type Suffix = String;
     type SuperSuffix = (ChainNameRaw, String);
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         let mut keys = self.source_chain.key();
         keys.extend(self.message_id.key());
         keys

--- a/packages/xrpl-types/src/types.rs
+++ b/packages/xrpl-types/src/types.rs
@@ -157,7 +157,7 @@ impl PrimaryKey<'_> for XRPLToken {
     type Suffix = XRPLToken;
     type SuperSuffix = XRPLToken;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![
             Key::Ref(self.issuer.as_ref()),
             Key::Ref(self.currency.as_ref()),
@@ -860,7 +860,7 @@ impl PrimaryKey<'_> for XRPLCurrency {
     type Suffix = XRPLCurrency;
     type SuperSuffix = XRPLCurrency;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         self.0.key()
     }
 }

--- a/tools/migration-remover/src/main.rs
+++ b/tools/migration-remover/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use clap::{arg, Parser};
+use clap::Parser;
 use error_stack::{Result, ResultExt};
 use thiserror::Error;
 use toml::Table;


### PR DESCRIPTION
### why
This PR:

1. Fixes Clippy lints introduced by newer Clippy versions.
1. Updates the `cosmwasm-check` version used in CI.
1. Fixes the cargo wasm subcommand to exclude crates that should not be compiled for CosmWasm.

### how
<!-- An agent will fill this out -->
