### PR TITLE
fix(ci): tag ampd handler images by SHA when no tag name is given

### DIFF
--- a/.github/workflows/ci-ampd-handlers-ecr.yaml
+++ b/.github/workflows/ci-ampd-handlers-ecr.yaml
@@ -94,15 +94,15 @@ jobs:
         id: set-tag
         run: |
           build_ref="${{ github.event.inputs.ref || github.ref }}"
-          
-          if git describe --exact-match --tags "$build_ref" >/dev/null 2>&1; then
+
+          if git rev-parse --verify --quiet "refs/tags/$build_ref" >/dev/null; then
             tag="$build_ref"
             echo "Building from tag: $tag"
           else
-            tag="${{ github.sha }}"
+            tag="$(git rev-parse HEAD)"
             echo "Building from ref '$build_ref', using commit SHA: $tag"
           fi
-          
+
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
   build-and-push:


### PR DESCRIPTION
### why
Pushing the builds to ECR fails if pushing to main when it has a tag.

The code did:
- if the commit **has** a tag, use the ref as name.

It should do:

- if the ref **is** a tag, use that as name

This caused problems because upon pull the ref was: "refs/heads/main", but if there is a tag on main
that ref was used as name and was used to push to ECR.

This should fix the current failures we are seeing on https://github.com/axelarnetwork/axelarate/actions/workflows/integration-tests.yml

part of CPI-370

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow tagging logic only; no runtime, auth, or application code changes.
> 
> **Overview**
> Fixes **ECR image tagging** in the ampd-handlers workflow so pushes from `main` no longer pick up an unrelated tag name when the checked-out commit happens to be tagged.
> 
> The **Set image tag** step now treats the build ref as a tag only when `refs/tags/$build_ref` exists, instead of using `git describe --exact-match` on the commit (which could match a tag while the ref was still `refs/heads/main`). For branch and other non-tag refs, the image tag is **`git rev-parse HEAD`** after checkout rather than **`github.sha`**, so manual builds from a chosen ref align with the checked-out commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504fc6e23e0f10a7acbfab9b254a13f125db05aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->