### PR TITLE
chore: ignore anchor-lang 1.0.2 advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,4 +21,5 @@ ignore = [
     "RUSTSEC-2026-0098",  # rustls-webpki: name constraints for URI names incorrectly accepted — same upstream blockers as RUSTSEC-2026-0049
     "RUSTSEC-2026-0099",  # rustls-webpki: name constraints accepted for wildcard certs — same upstream blockers as RUSTSEC-2026-0049
     "RUSTSEC-2026-0104",  # rustls-webpki: reachable panic in CRL parsing — same upstream blockers as RUSTSEC-2026-0049
+    "RUSTSEC-2026-0144",  # anchor-lang: Program<System> accepts arbitrary executable programs — upgrade to 1.0.2 blocked by Rust 1.86/CosmWasm optimizer; used off-chain for Solana event decoding so not vulnerable
 ]


### PR DESCRIPTION
### why

we have to ignore and not upgrade, due to anchor-lang v1.0.2 requiring rustc v1.87.0+, which we cannot upgrade because cosmwasm/optimizer doesn't support any newer rustc version.

we are also not influenced by the issue in anchor-lang at all in this repo.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to suppress a known advisory; no runtime or dependency version changes.
> 
> **Overview**
> Adds **RUSTSEC-2026-0144** (`anchor-lang`: `Program<System>` accepting arbitrary executable programs) to the `cargo audit` ignore list in `.cargo/audit.toml`, with a comment that a fix requires **anchor-lang 1.0.2** (Rust 1.87+), which is blocked by the CosmWasm optimizer toolchain, and that usage here is off-chain Solana event decoding so the advisory does not apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054c9d9225d0362268c829756bb05564de2aa871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->